### PR TITLE
Add contributor governance and agent-ready workflow

### DIFF
--- a/.github/AGENT_WORKFLOW.md
+++ b/.github/AGENT_WORKFLOW.md
@@ -1,0 +1,88 @@
+# Agent issue queue and review contract
+
+This document defines how repository issues become safe units of autonomous
+work. It applies to implementation agents and to humans preparing work for
+them.
+
+## Label contract
+
+| Label | Meaning |
+| --- | --- |
+| `agent-ready` | A maintainer has confirmed that the issue has sufficient scope, acceptance criteria, and verification instructions for autonomous implementation. |
+| `blocked` | Work cannot proceed until a named dependency or decision is resolved. A blocked issue is never in the agent queue, even if it still has `agent-ready`. |
+| `priority: p0` | Correctness, security, legal, or release foundation that should be handled first. |
+| `priority: p1` | High-impact user or maintainer improvement. |
+| `priority: p2` | Important follow-up with lower urgency. |
+| `area: accessibility` | Accessibility and inclusive interaction. |
+| `area: tooling` | Build, test, CI, or developer tooling. |
+| `area: components` | Component API, behavior, or styling. |
+| `area: docs` | Documentation and examples. |
+| `area: demo` | Angular demo application and website. |
+| `area: design-system` | Tokens, theming, or motion. |
+| `area: release` | Versioning, packaging, or publishing. |
+| `epic` | Tracking issue whose child issues, rather than the epic itself, are implementation units. |
+
+## Ready queue
+
+The automatic queue is exactly:
+
+```text
+is:issue is:open label:agent-ready -label:blocked
+```
+
+Priority labels order eligible work (`p0`, then `p1`, then `p2`). Priority does
+not override dependencies, issue scope, or repository permissions.
+
+Before applying `agent-ready`, a maintainer verifies that the issue contains:
+
+- a concrete objective and evidence;
+- bounded scope and explicit non-goals when ambiguity is likely;
+- testable acceptance criteria;
+- dependencies, or an explicit statement that there are none;
+- expected verification evidence;
+- the affected area and priority labels; and
+- any external-state or maintainer-only steps.
+
+Issue forms do not apply `agent-ready` automatically. Triage is the readiness
+gate.
+
+## Claiming and implementation
+
+An agent claims one issue by commenting with its branch name and intended
+scope. If another active claim exists, the agent does not start overlapping
+work. Use a branch named `codex/issue-<number>-<short-name>` unless the issue
+specifies another convention.
+
+Agents may implement, test, commit, push their branch, and open a pull request
+when those actions are requested by the issue. They must not merge, publish,
+create a release, rotate credentials, change repository settings, or broaden
+scope without explicit maintainer authorization.
+
+If a dependency appears during implementation:
+
+1. stop the dependent portion of the work;
+2. report the evidence and exact decision or dependency needed;
+3. apply or request `blocked`; and
+4. do not silently substitute a materially different design.
+
+## Pull request and completion
+
+The implementation pull request must:
+
+- include `Closes #N` for the claimed issue;
+- map its changes to the acceptance criteria;
+- report commands and manual checks actually performed;
+- identify risk, accessibility, documentation, and semver impact;
+- contain no unrelated changes; and
+- remain unmerged for owner review.
+
+Opening a pull request does not make the issue complete. The issue closes only
+after the pull request is reviewed and merged. If acceptance criteria change,
+the issue must be updated so the issue remains the source of truth.
+
+## Review ownership
+
+CODEOWNERS requests review from `@banegasn` for all paths. When GitHub cannot
+request that owner automatically, the pull request author must request review
+from the repository maintainer manually. Self-authored or agent-authored work
+is never self-approved; a maintainer owns merge and release decisions.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# The repository maintainer reviews all changes. More specific owners can be
+# added as the contributor base grows.
+* @banegasn

--- a/.github/ISSUE_TEMPLATE/agent-task.yml
+++ b/.github/ISSUE_TEMPLATE/agent-task.yml
@@ -1,0 +1,84 @@
+name: Agent implementation task
+description: Specify bounded, verifiable work for later maintainer triage into the autonomous queue.
+title: "[Agent task]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Submitting this form does not make work agent-ready. A maintainer applies `agent-ready` only after checking scope, dependencies, permissions, and verification.
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+      description: State one concrete outcome, not a list of unrelated improvements.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Current-state evidence
+      description: Cite files and lines, failing tests, screenshots, standards, or reproducible behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: In scope
+      description: List files, packages, behavior, documentation, and tests the implementation may change.
+    validations:
+      required: true
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Non-goals
+      description: List adjacent work that must remain unchanged.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Use testable checkboxes that define completion.
+      placeholder: "- [ ] ..."
+    validations:
+      required: true
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies and execution order
+      description: Link issues that must land first, identify external decisions, or write "None".
+    validations:
+      required: true
+  - type: textarea
+    id: permissions
+    attributes:
+      label: Authorized external actions
+      description: State whether the agent may only edit/test or may also commit, push, and open a pull request. Publishing and merging require explicit authorization.
+      placeholder: "May edit, test, commit, push a codex/* branch, and open a PR. Must not merge or publish."
+    validations:
+      required: true
+  - type: textarea
+    id: verification
+    attributes:
+      label: Required verification evidence
+      description: List exact commands, manual checks, screenshots, archive inspection, or browser coverage expected.
+    validations:
+      required: true
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks and rollback
+      description: Identify compatibility, accessibility, security, data, release, or deployment risks and a safe rollback.
+    validations:
+      required: true
+  - type: checkboxes
+    id: readiness
+    attributes:
+      label: Specification checks
+      options:
+        - label: The task can be implemented without guessing a product or API decision.
+          required: true
+        - label: Acceptance criteria describe the outcome rather than prescribing incidental implementation details.
+          required: true
+        - label: Dependencies and maintainer-only actions are explicit.
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,92 @@
+name: Bug report
+description: Report reproducible incorrect behavior in a component, package, or demo.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Do not include secrets or security vulnerabilities here; use the private security advisory link instead.
+  - type: input
+    id: package
+    attributes:
+      label: Affected package or area
+      description: Name the package, custom element, demo route, or repository tool.
+      placeholder: "@banegasn/m3-button / m3-button / demo / publishing"
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version or commit
+      description: Include the package version and, for source builds, the commit SHA.
+      placeholder: "@banegasn/m3-button 2.2.3"
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Browser, operating system, framework and version, package manager, and relevant assistive technology.
+      placeholder: "Chrome 128, macOS, Angular 21, pnpm 9.12.1"
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: Provide a repository, URL, or the smallest markup/script and exact steps that reproduce the problem.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior and evidence
+      description: Include errors, screenshots, recordings, accessibility output, or logs with secrets removed.
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Suggested scope and non-goals
+      description: If known, state the smallest safe fix and what should remain unchanged.
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: List observable conditions that prove the bug is fixed without regressions.
+      placeholder: |
+        - [ ] The reproduction no longer fails.
+        - [ ] A regression test covers the failure.
+    validations:
+      required: true
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies or blockers
+      description: Link dependent issues or write "None known".
+    validations:
+      required: true
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification plan
+      description: List automated and manual checks that should demonstrate completion.
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Submission checks
+      options:
+        - label: I searched for duplicate issues.
+          required: true
+        - label: This report does not disclose a security vulnerability or secret.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/Banegasn/components/security/advisories/new
+    about: Report suspected vulnerabilities privately; do not open a public issue.
+  - name: Contribution workflow
+    url: https://github.com/Banegasn/components/blob/main/CONTRIBUTING.md
+    about: Read setup, verification, and pull-request requirements before contributing.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,84 @@
+name: Feature request
+description: Propose a user-facing component, API, documentation, or tooling improvement.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem and user outcome
+      description: Describe the user need and the outcome, independently of a preferred implementation.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence and use cases
+      description: Include examples, standards, current limitations, or prior discussion.
+    validations:
+      required: true
+  - type: input
+    id: area
+    attributes:
+      label: Affected packages or areas
+      placeholder: "@banegasn/m3-dialog, Angular demo, documentation"
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Proposed scope
+      description: Describe the smallest coherent capability to add.
+    validations:
+      required: true
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Non-goals
+      description: State related work that this request should not include.
+    validations:
+      required: true
+  - type: textarea
+    id: api
+    attributes:
+      label: Public API or UX sketch
+      description: Show proposed tags, attributes, properties, events, slots, CSS hooks, or user flow when relevant.
+  - type: textarea
+    id: accessibility
+    attributes:
+      label: Accessibility considerations
+      description: Describe semantics, keyboard behavior, focus, announcements, motion, contrast, RTL, and touch implications.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: List observable, testable completion conditions.
+      placeholder: "- [ ] ..."
+    validations:
+      required: true
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies or blockers
+      description: Link dependent issues or write "None known".
+    validations:
+      required: true
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification plan
+      description: List the tests, documentation, demos, or manual evidence expected.
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Submission checks
+      options:
+        - label: I searched for an existing component or issue that addresses this need.
+          required: true
+        - label: I have identified compatibility or semver impact where possible.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,58 @@
+## Linked issue
+
+<!-- Use a closing keyword. Replace N with the issue number. -->
+Closes #N
+
+## Summary
+
+<!-- What changed, why, and what is intentionally out of scope? -->
+
+## Acceptance criteria
+
+<!-- Map the linked issue's acceptance criteria to implementation evidence. -->
+
+- [ ] The linked issue's acceptance criteria are satisfied.
+
+## Risk and compatibility
+
+<!-- Describe affected packages, public APIs, migration needs, and rollback. -->
+
+- Risk: low / medium / high
+- Semver impact: none / patch / minor / major
+- Rollback or mitigation:
+
+## Verification
+
+<!-- List commands and manual checks actually run, with results. Do not check a
+box for work that was not performed; explain omissions below. -->
+
+- [ ] `pnpm build`
+- [ ] `pnpm lint`
+- [ ] `pnpm test`
+- [ ] Focused package or app checks are listed below.
+- [ ] Package archives were checked when packaging changed.
+- [ ] Visual or interaction evidence is attached when UI behavior changed.
+
+Commands and results:
+
+```text
+
+```
+
+Not run, with reason:
+
+## Documentation and accessibility
+
+- [ ] README/API/demo documentation is updated, or this change does not affect documentation.
+- [ ] Keyboard and focus behavior was checked, or this change has no interaction impact.
+- [ ] Screen-reader semantics were checked, or this change has no semantic impact.
+- [ ] Reduced motion, RTL, high contrast, and responsive behavior were considered where relevant.
+
+## Release notes
+
+- [ ] A user-facing release note is included below, or no release note is needed.
+- [ ] This pull request does not publish, tag, release, or merge itself.
+
+Release note:
+
+<!-- One concise user-facing sentence, or "Not needed" with a reason. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,116 @@
+# Contributor Covenant Code of Conduct
+
+## Our pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic
+status, nationality, personal appearance, race, caste, color, religion, or
+sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement responsibilities
+
+Project maintainers are responsible for clarifying and enforcing standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to behavior they deem inappropriate, threatening, offensive, or
+harmful.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned with this Code of Conduct, and will communicate reasons
+for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all project spaces and when an individual
+is officially representing the project in public spaces.
+
+## Enforcement
+
+Report abusive, harassing, or otherwise unacceptable behavior privately with
+the repository's
+[GitHub security advisory form](https://github.com/Banegasn/components/security/advisories/new).
+All complaints will be reviewed and investigated promptly and fairly. The
+privacy and security of the reporter will be respected.
+
+## Enforcement guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for actions they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning, providing clarity around the
+nature of the violation and an explanation of why the behavior was
+inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external
+channels like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited
+interaction with those enforcing the Code of Conduct, is allowed during this
+period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][version].
+
+[homepage]: https://www.contributor-covenant.org
+[version]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,138 @@
+# Contributing
+
+Thank you for improving Material 3 Expressive Components. This guide is the
+contribution contract for people and autonomous agents.
+
+## Before you start
+
+Use an existing issue or open one with the appropriate issue form. Changes
+should have a bounded scope, explicit acceptance criteria, and known
+dependencies before implementation begins. Security reports must follow
+[SECURITY.md](SECURITY.md), not a public issue.
+
+Autonomous work must also follow [.github/AGENT_WORKFLOW.md](.github/AGENT_WORKFLOW.md).
+An issue is available to an agent only when it has the `agent-ready` label and
+does not have the `blocked` label.
+
+## Repository layout
+
+- `packages/m3-*`: independently versioned Lit custom-element packages.
+- `packages/svelte-components`: an internal Svelte workspace; it is currently
+  private and is not part of the public release queue.
+- `apps/angular-app`: documentation and integration demo.
+- `scripts`: publishing, screenshots, and repository verification utilities.
+- `.github/workflows`: deployment and release automation.
+
+Keep component behavior, package README examples, and the Angular demo aligned.
+Avoid unrelated cleanup in a focused pull request.
+
+## Set up the repository
+
+Requirements are Node.js 22.16 or newer and pnpm 9. The pinned pnpm version is
+9.12.1.
+
+```bash
+git clone https://github.com/Banegasn/components.git
+cd components
+corepack enable
+corepack prepare pnpm@9.12.1 --activate
+pnpm install --frozen-lockfile
+```
+
+Run the demo during development with:
+
+```bash
+pnpm --filter @apps/angular-app dev
+```
+
+Run a single package in watch mode with, for example:
+
+```bash
+pnpm --filter @banegasn/m3-button dev
+```
+
+## Make a change
+
+1. Create a branch from the latest `main`.
+2. Make the smallest change that satisfies the linked issue.
+3. Add or update tests for behavior changes.
+4. Update package documentation and demo examples when a public API changes.
+5. Check keyboard, screen-reader, reduced-motion, RTL, and high-contrast impact
+   where relevant.
+6. Run the verification appropriate to the affected workspaces.
+7. Open a pull request using the repository template and include `Closes #N`.
+
+### Adding or changing a component
+
+- Preserve framework-agnostic custom-element behavior.
+- Treat attributes, properties, methods, events, slots, CSS custom properties,
+  and CSS parts as public API.
+- Use kebab-case `m3-*` custom-element names and avoid silently changing an
+  existing tag or event.
+- Extend the package's existing test approach. Packages with a `test` script
+  use Web Test Runner; not every package has tests yet.
+- Show the supported states in `apps/angular-app` and keep the package README
+  accurate.
+
+## Verify your change
+
+For repository-wide changes, run:
+
+```bash
+pnpm build
+pnpm lint
+pnpm test
+pnpm verify:package-licenses
+```
+
+Turbo runs only scripts that exist in each workspace, so a successful root
+`lint` or `test` does not imply that every package has a linter or test suite.
+Call out affected packages without coverage in the pull request.
+
+For a focused component change, use filters to shorten the feedback loop:
+
+```bash
+pnpm --filter @banegasn/m3-button build
+pnpm --filter @banegasn/m3-button test
+```
+
+If the demo changes, also run:
+
+```bash
+pnpm --filter @apps/angular-app build
+```
+
+Visual changes should include before/after screenshots. Interaction changes
+should include the tested browser, input methods, and assistive-technology
+checks. If a command cannot be run, explain why and what evidence substitutes
+for it; do not mark it as completed.
+
+## Versioning and release boundaries
+
+Use semantic-versioning impact in the pull request:
+
+- **patch**: compatible bug, accessibility, documentation, or styling fix.
+- **minor**: backward-compatible public capability.
+- **major**: removal, rename, changed default, or incompatible behavior in a
+  public API.
+- **none**: repository-only work that does not change a published package.
+
+Contributors and implementation agents must not bump versions, publish
+packages, create releases, or push release tags unless a maintainer explicitly
+scopes that work in the issue. Maintainers own release credentials and the
+final release decision.
+
+## Definition of done
+
+A change is ready for review when:
+
+- the linked issue's acceptance criteria are satisfied;
+- relevant build, lint, test, packaging, and manual checks are reported;
+- tests cover changed behavior, or the coverage gap is explicit;
+- documentation, examples, accessibility, and semver impact are assessed;
+- generated files and unrelated changes are absent; and
+- the pull request is reviewable as one coherent change.
+
+All changes require review. Ownership and fallback review rules are documented
+in [.github/CODEOWNERS](.github/CODEOWNERS) and
+[.github/AGENT_WORKFLOW.md](.github/AGENT_WORKFLOW.md).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Nicolas Banegas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -390,11 +390,12 @@ pnpm install --force
 
 ## 🤝 Contributing
 
-1. Create a new branch
-2. Make your changes
-3. Run `pnpm build` and `pnpm test`
-4. Submit a pull request
+Read [CONTRIBUTING.md](CONTRIBUTING.md) for repository setup, architecture,
+quality checks, pull request requirements, semantic-versioning guidance, and
+the autonomous-agent workflow. All participation is governed by the
+[Code of Conduct](CODE_OF_CONDUCT.md). Report vulnerabilities privately by
+following [SECURITY.md](SECURITY.md).
 
 ## 📄 License
 
-MIT
+[MIT](LICENSE)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security policy
+
+## Supported versions
+
+Security fixes target the latest released version of each public
+`@banegasn/m3-*` package. Older versions may require upgrading to receive a
+fix. The private `@banegasn/svelte-components` workspace is not a supported
+published package.
+
+## Report a vulnerability
+
+Do not disclose a suspected vulnerability in a public issue, discussion, or
+pull request. Submit it privately through the repository's
+[GitHub security advisory form](https://github.com/Banegasn/components/security/advisories/new).
+
+Include, when available:
+
+- the affected package and version;
+- impact and realistic attack scenario;
+- reproduction steps or a minimal proof of concept;
+- affected browsers or frameworks;
+- any known mitigation; and
+- whether the report or related details have been shared elsewhere.
+
+The maintainer will assess reports on a best-effort basis, coordinate follow-up
+through the private advisory, and credit reporters who want attribution. Please
+do not test against systems or data you do not own or have permission to use.
+
+For non-security defects, use the public bug report form.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "version:major": "pnpm --filter \"./packages/*\" exec -- npm version major",
     "screenshots": "node scripts/screenshot-packages.js",
     "screenshots:dark": "node scripts/screenshot-packages.js --theme dark",
-    "screenshots:both": "node scripts/screenshot-packages.js --theme both"
+    "screenshots:both": "node scripts/screenshot-packages.js --theme both",
+    "verify:package-licenses": "node scripts/verify-package-licenses.js"
   },
   "repository": {
     "type": "git",

--- a/packages/m3-badge/package.json
+++ b/packages/m3-badge/package.json
@@ -19,6 +19,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "prepack": "node ../../scripts/package-license.js prepare",
+    "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist"
   },
   "repository": {

--- a/packages/m3-button/package.json
+++ b/packages/m3-button/package.json
@@ -19,6 +19,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "prepack": "node ../../scripts/package-license.js prepare",
+    "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist"
   },
   "repository": {

--- a/packages/m3-card/package.json
+++ b/packages/m3-card/package.json
@@ -19,6 +19,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "prepack": "node ../../scripts/package-license.js prepare",
+    "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist"
   },
   "repository": {

--- a/packages/m3-checkbox/package.json
+++ b/packages/m3-checkbox/package.json
@@ -19,6 +19,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "prepack": "node ../../scripts/package-license.js prepare",
+    "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist"
   },
   "repository": {

--- a/packages/m3-chip/package.json
+++ b/packages/m3-chip/package.json
@@ -19,6 +19,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "prepack": "node ../../scripts/package-license.js prepare",
+    "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist"
   },
   "repository": {

--- a/packages/m3-dialog/package.json
+++ b/packages/m3-dialog/package.json
@@ -19,6 +19,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "prepack": "node ../../scripts/package-license.js prepare",
+    "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist"
   },
   "repository": {

--- a/packages/m3-divider/package.json
+++ b/packages/m3-divider/package.json
@@ -20,6 +20,8 @@
     "dev": "tsc --watch",
     "test": "wtr src/**/*.test.ts --node-resolve",
     "test:watch": "wtr src/**/*.test.ts --node-resolve --watch",
+    "prepack": "node ../../scripts/package-license.js prepare",
+    "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist"
   },
   "repository": {

--- a/packages/m3-fab-menu/package.json
+++ b/packages/m3-fab-menu/package.json
@@ -19,6 +19,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "prepack": "node ../../scripts/package-license.js prepare",
+    "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist",
     "lint": "eslint src --ext .ts"
   },

--- a/packages/m3-icon-button/package.json
+++ b/packages/m3-icon-button/package.json
@@ -20,6 +20,8 @@
     "dev": "tsc --watch",
     "test": "wtr src/**/*.test.ts --node-resolve",
     "test:watch": "wtr src/**/*.test.ts --node-resolve --watch",
+    "prepack": "node ../../scripts/package-license.js prepare",
+    "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist"
   },
   "repository": {

--- a/packages/m3-list/package.json
+++ b/packages/m3-list/package.json
@@ -20,6 +20,8 @@
     "dev": "tsc --watch",
     "test": "wtr src/**/*.test.ts --node-resolve",
     "test:watch": "wtr src/**/*.test.ts --node-resolve --watch",
+    "prepack": "node ../../scripts/package-license.js prepare",
+    "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist"
   },
   "repository": {

--- a/packages/m3-loading-indicator/package.json
+++ b/packages/m3-loading-indicator/package.json
@@ -19,6 +19,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "prepack": "node ../../scripts/package-license.js prepare",
+    "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist",
     "lint": "eslint src --ext .ts"
   },

--- a/packages/m3-menu/package.json
+++ b/packages/m3-menu/package.json
@@ -19,6 +19,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "prepack": "node ../../scripts/package-license.js prepare",
+    "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist",
     "lint": "eslint src --ext .ts"
   },

--- a/packages/m3-navigation-bar/package.json
+++ b/packages/m3-navigation-bar/package.json
@@ -19,6 +19,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "prepack": "node ../../scripts/package-license.js prepare",
+    "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist"
   },
   "repository": {

--- a/packages/m3-navigation-rail/package.json
+++ b/packages/m3-navigation-rail/package.json
@@ -19,6 +19,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "prepack": "node ../../scripts/package-license.js prepare",
+    "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist"
   },
   "repository": {

--- a/packages/m3-progress/package.json
+++ b/packages/m3-progress/package.json
@@ -19,6 +19,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "prepack": "node ../../scripts/package-license.js prepare",
+    "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist"
   },
   "repository": {

--- a/packages/m3-radio-button/package.json
+++ b/packages/m3-radio-button/package.json
@@ -19,6 +19,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "prepack": "node ../../scripts/package-license.js prepare",
+    "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist"
   },
   "repository": {

--- a/packages/m3-search-bar/package.json
+++ b/packages/m3-search-bar/package.json
@@ -19,6 +19,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "prepack": "node ../../scripts/package-license.js prepare",
+    "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist"
   },
   "repository": {

--- a/packages/m3-slider/package.json
+++ b/packages/m3-slider/package.json
@@ -19,6 +19,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "prepack": "node ../../scripts/package-license.js prepare",
+    "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist"
   },
   "repository": {

--- a/packages/m3-snackbar/package.json
+++ b/packages/m3-snackbar/package.json
@@ -20,6 +20,8 @@
     "dev": "tsc --watch",
     "test": "wtr src/**/*.test.ts --node-resolve",
     "test:watch": "wtr src/**/*.test.ts --node-resolve --watch",
+    "prepack": "node ../../scripts/package-license.js prepare",
+    "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist"
   },
   "repository": {

--- a/packages/m3-split-button/package.json
+++ b/packages/m3-split-button/package.json
@@ -19,6 +19,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "prepack": "node ../../scripts/package-license.js prepare",
+    "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist",
     "lint": "eslint src --ext .ts"
   },

--- a/packages/m3-switch/package.json
+++ b/packages/m3-switch/package.json
@@ -19,6 +19,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "prepack": "node ../../scripts/package-license.js prepare",
+    "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist"
   },
   "repository": {

--- a/packages/m3-tabs/package.json
+++ b/packages/m3-tabs/package.json
@@ -19,6 +19,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "prepack": "node ../../scripts/package-license.js prepare",
+    "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist"
   },
   "repository": {

--- a/packages/m3-text-field/package.json
+++ b/packages/m3-text-field/package.json
@@ -19,6 +19,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "prepack": "node ../../scripts/package-license.js prepare",
+    "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist"
   },
   "repository": {

--- a/packages/m3-tooltip/package.json
+++ b/packages/m3-tooltip/package.json
@@ -19,6 +19,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "prepack": "node ../../scripts/package-license.js prepare",
+    "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist"
   },
   "repository": {

--- a/packages/m3-top-app-bar/package.json
+++ b/packages/m3-top-app-bar/package.json
@@ -20,6 +20,8 @@
     "dev": "tsc --watch",
     "test": "wtr src/**/*.test.ts --node-resolve",
     "test:watch": "wtr src/**/*.test.ts --node-resolve --watch",
+    "prepack": "node ../../scripts/package-license.js prepare",
+    "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist"
   },
   "repository": {

--- a/scripts/package-license.js
+++ b/scripts/package-license.js
@@ -1,0 +1,34 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const action = process.argv[2];
+const repositoryRoot = path.resolve(__dirname, '..');
+const source = path.join(repositoryRoot, 'LICENSE');
+const target = path.join(process.cwd(), 'LICENSE');
+const manifestPath = path.join(process.cwd(), 'package.json');
+
+if (!['prepare', 'clean'].includes(action)) {
+  throw new Error('Usage: node scripts/package-license.js <prepare|clean>');
+}
+if (path.resolve(target) === path.resolve(source) || !fs.existsSync(manifestPath)) {
+  throw new Error('Package license lifecycle must run from a package directory');
+}
+
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+if (manifest.private) {
+  throw new Error(`Refusing to prepare a license archive for private package ${manifest.name}`);
+}
+
+const license = fs.readFileSync(source, 'utf8');
+
+if (action === 'prepare') {
+  if (fs.existsSync(target) && fs.readFileSync(target, 'utf8') !== license) {
+    throw new Error(`Refusing to overwrite a different license at ${target}`);
+  }
+  fs.writeFileSync(target, license);
+} else if (fs.existsSync(target)) {
+  if (fs.readFileSync(target, 'utf8') !== license) {
+    throw new Error(`Refusing to remove a different license at ${target}`);
+  }
+  fs.unlinkSync(target);
+}

--- a/scripts/verify-package-licenses.js
+++ b/scripts/verify-package-licenses.js
@@ -1,0 +1,55 @@
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repositoryRoot = path.resolve(__dirname, '..');
+const packagesRoot = path.join(repositoryRoot, 'packages');
+const canonicalLicense = fs.readFileSync(path.join(repositoryRoot, 'LICENSE'), 'utf8');
+const packageDirectories = fs.readdirSync(packagesRoot, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => path.join(packagesRoot, entry.name))
+  .filter((directory) => fs.existsSync(path.join(directory, 'package.json')))
+  .sort();
+
+const failures = [];
+let checked = 0;
+
+for (const directory of packageDirectories) {
+  const manifest = JSON.parse(fs.readFileSync(path.join(directory, 'package.json'), 'utf8'));
+  if (manifest.private) continue;
+  checked += 1;
+
+  try {
+    const output = execFileSync(
+      'npm',
+      ['pack', '--dry-run', '--json', '--ignore-scripts=false'],
+      { cwd: directory, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }
+    );
+    const result = JSON.parse(output);
+    const files = result[0]?.files?.map((file) => file.path) ?? [];
+
+    if (!files.includes('LICENSE')) {
+      failures.push(`${manifest.name}: packed archive does not include LICENSE`);
+    }
+  } catch (error) {
+    const detail = error.stderr?.trim() || error.message;
+    failures.push(`${manifest.name}: npm pack failed: ${detail}`);
+  } finally {
+    const generatedLicense = path.join(directory, 'LICENSE');
+    if (fs.existsSync(generatedLicense)) {
+      if (fs.readFileSync(generatedLicense, 'utf8') === canonicalLicense) {
+        fs.unlinkSync(generatedLicense);
+        failures.push(`${manifest.name}: generated LICENSE required verifier cleanup after packing`);
+      } else {
+        failures.push(`${manifest.name}: unexpected package-specific LICENSE was left in place`);
+      }
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error(failures.join('\n'));
+  process.exit(1);
+}
+
+console.log(`Verified LICENSE in ${checked} public package archives.`);


### PR DESCRIPTION
## Summary

- add the canonical MIT license and link it from the repository README
- inject that canonical license into each public package during `prepack`, clean it during `postpack`, and verify all public archive file lists from one root command
- add repository-specific contributor setup, architecture, verification, semver, release-boundary, security, and conduct policies
- define the existing label vocabulary and the exact `agent-ready` / unblocked queue and claim/close rules
- add CODEOWNERS with the actual repository maintainer, three structured issue forms, issue-template configuration, and a risk/test/docs/a11y/release-aware pull request template

Closes #18

## Verification

Passed:

- `pnpm install --frozen-lockfile`
- `pnpm build` — 27/27 workspace builds; Angular emitted pre-existing size warnings
- `pnpm verify:package-licenses` — confirmed `LICENSE` in all 25 public package dry-run archives and confirmed lifecycle cleanup
- actual `npm pack --json` for `@banegasn/m3-button` — archive contains the canonical `LICENSE` and `postpack` removes the generated package copy
- JSON parsing for the root and all workspace manifests
- YAML parsing for every issue form and issue-template config
- `node --check scripts/package-license.js`
- `node --check scripts/verify-package-licenses.js`
- `git diff --check`

Existing repository failures, not introduced or expanded by this governance-only change:

- `pnpm lint` fails because `m3-fab-menu`, `m3-loading-indicator`, `m3-menu`, and `m3-split-button` declare ESLint commands but ESLint is not installed.
- `pnpm test` fails because the Angular app's Karma configuration cannot resolve `karma-jasmine`.

## Risk and release assessment

- Risk: low; documentation, templates, and package lifecycle metadata only
- Semver impact: none
- Accessibility impact: the templates require accessibility assessment; no component behavior changed
- Release note: not needed; no published component API or behavior changed
