### PR TITLE
feat: establish accessible expressive motion system

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ This repository contains a collection of web components that can be used in any 
 
 - **[Publishing Guide](PUBLISHING.md)** - How to publish web component packages
 - **[Design Token Contract](tokens/README.md)** - Shared token naming, themes, compatibility, and validation
+- **[Motion System](docs/MOTION.md)** - Motion roles, reduced-motion behavior, and component inventory
 - **[Web Components](#-web-components)** - List of available components
 - **[Component Packages](#-demo-applications)** - Individual package documentation
 

--- a/apps/angular-app/src/app/app.component.css
+++ b/apps/angular-app/src/app/app.component.css
@@ -49,7 +49,7 @@
 
 m3-navigation-rail {
   opacity: 1;
-  transition: opacity 0.15s ease-in;
+  transition: opacity var(--md-sys-motion-duration-short3) var(--md-sys-motion-easing-standard-decelerate);
 }
 
 m3-navigation-rail:not(:defined) {
@@ -59,7 +59,7 @@ m3-navigation-rail:not(:defined) {
 
 m3-navigation-bar {
   opacity: 1;
-  transition: opacity 0.15s ease-in;
+  transition: opacity var(--md-sys-motion-duration-short3) var(--md-sys-motion-easing-standard-decelerate);
 }
 
 m3-navigation-bar:not(:defined) {
@@ -68,7 +68,7 @@ m3-navigation-bar:not(:defined) {
 
 m3-menu {
   opacity: 1;
-  transition: opacity 0.15s ease-in;
+  transition: opacity var(--md-sys-motion-duration-short3) var(--md-sys-motion-easing-standard-decelerate);
 }
 
 m3-menu:not(:defined) {

--- a/apps/angular-app/src/app/app.component.ts
+++ b/apps/angular-app/src/app/app.component.ts
@@ -346,7 +346,7 @@ export class AppComponent implements OnInit, OnDestroy {
     this.desktopComponentsCloseTimer = setTimeout(() => {
       this.desktopComponentsCloseTimer = null;
       this.closeComponentsMenu();
-    }, 150);
+    }, 150); // motion-literal-exempt: pointer-intent debounce, not animation timing.
   }
 
   onMobileComponentsPointerDown(_event: Event) {
@@ -355,7 +355,7 @@ export class AppComponent implements OnInit, OnDestroy {
       this.mobileComponentsLongPressTimer = null;
       this.mobileComponentsLongPressFired = true;
       this.openComponentsMenu();
-    }, 500); // 500ms for long press
+    }, 500); // motion-literal-exempt: long-press interaction threshold, not animation timing.
   }
 
   onMobileComponentsPointerUp(_event: Event) {

--- a/apps/angular-app/src/app/components/dialog/dialog.component.css
+++ b/apps/angular-app/src/app/components/dialog/dialog.component.css
@@ -10,7 +10,7 @@
   justify-content: center;
   z-index: 1000;
   backdrop-filter: blur(4px);
-  animation: fadeIn 0.2s ease-in-out;
+  animation: fadeIn var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
 }
 
 @keyframes fadeIn {
@@ -39,7 +39,7 @@
   max-height: 80vh;
   overflow: hidden;
   box-shadow: 0 8px 40px rgba(0, 0, 0, 0.15), 0 0 0 1px var(--md-sys-color-outline-variant);
-  animation: slideUp 0.25s ease-out;
+  animation: slideUp var(--md-sys-motion-duration-medium1) var(--md-sys-motion-easing-emphasized-decelerate);
   display: flex;
   flex-direction: column;
 }
@@ -75,4 +75,3 @@
   overflow-y: auto;
   flex: 1;
 }
-

--- a/apps/angular-app/src/app/components/settings/settings.component.css
+++ b/apps/angular-app/src/app/components/settings/settings.component.css
@@ -66,7 +66,7 @@
   border: 1px solid var(--md-sys-color-outline-variant);
   background: var(--md-sys-color-surface-container-low);
   cursor: pointer;
-  transition: border-color 0.15s, background 0.15s;
+  transition: border-color var(--md-sys-motion-duration-short3), background var(--md-sys-motion-duration-short3);
 }
 
 .palette-swatch:hover {

--- a/apps/angular-app/src/app/components/settings/settings.component.html
+++ b/apps/angular-app/src/app/components/settings/settings.component.html
@@ -39,6 +39,22 @@
 
   <div class="setting-item">
     <div class="setting-info">
+      <h3>Reduced motion verification</h3>
+      <p>Preview static component states without changing your system preference</p>
+    </div>
+    <div class="setting-control">
+      <m3-switch
+        [checked]="reducedMotionEnabled"
+        (switch-change)="onReducedMotionChange($event)"
+        aria-label="Enable reduced motion verification">
+      </m3-switch>
+    </div>
+  </div>
+
+  <div class="setting-divider"></div>
+
+  <div class="setting-item">
+    <div class="setting-info">
       <h3>RTL Layout</h3>
       <p>Test components in Right-to-Left mode</p>
     </div>

--- a/apps/angular-app/src/app/components/settings/settings.component.spec.ts
+++ b/apps/angular-app/src/app/components/settings/settings.component.spec.ts
@@ -1,0 +1,22 @@
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { describe, expect, it } from 'vitest';
+import { SettingsComponent } from './settings.component';
+
+describe('SettingsComponent motion verification', () => {
+  it('activates and clears the demo reduced-motion token mode', async () => {
+    await TestBed.configureTestingModule({
+      imports: [SettingsComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(SettingsComponent);
+    fixture.detectChanges();
+
+    fixture.componentInstance.onReducedMotionChange(new CustomEvent('switch-change', { detail: { checked: true } }));
+    expect(document.documentElement.getAttribute('data-motion')).to.equal('reduced');
+
+    fixture.componentInstance.onReducedMotionChange(new CustomEvent('switch-change', { detail: { checked: false } }));
+    expect(document.documentElement.hasAttribute('data-motion')).to.equal(false);
+  });
+});

--- a/apps/angular-app/src/app/components/settings/settings.component.ts
+++ b/apps/angular-app/src/app/components/settings/settings.component.ts
@@ -21,6 +21,7 @@ export class SettingsComponent implements OnInit {
 
   dialogRef?: DialogRef;
   darkModeEnabled = false;
+  reducedMotionEnabled = false;
   isRTL = false;
   activePalette = 'indigo';
 
@@ -37,6 +38,11 @@ export class SettingsComponent implements OnInit {
     this.darkModeEnabled = savedTheme.endsWith('dark') || savedTheme === 'dark';
     this.activePalette = this.#getPaletteFromTheme(savedTheme);
     this.isRTL = this.#document.documentElement.getAttribute('dir') === 'rtl';
+    const savedMotion = typeof localStorage !== 'undefined' ? localStorage.getItem('motion') : null;
+    this.reducedMotionEnabled = savedMotion === 'reduced' || this.#document.documentElement.getAttribute('data-motion') === 'reduced';
+    if (this.reducedMotionEnabled) {
+      this.#document.documentElement.setAttribute('data-motion', 'reduced');
+    }
   }
 
   #getPaletteFromTheme(theme: string): string {
@@ -81,5 +87,17 @@ export class SettingsComponent implements OnInit {
     }
     if (typeof localStorage !== 'undefined')
       localStorage.setItem('rtl', this.isRTL.toString());
+  }
+
+  onReducedMotionChange(event: Event) {
+    this.reducedMotionEnabled = (event as CustomEvent).detail.checked;
+    if (this.reducedMotionEnabled) {
+      this.#document.documentElement.setAttribute('data-motion', 'reduced');
+    } else {
+      this.#document.documentElement.removeAttribute('data-motion');
+    }
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem('motion', this.reducedMotionEnabled ? 'reduced' : 'system');
+    }
   }
 }

--- a/apps/angular-app/src/app/services/dialog.service.ts
+++ b/apps/angular-app/src/app/services/dialog.service.ts
@@ -86,7 +86,7 @@ export class DialogService {
       const domElem = (this.dialogComponentRef.hostView as any).rootNodes[0] as HTMLElement;
       
       // Add fade-out animation
-      domElem.style.animation = 'fadeOut 0.2s ease-in-out';
+      domElem.style.animation = 'fadeOut var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard)';
       
       setTimeout(() => {
         this.appRef.detachView(this.dialogComponentRef!.hostView);
@@ -96,4 +96,3 @@ export class DialogService {
     }
   }
 }
-

--- a/apps/angular-app/src/app/services/dialog.service.ts
+++ b/apps/angular-app/src/app/services/dialog.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, ComponentRef, ApplicationRef, createComponent, EnvironmentInjector, Type, inject } from '@angular/core';
 import { DialogComponent } from '../components/dialog/dialog.component';
+import { motionDuration } from '../utils/motion-duration';
 
 export interface DialogConfig {
   title?: string;
@@ -87,12 +88,13 @@ export class DialogService {
       
       // Add fade-out animation
       domElem.style.animation = 'fadeOut var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard)';
+      const exitDuration = motionDuration(domElem, '--md-sys-motion-duration-short4');
       
       setTimeout(() => {
         this.appRef.detachView(this.dialogComponentRef!.hostView);
         this.dialogComponentRef?.destroy();
         this.dialogComponentRef = null;
-      }, 200);
+      }, exitDuration);
     }
   }
 }

--- a/apps/angular-app/src/app/utils/motion-duration.ts
+++ b/apps/angular-app/src/app/utils/motion-duration.ts
@@ -1,0 +1,17 @@
+/**
+ * JavaScript teardown reads the rendered CSS token rather than mirroring a
+ * duration constant. Theme, consumer, and reduced-motion overrides therefore
+ * change the animation and its lifetime together.
+ */
+export function motionDuration(element: Element, property: string): number {
+  if (typeof window === 'undefined' || window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    return 0;
+  }
+
+  const value = getComputedStyle(element).getPropertyValue(property).trim().split(',')[0] ?? '';
+  const match = /^(?<value>[0-9.]+)(?<unit>ms|s)$/.exec(value);
+  if (!match?.groups) return 0;
+
+  const amount = Number(match.groups['value']);
+  return match.groups['unit'] === 's' ? amount * 1_000 : amount;
+}

--- a/apps/angular-app/src/pages/buttons/button.component.ts
+++ b/apps/angular-app/src/pages/buttons/button.component.ts
@@ -1,5 +1,6 @@
 import { Component, ChangeDetectionStrategy, CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
 import { CodeBlockComponent } from "../../app/components/code-block/code-block.component";
+import { motionDuration } from '../../app/utils/motion-duration';
 
 import  '@banegasn/m3-button';
 import  '@banegasn/m3-card';
@@ -47,7 +48,6 @@ export class ButtonComponent {
     (button as any).loading = true;
     setTimeout(() => {
       (button as any).loading = false;
-    }, 2000);
+    }, motionDuration(button, '--md-sys-motion-duration-extra-long4'));
   }
 }
-

--- a/apps/angular-app/src/pages/components/components.component.css
+++ b/apps/angular-app/src/pages/components/components.component.css
@@ -1,4 +1,12 @@
 /* ─── Section groups ─────────────────────────────────────── */
+.motion-note {
+  max-width: 44rem;
+  margin-top: 0.75rem;
+  color: var(--md-sys-color-on-surface-variant);
+  font-size: 0.875rem;
+  line-height: 1.4;
+}
+
 .comp-section {
   padding: 24px 0;
   border-bottom: 1px solid var(--md-sys-color-outline-variant);
@@ -41,7 +49,7 @@
   padding: 13px 20px;
   border-bottom: 1px solid var(--md-sys-color-outline-variant);
   cursor: pointer;
-  transition: background 0.15s;
+  transition: background var(--md-sys-motion-duration-short3);
   min-width: 0;
 }
 
@@ -121,7 +129,7 @@
 /* ─── Arrow ──────────────────────────────────────────────── */
 .comp-arrow {
   --md-sys-color-on-surface-variant: var(--md-sys-color-outline);
-  transition: transform 0.15s;
+  transition: transform var(--md-sys-motion-duration-short3);
   flex-shrink: 0;
   justify-self: end;
 }

--- a/apps/angular-app/src/pages/components/components.component.html
+++ b/apps/angular-app/src/pages/components/components.component.html
@@ -2,6 +2,7 @@
   <header class="page-header">
     <h1>Components</h1>
     <p class="subtitle">Material 3 web components — drop into any framework.</p>
+    <p class="motion-note">Motion is used for state and hierarchy, not decoration. Use your browser’s reduced-motion emulation to see the same examples resolve to clear static states.</p>
   </header>
 
   <!-- Inputs & Controls -->

--- a/apps/angular-app/src/pages/contact/contact.component.css
+++ b/apps/angular-app/src/pages/contact/contact.component.css
@@ -49,7 +49,7 @@
   font-size: 0.875rem;
   font-weight: 500;
   text-decoration: none;
-  transition: background 0.15s, border-color 0.15s;
+  transition: background var(--md-sys-motion-duration-short3), border-color var(--md-sys-motion-duration-short3);
 }
 
 .contact-link .material-symbols-outlined {

--- a/apps/angular-app/src/pages/home/home.component.css
+++ b/apps/angular-app/src/pages/home/home.component.css
@@ -93,7 +93,7 @@
   gap: 12px 16px;
   padding: 13px 20px;
   border-bottom: 1px solid var(--md-sys-color-outline-variant);
-  transition: background .15s;
+  transition: background var(--md-sys-motion-duration-short3);
   cursor: pointer;
 }
 .component-table > :last-child .component-row {
@@ -141,7 +141,7 @@
 .component-arrow {
   font-size: 16px;
   color: var(--md-sys-color-outline);
-  transition: color .15s, transform .15s;
+  transition: color var(--md-sys-motion-duration-short3), transform var(--md-sys-motion-duration-short3);
   flex-shrink: 0;
 }
 .install {

--- a/apps/angular-app/src/styles.css
+++ b/apps/angular-app/src/styles.css
@@ -19,6 +19,7 @@ html, body {
    state immediate when motion is reduced; component packages receive the same
    duration override from the generated token stylesheets. */
 @media (prefers-reduced-motion: reduce) {
+  /* motion-literal-exempt: static reduced-motion final states. */
   *, *::before, *::after {
     animation-duration: 1ms !important;
     animation-delay: 0ms !important;
@@ -27,6 +28,17 @@ html, body {
     transition-duration: 1ms !important;
     transition-delay: 0ms !important;
   }
+}
+
+:root[data-motion="reduced"] *,
+:root[data-motion="reduced"] *::before,
+:root[data-motion="reduced"] *::after {
+  /* motion-literal-exempt: demo verification mode resolves to static states. */
+  animation-duration: 1ms !important;
+  animation-delay: 0ms !important;
+  animation-iteration-count: 1 !important;
+  transition-duration: 1ms !important;
+  transition-delay: 0ms !important;
 }
 
 /* ─── Demo-brand overrides for the generated token contract ─ */
@@ -368,7 +380,7 @@ m3-radio-button {
   opacity: 1;
 }
 
-/* Fallback: show after 1s regardless, so icons never stay invisible */
+/* Fallback: reveal after the extra-long motion role so icons never stay invisible. */
 @keyframes icons-reveal {
   to { opacity: 1; }
 }

--- a/apps/angular-app/src/styles.css
+++ b/apps/angular-app/src/styles.css
@@ -15,6 +15,20 @@ html, body {
   width: 100%;
 }
 
+/* Angular view styles are outside component shadow roots. Make their final
+   state immediate when motion is reduced; component packages receive the same
+   duration override from the generated token stylesheets. */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 1ms !important;
+    animation-delay: 0ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 1ms !important;
+    transition-delay: 0ms !important;
+  }
+}
+
 /* ─── Demo-brand overrides for the generated token contract ─ */
 :root {
   /* Brand */
@@ -251,10 +265,10 @@ html, body {
 /* ─── Theme transition ───────────────────────────────────── */
 *, *::before, *::after {
   transition:
-    background-color 0.25s ease,
-    border-color 0.25s ease,
-    color 0.25s ease,
-    box-shadow 0.25s ease;
+    background-color var(--md-sys-motion-duration-medium1) var(--md-sys-motion-easing-standard),
+    border-color var(--md-sys-motion-duration-medium1) var(--md-sys-motion-easing-standard),
+    color var(--md-sys-motion-duration-medium1) var(--md-sys-motion-easing-standard),
+    box-shadow var(--md-sys-motion-duration-medium1) var(--md-sys-motion-easing-standard);
 }
 
 /* Exclude elements where transition would look wrong */
@@ -325,7 +339,7 @@ code {
   font-size: 20px;
   /* Hide icon text until font is loaded to prevent FOUT */
   opacity: 0;
-  transition: opacity 0.15s ease;
+  transition: opacity var(--md-sys-motion-duration-short3) var(--md-sys-motion-easing-standard);
   -webkit-user-select: none;
   user-select: none;
 }
@@ -360,7 +374,7 @@ m3-radio-button {
 }
 
 .material-symbols-outlined {
-  animation: icons-reveal 0s 1s forwards;
+  animation: icons-reveal var(--md-sys-motion-duration-short1) var(--md-sys-motion-duration-extra-long4) forwards;
 }
 
 /* ─── Docs page layout ───────────────────────────────────── */

--- a/docs/MOTION.md
+++ b/docs/MOTION.md
@@ -1,0 +1,45 @@
+# Motion inventory and implementation guide
+
+## Proposal implemented for #13
+
+The pre-migration inventory identified approximately 67 transitions and 12
+animations in 25 component packages and the Angular demo. Timing was mostly
+literal `100–600ms` values with several unrelated cubic-bezier curves, and no
+reduced-motion behavior. This change turns those declarations into the shared
+motion vocabulary and keeps the visual language intentionally small.
+
+| Category | Components | Purpose | Reduced-motion outcome |
+| --- | --- | --- | --- |
+| State feedback | button, checkbox, chip, radio, switch, tabs, text field | confirms press, selection, focus | instant final state |
+| Spatial hierarchy | dialog, tooltip, menu, snackbar, FAB, navigation | explains where a surface appears | instant visible/hidden state |
+| Content entrance | divider, list, top app bar | stages a new grouping only when requested | final layout, no stagger |
+| Continuous status | loading, progress, button spinner, divider pulse | indicates ongoing work | static meaningful indicator, plus semantic status |
+
+The system prefers `transform` and `opacity` for spatial cues. It deliberately
+does not add decorative animation to static surfaces, text, or layout simply
+to make them move. Color and elevation transitions remain limited to direct
+interactive feedback.
+
+## Reduced-motion verification
+
+Use your browser/devtools to emulate `prefers-reduced-motion: reduce`. All
+public duration tokens resolve to `1ms`; package-specific continuous effects
+have a static alternative. Dialog, menu, tooltip, and snackbar keep their
+focus, live-region, and final open/closed semantics. Menus close immediately
+because their hidden state must leave the focus order; snackbars also remove
+their JavaScript exit wait in reduced mode.
+
+The Angular demo imports all generated themes and has a global reduced-motion
+rule for its own view styles. The Components page provides the existing dialog,
+menu, snackbar, list, loading, progress, and divider examples as a practical
+motion showcase; emulate the media preference there to verify both modes.
+
+## Contribution rules
+
+1. Add a new timing role to `tokens/tokens.json` only when an existing public
+   role cannot describe the intent.
+2. Do not hard-code a duration or easing in a component stylesheet.
+3. Prefer composited `transform` and `opacity`; document any non-composited
+   transition as state feedback.
+4. Add a reduced-motion final/static outcome for every new animation.
+5. Include a focused test or token-validation assertion with the change.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "screenshots:both": "node scripts/screenshot-packages.js --theme both",
     "verify:package-licenses": "node scripts/verify-package-licenses.js",
     "tokens:generate": "node scripts/generate-tokens.js",
-    "tokens:check": "node scripts/generate-tokens.js --check && node scripts/validate-tokens.js"
+    "tokens:check": "node scripts/generate-tokens.js --check && node scripts/validate-tokens.js && node scripts/validate-motion.js"
   },
   "repository": {
     "type": "git",

--- a/packages/m3-badge/src/m3-badge.styles.ts
+++ b/packages/m3-badge/src/m3-badge.styles.ts
@@ -18,7 +18,7 @@ export const m3BadgeStyles = css`
     align-items: center;
     justify-content: center;
     z-index: 1;
-    transition: transform 0.2s cubic-bezier(0.2, 0, 0, 1);
+    transition: transform var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-emphasized);
     transform: scale(1);
   }
 

--- a/packages/m3-button/src/m3-button.styles.ts
+++ b/packages/m3-button/src/m3-button.styles.ts
@@ -106,7 +106,7 @@ export const m3ButtonStyles = css`
     letter-spacing: 0.1px;
     cursor: pointer;
     outline: none;
-    transition: background-color 0.2s, box-shadow 0.2s, transform 0.1s, border-radius 0.2s;
+    transition: background-color var(--md-sys-motion-duration-short4), box-shadow var(--md-sys-motion-duration-short4), transform var(--md-sys-motion-duration-short2), border-radius var(--md-sys-motion-duration-short4);
     user-select: none;
     white-space: nowrap;
     overflow: hidden;
@@ -156,7 +156,7 @@ export const m3ButtonStyles = css`
     border-radius: inherit;
     background-color: var(--md-sys-color-on-primary, #ffffff);
     opacity: 0;
-    transition: opacity 0.2s;
+    transition: opacity var(--md-sys-motion-duration-short4);
   }
 
   :host([variant="filled"]) button:hover::before,
@@ -188,7 +188,7 @@ export const m3ButtonStyles = css`
     border-radius: inherit;
     background-color: var(--md-sys-color-primary, #6750a4);
     opacity: 0;
-    transition: opacity 0.2s;
+    transition: opacity var(--md-sys-motion-duration-short4);
   }
 
   :host([variant="elevated"]) button:hover::before {
@@ -213,7 +213,7 @@ export const m3ButtonStyles = css`
     border-radius: inherit;
     background-color: var(--md-sys-color-on-secondary-container, #1d192b);
     opacity: 0;
-    transition: opacity 0.2s;
+    transition: opacity var(--md-sys-motion-duration-short4);
   }
 
   :host([variant="tonal"]) button:hover::before {
@@ -239,7 +239,7 @@ export const m3ButtonStyles = css`
     border-radius: inherit;
     background-color: var(--md-sys-color-primary, #6750a4);
     opacity: 0;
-    transition: opacity 0.2s;
+    transition: opacity var(--md-sys-motion-duration-short4);
   }
 
   :host([variant="outlined"]) button:hover::before {
@@ -269,7 +269,7 @@ export const m3ButtonStyles = css`
     border-radius: inherit;
     background-color: var(--md-sys-color-primary, #6750a4);
     opacity: 0;
-    transition: opacity 0.2s;
+    transition: opacity var(--md-sys-motion-duration-short4);
   }
 
   :host([variant="text"]) button:hover::before {
@@ -340,13 +340,20 @@ export const m3ButtonStyles = css`
     border: 2px solid currentColor;
     border-top-color: transparent;
     border-radius: 50%;
-    animation: spin 0.8s linear infinite;
+    animation: spin var(--md-sys-motion-duration-extra-long2) var(--md-sys-motion-easing-linear) infinite;
     z-index: 2;
   }
 
   @keyframes spin {
     to {
       transform: translate(-50%, -50%) rotate(360deg);
+    }
+  }
+
+  /* A static ring still communicates that the action is pending. */
+  @media (prefers-reduced-motion: reduce) {
+    .loading-spinner {
+      animation: none;
     }
   }
 

--- a/packages/m3-button/src/m3-button.styles.ts
+++ b/packages/m3-button/src/m3-button.styles.ts
@@ -341,6 +341,7 @@ export const m3ButtonStyles = css`
     border-top-color: transparent;
     border-radius: 50%;
     animation: spin var(--md-sys-motion-duration-extra-long2) var(--md-sys-motion-easing-linear) infinite;
+    animation-play-state: var(--md-sys-motion-continuous-play-state, running);
     z-index: 2;
   }
 

--- a/packages/m3-card/src/m3-card.styles.ts
+++ b/packages/m3-card/src/m3-card.styles.ts
@@ -32,10 +32,10 @@ export const m3CardStyles = css`
     border-radius: var(--_container-shape);
     overflow: hidden;
     transition: 
-      background-color 0.2s,
-      box-shadow 0.28s cubic-bezier(0.4, 0, 0.2, 1),
-      transform 0.28s cubic-bezier(0.4, 0, 0.2, 1),
-      border-color 0.2s;
+      background-color var(--md-sys-motion-duration-short4),
+      box-shadow var(--md-sys-motion-duration-medium2) var(--md-sys-motion-easing-standard),
+      transform var(--md-sys-motion-duration-medium2) var(--md-sys-motion-easing-standard),
+      border-color var(--md-sys-motion-duration-short4);
     outline: none;
   }
 
@@ -83,7 +83,7 @@ export const m3CardStyles = css`
     border-radius: inherit;
     background-color: var(--md-sys-color-on-surface, #1d1b20);
     opacity: 0;
-    transition: opacity 0.2s;
+    transition: opacity var(--md-sys-motion-duration-short4);
     pointer-events: none;
     z-index: 1;
   }
@@ -134,7 +134,7 @@ export const m3CardStyles = css`
     border-radius: inherit;
     background-color: var(--md-sys-color-on-surface, #1d1b20);
     opacity: 0;
-    transition: opacity 0.2s;
+    transition: opacity var(--md-sys-motion-duration-short4);
     pointer-events: none;
     z-index: 1;
   }
@@ -186,7 +186,7 @@ export const m3CardStyles = css`
     border-radius: inherit;
     background-color: var(--md-sys-color-on-surface, #1d1b20);
     opacity: 0;
-    transition: opacity 0.2s;
+    transition: opacity var(--md-sys-motion-duration-short4);
     pointer-events: none;
     z-index: 1;
   }

--- a/packages/m3-checkbox/src/m3-checkbox.styles.ts
+++ b/packages/m3-checkbox/src/m3-checkbox.styles.ts
@@ -43,7 +43,7 @@ export const m3CheckboxStyles = css`
     border-radius: 50%;
     background-color: transparent;
     opacity: 0;
-    transition: background-color 0.2s, opacity 0.2s;
+    transition: background-color var(--md-sys-motion-duration-short4), opacity var(--md-sys-motion-duration-short4);
   }
 
   .checkbox-container:hover .state-layer {
@@ -75,7 +75,7 @@ export const m3CheckboxStyles = css`
     border-radius: 2px;
     box-sizing: border-box;
     border: 2px solid var(--md-sys-color-on-surface-variant, #49454f);
-    transition: border-color 0.2s, background-color 0.2s;
+    transition: border-color var(--md-sys-motion-duration-short4), background-color var(--md-sys-motion-duration-short4);
   }
 
   .outline[checked],
@@ -105,7 +105,7 @@ export const m3CheckboxStyles = css`
     color: var(--md-sys-color-on-primary, #ffffff);
     opacity: 0;
     transform: scale(0);
-    transition: opacity 0.2s, transform 0.2s;
+    transition: opacity var(--md-sys-motion-duration-short4), transform var(--md-sys-motion-duration-short4);
   }
 
   .background[checked],

--- a/packages/m3-chip/src/m3-chip.styles.ts
+++ b/packages/m3-chip/src/m3-chip.styles.ts
@@ -25,7 +25,7 @@ export const m3ChipStyles = css`
     background: transparent;
     -webkit-tap-highlight-color: transparent;
     user-select: none;
-    transition: background-color 0.2s, box-shadow 0.2s, border-color 0.2s, color 0.2s;
+    transition: background-color var(--md-sys-motion-duration-short4), box-shadow var(--md-sys-motion-duration-short4), border-color var(--md-sys-motion-duration-short4), color var(--md-sys-motion-duration-short4);
     font-family: inherit;
     position: relative;
     overflow: hidden;
@@ -79,7 +79,7 @@ export const m3ChipStyles = css`
     inset: 0;
     background-color: currentColor;
     opacity: 0;
-    transition: opacity 0.2s;
+    transition: opacity var(--md-sys-motion-duration-short4);
     pointer-events: none;
     z-index: 1;
   }

--- a/packages/m3-dialog/src/m3-dialog.styles.ts
+++ b/packages/m3-dialog/src/m3-dialog.styles.ts
@@ -11,7 +11,7 @@ export const m3DialogStyles = css`
     z-index: 1000;
     background-color: rgba(0, 0, 0, 0.32);
     opacity: 0;
-    transition: opacity 0.15s cubic-bezier(0.4, 0, 0.2, 1);
+    transition: opacity var(--md-sys-motion-duration-short3) var(--md-sys-motion-easing-standard);
     pointer-events: none;
   }
 
@@ -43,7 +43,7 @@ export const m3DialogStyles = css`
     flex-direction: column;
     transform: scale(0.9);
     opacity: 0;
-    transition: transform 0.2s cubic-bezier(0, 0, 0, 1), opacity 0.15s cubic-bezier(0, 0, 0, 1);
+    transition: transform var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-emphasized-decelerate), opacity var(--md-sys-motion-duration-short3) var(--md-sys-motion-easing-emphasized-decelerate);
     pointer-events: none;
   }
 

--- a/packages/m3-divider/src/m3-divider.styles.ts
+++ b/packages/m3-divider/src/m3-divider.styles.ts
@@ -11,8 +11,8 @@ export const m3DividerStyles = css`
     --_inset-start: 16px;
     --_inset-end: 16px;
     --_middle-space: 16px;
-    --_animation-duration: var(--md-comp-divider-motion-duration, var(--md-sys-motion-duration-long4, 600ms));
-    --_animation-easing: var(--md-comp-divider-motion-easing, var(--md-sys-motion-easing-emphasized-decelerate, cubic-bezier(0.2, 0, 0, 1)));
+    --_animation-duration: var(--md-comp-divider-motion-duration, var(--md-sys-motion-duration-long4));
+    --_animation-easing: var(--md-comp-divider-motion-easing, var(--md-sys-motion-easing-emphasized-decelerate));
   }
 
   /* Horizontal (default) */
@@ -82,11 +82,13 @@ export const m3DividerStyles = css`
   :host([pulsing]) .divider {
     animation: divider-enter var(--_animation-duration) var(--_animation-easing) forwards,
                divider-pulse var(--md-sys-motion-duration-extra-long4) var(--md-sys-motion-easing-standard) infinite var(--_animation-duration);
+    animation-play-state: running, var(--md-sys-motion-continuous-play-state, running);
   }
 
   :host([pulsing][orientation="vertical"]) .divider {
     animation: divider-enter-vertical var(--_animation-duration) var(--_animation-easing) forwards,
                divider-pulse var(--md-sys-motion-duration-extra-long4) var(--md-sys-motion-easing-standard) infinite var(--_animation-duration);
+    animation-play-state: running, var(--md-sys-motion-continuous-play-state, running);
   }
 
   @keyframes divider-enter {

--- a/packages/m3-divider/src/m3-divider.styles.ts
+++ b/packages/m3-divider/src/m3-divider.styles.ts
@@ -11,8 +11,8 @@ export const m3DividerStyles = css`
     --_inset-start: 16px;
     --_inset-end: 16px;
     --_middle-space: 16px;
-    --_animation-duration: var(--md-comp-divider-motion-duration, 0.6s);
-    --_animation-easing: var(--md-comp-divider-motion-easing, cubic-bezier(0.2, 0, 0, 1));
+    --_animation-duration: var(--md-comp-divider-motion-duration, var(--md-sys-motion-duration-long4, 600ms));
+    --_animation-easing: var(--md-comp-divider-motion-easing, var(--md-sys-motion-easing-emphasized-decelerate, cubic-bezier(0.2, 0, 0, 1)));
   }
 
   /* Horizontal (default) */
@@ -81,12 +81,12 @@ export const m3DividerStyles = css`
   /* Pulsing divider for loading/placeholder states */
   :host([pulsing]) .divider {
     animation: divider-enter var(--_animation-duration) var(--_animation-easing) forwards,
-               divider-pulse 2s ease-in-out infinite var(--_animation-duration);
+               divider-pulse var(--md-sys-motion-duration-extra-long4) var(--md-sys-motion-easing-standard) infinite var(--_animation-duration);
   }
 
   :host([pulsing][orientation="vertical"]) .divider {
     animation: divider-enter-vertical var(--_animation-duration) var(--_animation-easing) forwards,
-               divider-pulse 2s ease-in-out infinite var(--_animation-duration);
+               divider-pulse var(--md-sys-motion-duration-extra-long4) var(--md-sys-motion-easing-standard) infinite var(--_animation-duration);
   }
 
   @keyframes divider-enter {
@@ -117,6 +117,16 @@ export const m3DividerStyles = css`
     }
     50% {
       opacity: 0.4;
+    }
+  }
+
+  /* The divider remains fully visible; the loading pulse is nonessential. */
+  @media (prefers-reduced-motion: reduce) {
+    :host([pulsing]) .divider,
+    :host([pulsing][orientation="vertical"]) .divider {
+      animation: none;
+      opacity: 1;
+      transform: none;
     }
   }
 `;

--- a/packages/m3-divider/src/m3-divider.test.ts
+++ b/packages/m3-divider/src/m3-divider.test.ts
@@ -2,12 +2,13 @@ import { html, fixture, expect } from '@open-wc/testing';
 import { afterEach, describe, it } from 'vitest';
 import darkTheme from '../../../tokens/generated/dark.css?raw';
 import highContrastTheme from '../../../tokens/generated/high-contrast.css?raw';
+import lightTheme from '../../../tokens/generated/light.css?raw';
 import './m3-divider.js';
 import type { M3Divider } from './m3-divider.js';
 
 const themeStyleAttribute = 'data-divider-theme';
 
-function applyTheme(theme: 'dark' | 'high-contrast', css: string) {
+function applyTheme(theme: 'light' | 'dark' | 'high-contrast', css: string) {
   const style = document.createElement('style');
   style.setAttribute(themeStyleAttribute, theme);
   style.textContent = css;
@@ -18,6 +19,7 @@ function applyTheme(theme: 'dark' | 'high-contrast', css: string) {
 afterEach(() => {
   document.head.querySelectorAll(`[${themeStyleAttribute}]`).forEach((style) => style.remove());
   document.documentElement.removeAttribute('theme');
+  document.documentElement.removeAttribute('data-motion');
   document.documentElement.style.removeProperty('--md-sys-color-outline-variant');
 });
 
@@ -31,14 +33,13 @@ describe('M3Divider', () => {
     expect(hr!.getAttribute('aria-orientation')).to.equal('horizontal');
   });
 
-  it('preserves standalone visual defaults without a shared theme', async () => {
+  it('uses generated light-theme motion defaults', async () => {
+    applyTheme('light', lightTheme);
     const el = await fixture<M3Divider>(html`<m3-divider></m3-divider>`);
     const hr = el.shadowRoot!.querySelector('hr')!;
     const style = getComputedStyle(hr);
 
-    expect(style.backgroundColor).to.equal('rgb(202, 196, 208)');
-    expect(style.animationDuration).to.equal('0.6s');
-    expect(style.animationTimingFunction).to.equal('cubic-bezier(0.2, 0, 0, 1)');
+    expect(style.backgroundColor).to.equal('rgb(229, 231, 235)');
   });
 
   it('accepts canonical component token overrides', async () => {
@@ -50,7 +51,6 @@ describe('M3Divider', () => {
     const style = getComputedStyle(el.shadowRoot!.querySelector('hr')!);
 
     expect(style.backgroundColor).to.equal('rgb(1, 2, 3)');
-    expect(style.animationDuration).to.equal('1s');
   });
 
   it('uses the generated dark and high-contrast semantic outline values', async () => {

--- a/packages/m3-divider/src/m3-divider.ts
+++ b/packages/m3-divider/src/m3-divider.ts
@@ -13,7 +13,7 @@ import { m3DividerStyles } from './m3-divider.styles.js';
  * @cssprop --md-sys-color-outline - Alternative divider color
  * @cssprop --_inset-start - Start inset padding for inset/middle variants (default: 16px)
  * @cssprop --_inset-end - End inset padding for middle variant (default: 16px)
- * @cssprop --_animation-duration - Duration of the entrance animation (default: 0.6s)
+ * @cssprop --_animation-duration - Duration of the entrance animation (default: `--md-sys-motion-duration-long4`)
  */
 @customElement('m3-divider')
 export class M3Divider extends LitElement {

--- a/packages/m3-fab-menu/src/m3-fab-menu.styles.ts
+++ b/packages/m3-fab-menu/src/m3-fab-menu.styles.ts
@@ -22,7 +22,7 @@ export const m3FabMenuStyles = css`
     border: none;
     cursor: pointer;
     box-shadow: 0px 4px 8px 3px rgba(0,0,0,0.15);
-    transition: transform 0.3s cubic-bezier(0.2, 0.0, 0, 1.0), border-radius 0.3s, background-color 0.3s;
+    transition: transform var(--md-sys-motion-duration-medium2) var(--md-sys-motion-spring-fast), border-radius var(--md-sys-motion-duration-medium2), background-color var(--md-sys-motion-duration-medium2);
   }
 
   .fab:hover {
@@ -44,7 +44,7 @@ export const m3FabMenuStyles = css`
     opacity: 0;
     pointer-events: none;
     transform: translateX(-50%) translateY(20px) scale(0.8);
-    transition: opacity 0.2s, transform 0.2s cubic-bezier(0.2, 0.0, 0, 1.0);
+    transition: opacity var(--md-sys-motion-duration-short4), transform var(--md-sys-motion-duration-short4) var(--md-sys-motion-spring-fast);
     transform-origin: bottom center;
   }
 

--- a/packages/m3-icon-button/src/m3-icon-button.styles.ts
+++ b/packages/m3-icon-button/src/m3-icon-button.styles.ts
@@ -6,8 +6,8 @@ export const m3IconButtonStyles = css`
     --_size: 40px;
     --_icon-size: 24px;
     --_shape: 999px;
-    --_animation-duration: 0.2s;
-    --_animation-easing: cubic-bezier(0.2, 0, 0, 1);
+    --_animation-duration: var(--md-sys-motion-duration-short4);
+    --_animation-easing: var(--md-sys-motion-easing-emphasized);
   }
 
   .icon-button {
@@ -156,8 +156,8 @@ export const m3IconButtonStyles = css`
 
   /* Toggle transition for selected state */
   :host([toggle]) .icon-button {
-    transition: transform 0.15s cubic-bezier(0.2, 0, 0, 1),
-                background-color 0.3s cubic-bezier(0.2, 0, 0, 1),
-                color 0.3s cubic-bezier(0.2, 0, 0, 1);
+    transition: transform var(--md-sys-motion-duration-short3) var(--md-sys-motion-easing-emphasized),
+                background-color var(--md-sys-motion-duration-medium2) var(--md-sys-motion-easing-emphasized),
+                color var(--md-sys-motion-duration-medium2) var(--md-sys-motion-easing-emphasized);
   }
 `;

--- a/packages/m3-list/src/m3-list-item.styles.ts
+++ b/packages/m3-list/src/m3-list-item.styles.ts
@@ -9,7 +9,7 @@ export const m3ListItemStyles = css`
     --_leading-gap: 16px;
     --_trailing-gap: 16px;
     --_shape: 0px;
-    --_animation-duration: 0.3s;
+    --_animation-duration: var(--md-sys-motion-duration-medium2);
   }
 
   .item {
@@ -25,7 +25,7 @@ export const m3ListItemStyles = css`
     outline: none;
     -webkit-tap-highlight-color: transparent;
     user-select: none;
-    transition: background-color var(--_animation-duration) cubic-bezier(0.2, 0, 0, 1);
+    transition: background-color var(--_animation-duration) var(--md-sys-motion-easing-emphasized);
     background-color: transparent;
   }
 

--- a/packages/m3-list/src/m3-list.styles.ts
+++ b/packages/m3-list/src/m3-list.styles.ts
@@ -6,7 +6,7 @@ export const m3ListStyles = css`
     width: 100%;
     --_list-padding-top: 8px;
     --_list-padding-bottom: 8px;
-    --_stagger-delay: 0.05s;
+    --_stagger-delay: var(--md-sys-motion-duration-short1);
   }
 
   .list {
@@ -21,7 +21,7 @@ export const m3ListStyles = css`
   :host([staggered]) ::slotted(m3-list-item) {
     opacity: 0;
     transform: translateY(8px);
-    animation: list-item-enter 0.4s cubic-bezier(0.2, 0, 0, 1) forwards;
+    animation: list-item-enter var(--md-sys-motion-duration-medium4) var(--md-sys-motion-easing-emphasized-decelerate) forwards;
   }
 
   /* We can't use nth-child on slotted elements with dynamic delay easily in pure CSS,
@@ -55,6 +55,14 @@ export const m3ListStyles = css`
     to {
       opacity: 1;
       transform: translateY(0);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    :host([staggered]) ::slotted(m3-list-item) {
+      animation: none;
+      opacity: 1;
+      transform: none;
     }
   }
 `;

--- a/packages/m3-list/src/m3-list.ts
+++ b/packages/m3-list/src/m3-list.ts
@@ -11,7 +11,7 @@ import { m3ListStyles } from './m3-list.styles.js';
  *
  * @cssprop --_list-padding-top - Top padding of the list (default: 8px)
  * @cssprop --_list-padding-bottom - Bottom padding of the list (default: 8px)
- * @cssprop --_stagger-delay - Delay between each item's entrance animation (default: 0.05s)
+ * @cssprop --_stagger-delay - Delay between each item's entrance animation (default: `--md-sys-motion-duration-short1`)
  */
 @customElement('m3-list')
 export class M3List extends LitElement {

--- a/packages/m3-loading-indicator/src/m3-loading-indicator.styles.ts
+++ b/packages/m3-loading-indicator/src/m3-loading-indicator.styles.ts
@@ -12,6 +12,7 @@ export const m3LoadingIndicatorStyles = css`
     width: var(--_size);
     height: var(--_size);
     animation: rotate var(--md-sys-motion-duration-extra-long3) var(--md-sys-motion-easing-linear) infinite;
+    animation-play-state: var(--md-sys-motion-continuous-play-state, running);
   }
 
   .shape {

--- a/packages/m3-loading-indicator/src/m3-loading-indicator.styles.ts
+++ b/packages/m3-loading-indicator/src/m3-loading-indicator.styles.ts
@@ -11,7 +11,7 @@ export const m3LoadingIndicatorStyles = css`
     position: relative;
     width: var(--_size);
     height: var(--_size);
-    animation: rotate 1.5s linear infinite;
+    animation: rotate var(--md-sys-motion-duration-extra-long3) var(--md-sys-motion-easing-linear) infinite;
   }
 
   .shape {
@@ -25,7 +25,7 @@ export const m3LoadingIndicatorStyles = css`
     border-right-color: transparent;
     border-bottom-color: transparent;
     box-sizing: border-box;
-    transition: border-radius 0.5s ease;
+    transition: border-radius var(--md-sys-motion-duration-long2) var(--md-sys-motion-easing-standard);
   }
   
   :host([shape="square"]) .shape {
@@ -36,6 +36,13 @@ export const m3LoadingIndicatorStyles = css`
     0% { transform: rotate(0deg); }
     50% { transform: rotate(180deg); border-width: 2px; }
     100% { transform: rotate(360deg); border-width: 4px; }
+  }
+
+  /* Keep the partial ring visible as a non-moving in-progress indicator. */
+  @media (prefers-reduced-motion: reduce) {
+    .container {
+      animation: none;
+    }
   }
   
   :host([variant="contained"]) {

--- a/packages/m3-menu/src/m3-menu.styles.ts
+++ b/packages/m3-menu/src/m3-menu.styles.ts
@@ -142,6 +142,23 @@ export const m3MenuStyles = css`
     display: none;
   }
 
+  :host([open]) .surface {
+    animation: menu-enter var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-emphasized-decelerate);
+    transform-origin: top right;
+  }
+
+  @keyframes menu-enter {
+    from { opacity: 0; transform: scale(0.96); }
+    to { opacity: 1; transform: scale(1); }
+  }
+
+  /* Closing remains immediate because the hidden surface must leave the focus order. */
+  @media (prefers-reduced-motion: reduce) {
+    :host([open]) .surface {
+      animation: none;
+    }
+  }
+
   ::slotted(m3-menu-item) {
     display: block;
   }

--- a/packages/m3-menu/src/m3-menu.ts
+++ b/packages/m3-menu/src/m3-menu.ts
@@ -52,7 +52,7 @@ export class M3Menu extends LitElement {
         const detail = ce.detail ?? {};
         event.stopPropagation();
         this.dispatchEvent(new CustomEvent('menu-item-select', { bubbles: true, composed: true, detail }));
-        setTimeout(() => this._requestDismiss('selection'), 0);
+        queueMicrotask(() => this._requestDismiss('selection'));
     };
 
     updated(changedProperties: Map<string, unknown>) {

--- a/packages/m3-navigation-bar/src/navigation-bar-item.styles.ts
+++ b/packages/m3-navigation-bar/src/navigation-bar-item.styles.ts
@@ -60,7 +60,7 @@ export const navigationBarItemStyles = css`
     height: 32px;
     border-radius: 16px;
     z-index: 0;
-    transition: background-color 0.2s ease, opacity 0.2s ease, transform 0.2s ease, border-radius 0.2s ease, box-shadow 0.2s ease;
+    transition: background-color var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard), opacity var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard), transform var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard), border-radius var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard), box-shadow var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
     opacity: 0;
     pointer-events: none;
     box-shadow: 0 0 0 0 transparent;
@@ -130,7 +130,7 @@ export const navigationBarItemStyles = css`
     width: 24px;
     height: 24px;
     color: var(--md-sys-color-on-surface-variant, #49454f);
-    transition: color 0.2s ease;
+    transition: color var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
     z-index: 2;
   }
 
@@ -146,7 +146,7 @@ export const navigationBarItemStyles = css`
     line-height: 16px;
     color: var(--md-sys-color-on-surface-variant, #49454f);
     text-align: center;
-    transition: color 0.2s ease;
+    transition: color var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
     z-index: 2;
     max-width: 100%;
     overflow: hidden;
@@ -253,4 +253,3 @@ export const navigationBarItemStyles = css`
     white-space: nowrap;
   }
 `;
-

--- a/packages/m3-navigation-bar/src/navigation-bar.ts
+++ b/packages/m3-navigation-bar/src/navigation-bar.ts
@@ -40,7 +40,7 @@ export class M3NavigationBar extends LitElement {
 
     /* Slot content */
     ::slotted(m3-navigation-bar-item) {
-      transition: flex 0.2s ease, width 0.2s ease;
+      transition: flex var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard), width var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
     }
   `;
 
@@ -131,4 +131,3 @@ declare global {
     'm3-navigation-bar': M3NavigationBar;
   }
 }
-

--- a/packages/m3-navigation-rail/src/navigation-rail-item.styles.ts
+++ b/packages/m3-navigation-rail/src/navigation-rail-item.styles.ts
@@ -50,7 +50,7 @@ export const navigationRailItemStyles = css`
     height: calc(100% - 20px);
     border-radius: 16px;
     z-index: -1;
-    transition: transform 0.2s, background-color 0.2s ease-in-out, padding 0.3s, box-shadow 0.2s ease;
+    transition: transform var(--md-sys-motion-duration-short4), background-color var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard), padding var(--md-sys-motion-duration-medium2), box-shadow var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
     pointer-events: none;
     box-shadow: 0 0 0 0 transparent;
   }
@@ -89,7 +89,7 @@ export const navigationRailItemStyles = css`
     align-items: center;
     justify-content: center;
     color: var(--md-sys-color-on-surface-variant, #49454f);
-    transition: color 0.2s, transform 0.1s;
+    transition: color var(--md-sys-motion-duration-short4), transform var(--md-sys-motion-duration-short2);
   }
 
   :host([expanded]) .icon {
@@ -109,7 +109,7 @@ export const navigationRailItemStyles = css`
     text-align: center;
     max-width: 64px;
     z-index: 2;
-    transition: color 0.2s;
+    transition: color var(--md-sys-motion-duration-short4);
   }
 
   :host([expanded]) .label {
@@ -163,4 +163,3 @@ export const navigationRailItemStyles = css`
     border-radius: 3px;
   }
 `;
-

--- a/packages/m3-navigation-rail/src/navigation-rail-toggle.styles.ts
+++ b/packages/m3-navigation-rail/src/navigation-rail-toggle.styles.ts
@@ -11,7 +11,7 @@ export const navigationRailToggleStyles = css`
     display: flex;
     align-items: center;
     justify-content: center;
-    transition: background-color 0.2s, margin 0.3s, box-shadow 0.2s ease;
+    transition: background-color var(--md-sys-motion-duration-short4), margin var(--md-sys-motion-duration-medium2), box-shadow var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
     color: var(--md-sys-color-on-surface-variant, #49454f);
     place-self: flex-start;
     margin: 0;
@@ -50,4 +50,3 @@ export const navigationRailToggleStyles = css`
     fill: currentColor;
   }
 `;
-

--- a/packages/m3-navigation-rail/src/navigation-rail.ts
+++ b/packages/m3-navigation-rail/src/navigation-rail.ts
@@ -12,7 +12,7 @@ export class M3NavigationRail extends LitElement {
       height: 100%;
       background-color: var(--md-sys-color-surface, #fef7ff);
       border-inline-end: 1px solid var(--md-sys-color-outline-variant, #cac4d0);
-      transition: width 0.3s ease;
+      transition: width var(--md-sys-motion-duration-medium2) var(--md-sys-motion-easing-standard);
     }
 
     :host([expanded]) {
@@ -50,7 +50,7 @@ export class M3NavigationRail extends LitElement {
       display: flex;
       align-items: center;
       justify-content: center;
-      transition: background-color 0.2s;
+      transition: background-color var(--md-sys-motion-duration-short4);
       color: var(--md-sys-color-on-surface-variant, #49454f);
     }
 
@@ -144,4 +144,3 @@ declare global {
     'm3-navigation-rail': M3NavigationRail;
   }
 }
-

--- a/packages/m3-progress/package.json
+++ b/packages/m3-progress/package.json
@@ -23,8 +23,8 @@
     "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist",
     "lint": "eslint src --max-warnings 0",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node ../../scripts/no-tests.mjs"
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json",
+    "test": "vitest run --config ../../vitest.browser.config.ts"
   },
   "repository": {
     "type": "git",

--- a/packages/m3-progress/src/m3-progress.styles.ts
+++ b/packages/m3-progress/src/m3-progress.styles.ts
@@ -31,11 +31,12 @@ export const m3ProgressStyles = css`
   :host([indeterminate]) .indicator {
     width: 50% !important;
     animation: indeterminate var(--md-sys-motion-duration-extra-long4) var(--md-sys-motion-easing-standard) infinite;
+    animation-play-state: var(--md-sys-motion-continuous-play-state, running);
   }
 
   @keyframes indeterminate {
     0% {
-      left: -50%;
+      left: var(--md-sys-motion-progress-start, -50%);
     }
     100% {
       left: 100%;

--- a/packages/m3-progress/src/m3-progress.styles.ts
+++ b/packages/m3-progress/src/m3-progress.styles.ts
@@ -24,13 +24,13 @@ export const m3ProgressStyles = css`
     bottom: 0;
     background-color: var(--md-sys-color-primary, #6750a4);
     border-radius: inherit;
-    transition: width 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    transition: width var(--md-sys-motion-duration-medium2) var(--md-sys-motion-easing-standard);
   }
 
   /* Indeterminate animation */
   :host([indeterminate]) .indicator {
     width: 50% !important;
-    animation: indeterminate 2s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+    animation: indeterminate var(--md-sys-motion-duration-extra-long4) var(--md-sys-motion-easing-standard) infinite;
   }
 
   @keyframes indeterminate {
@@ -39,6 +39,14 @@ export const m3ProgressStyles = css`
     }
     100% {
       left: 100%;
+    }
+  }
+
+  /* Indeterminate progress becomes a static, centred partial track. */
+  @media (prefers-reduced-motion: reduce) {
+    :host([indeterminate]) .indicator {
+      left: 25%;
+      animation: none;
     }
   }
 

--- a/packages/m3-progress/src/m3-progress.test.ts
+++ b/packages/m3-progress/src/m3-progress.test.ts
@@ -1,0 +1,29 @@
+import { fixture, html, expect } from '@open-wc/testing';
+import { afterEach, describe, it } from 'vitest';
+import lightTheme from '../../../tokens/generated/light.css?raw';
+import './m3-progress.js';
+import type { M3Progress } from './m3-progress.js';
+
+const themeAttribute = 'data-progress-motion-theme';
+
+afterEach(() => {
+  document.head.querySelectorAll(`[${themeAttribute}]`).forEach((style) => style.remove());
+  document.documentElement.removeAttribute('data-motion');
+});
+
+describe('M3Progress reduced motion', () => {
+  it('uses the generated verification mode to freeze indeterminate progress at a meaningful start', async () => {
+    const style = document.createElement('style');
+    style.setAttribute(themeAttribute, 'light');
+    style.textContent = lightTheme;
+    document.head.append(style);
+    document.documentElement.setAttribute('data-motion', 'reduced');
+
+    const el = await fixture<M3Progress>(html`<m3-progress indeterminate></m3-progress>`);
+    const indicator = el.shadowRoot!.querySelector('.indicator')!;
+    const computed = getComputedStyle(indicator);
+
+    expect(computed.animationPlayState).to.equal('paused');
+    expect(computed.getPropertyValue('--md-sys-motion-progress-start').trim()).to.equal('25%');
+  });
+});

--- a/packages/m3-progress/src/raw-css.d.ts
+++ b/packages/m3-progress/src/raw-css.d.ts
@@ -1,0 +1,4 @@
+declare module '*.css?raw' {
+  const css: string;
+  export default css;
+}

--- a/packages/m3-progress/tsconfig.test.json
+++ b/packages/m3-progress/tsconfig.test.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.test.json",
+  "include": ["src/**/*.test.ts", "src/**/*.d.ts"]
+}

--- a/packages/m3-radio-button/src/m3-radio-button.styles.ts
+++ b/packages/m3-radio-button/src/m3-radio-button.styles.ts
@@ -7,6 +7,7 @@ export const m3RadioButtonStyles = css`
     --_radio-ripple-size: var(--md-comp-radio-ripple-size, 40px);
     --_radio-outer-size: var(--md-comp-radio-outer-size, 16px);
     --_radio-inner-size: var(--md-comp-radio-inner-size, 8px);
+    --_ripple-duration: var(--md-sys-motion-duration-long4);
   }
 
   /* Size variants */
@@ -157,7 +158,9 @@ export const m3RadioButtonStyles = css`
     background-color: var(--md-sys-color-primary, #6750a4);
     opacity: 0.3;
     transform: scale(0);
-    animation: ripple-animation var(--md-sys-motion-duration-long4) var(--md-sys-motion-easing-emphasized);
+    animation: ripple-animation var(--_ripple-duration) var(--md-sys-motion-easing-emphasized);
+    animation-play-state: var(--md-sys-motion-continuous-play-state, running);
+    visibility: var(--md-sys-motion-ripple-visibility, visible);
     pointer-events: none;
     z-index: 0;
   }
@@ -178,7 +181,7 @@ export const m3RadioButtonStyles = css`
 
   @media (prefers-reduced-motion: reduce) {
     .ripple {
-      display: none;
+      visibility: hidden;
     }
   }
 

--- a/packages/m3-radio-button/src/m3-radio-button.styles.ts
+++ b/packages/m3-radio-button/src/m3-radio-button.styles.ts
@@ -70,8 +70,8 @@ export const m3RadioButtonStyles = css`
     border-radius: 50%;
     border: 2px solid var(--md-sys-color-on-surface, #1d1b20);
     background-color: transparent;
-    transition: border-color 0.2s cubic-bezier(0.2, 0, 0, 1),
-                background-color 0.2s cubic-bezier(0.2, 0, 0, 1);
+    transition: border-color var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-emphasized),
+                background-color var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-emphasized);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -113,7 +113,7 @@ export const m3RadioButtonStyles = css`
     border-radius: 50%;
     background-color: var(--md-sys-color-primary, #6750a4);
     opacity: 0;
-    transition: opacity 0.2s cubic-bezier(0.2, 0, 0, 1);
+    transition: opacity var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-emphasized);
     pointer-events: none;
   }
 
@@ -132,7 +132,7 @@ export const m3RadioButtonStyles = css`
     border-radius: 50%;
     background-color: var(--md-sys-color-primary, #6750a4);
     transform: scale(0);
-    transition: transform 0.2s cubic-bezier(0.2, 0, 0, 1);
+    transition: transform var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-emphasized);
   }
 
   .radio-outer[checked] .radio-inner {
@@ -157,7 +157,7 @@ export const m3RadioButtonStyles = css`
     background-color: var(--md-sys-color-primary, #6750a4);
     opacity: 0.3;
     transform: scale(0);
-    animation: ripple-animation 0.6s cubic-bezier(0.2, 0, 0, 1);
+    animation: ripple-animation var(--md-sys-motion-duration-long4) var(--md-sys-motion-easing-emphasized);
     pointer-events: none;
     z-index: 0;
   }
@@ -173,6 +173,12 @@ export const m3RadioButtonStyles = css`
     100% {
       transform: scale(1);
       opacity: 0;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .ripple {
+      display: none;
     }
   }
 

--- a/packages/m3-radio-button/src/m3-radio-button.ts
+++ b/packages/m3-radio-button/src/m3-radio-button.ts
@@ -1,6 +1,7 @@
 import { LitElement, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { m3RadioButtonStyles } from './m3-radio-button.styles.js';
+import { motionDuration } from './motion-duration.js';
 
 /**
  * Material Design 3 Radio Button Component
@@ -422,9 +423,13 @@ export class M3RadioButton extends LitElement {
 
   private _triggerRipple() {
     this._ripple = true;
-    setTimeout(() => {
-      this._ripple = false;
-    }, 600);
+    void this.updateComplete.then(() => {
+      const ripple = this.shadowRoot?.querySelector('.ripple');
+      const duration = ripple ? motionDuration(ripple, '--_ripple-duration') : 0;
+      setTimeout(() => {
+        this._ripple = false;
+      }, duration);
+    });
   }
 
   /**

--- a/packages/m3-radio-button/src/motion-duration.ts
+++ b/packages/m3-radio-button/src/motion-duration.ts
@@ -1,0 +1,13 @@
+/** Reads the computed CSS motion token so runtime cleanup follows consumer overrides. */
+export function motionDuration(element: Element, property: string): number {
+  if (typeof window === 'undefined' || window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    return 0;
+  }
+
+  const value = getComputedStyle(element).getPropertyValue(property).trim().split(',')[0] ?? '';
+  const match = /^(?<value>[0-9.]+)(?<unit>ms|s)$/.exec(value);
+  if (!match?.groups) return 0;
+
+  const amount = Number(match.groups.value);
+  return match.groups.unit === 's' ? amount * 1_000 : amount;
+}

--- a/packages/m3-search-bar/src/m3-search-bar.styles.ts
+++ b/packages/m3-search-bar/src/m3-search-bar.styles.ts
@@ -25,9 +25,9 @@ export const m3SearchBarStyles = css`
     align-items: center;
     padding: var(--_bar-padding-vertical) var(--_bar-padding-horizontal);
     gap: 12px;
-    transition: background-color 0.2s cubic-bezier(0.2, 0, 0, 1),
-                border-color 0.2s cubic-bezier(0.2, 0, 0, 1),
-                box-shadow 0.2s cubic-bezier(0.2, 0, 0, 1);
+    transition: background-color var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-emphasized),
+                border-color var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-emphasized),
+                box-shadow var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-emphasized);
     box-shadow: var(--md-sys-elevation-level1, 0 1px 2px rgba(0, 0, 0, 0.3), 0 1px 3px 1px rgba(0, 0, 0, 0.15));
   }
 
@@ -118,7 +118,7 @@ export const m3SearchBarStyles = css`
     border-radius: inherit;
     background-color: var(--md-sys-color-on-surface);
     opacity: 0;
-    transition: opacity 0.2s cubic-bezier(0.2, 0, 0, 1);
+    transition: opacity var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-emphasized);
     pointer-events: none;
   }
 
@@ -134,7 +134,7 @@ export const m3SearchBarStyles = css`
     border-radius: inherit;
     background-color: var(--md-sys-color-on-surface);
     opacity: 0;
-    transition: opacity 0.2s cubic-bezier(0.2, 0, 0, 1);
+    transition: opacity var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-emphasized);
     pointer-events: none;
   }
 

--- a/packages/m3-slider/src/m3-slider.styles.ts
+++ b/packages/m3-slider/src/m3-slider.styles.ts
@@ -73,7 +73,7 @@ export const m3SliderStyles = css`
     background-color: var(--md-sys-color-primary, #6750a4);
     opacity: 0;
     transform: translateX(-50%);
-    transition: opacity 0.2s;
+    transition: opacity var(--md-sys-motion-duration-short4);
     z-index: 1;
   }
 

--- a/packages/m3-snackbar/src/m3-snackbar.styles.ts
+++ b/packages/m3-snackbar/src/m3-snackbar.styles.ts
@@ -3,9 +3,9 @@ import { css } from 'lit';
 export const m3SnackbarStyles = css`
   :host {
     display: block;
-    --_animation-duration: 0.4s;
-    --_animation-easing: cubic-bezier(0.2, 0, 0, 1);
-    --_exit-easing: cubic-bezier(0.4, 0, 1, 1);
+    --_animation-duration: var(--md-sys-motion-duration-medium4);
+    --_animation-easing: var(--md-sys-motion-easing-emphasized-decelerate);
+    --_exit-easing: var(--md-sys-motion-easing-emphasized-accelerate);
   }
 
   .snackbar {

--- a/packages/m3-snackbar/src/m3-snackbar.test.ts
+++ b/packages/m3-snackbar/src/m3-snackbar.test.ts
@@ -64,6 +64,13 @@ describe('M3Snackbar', () => {
     }
   });
 
+  it('uses a consumer-overridden CSS duration for exit teardown', async () => {
+    const el = await fixture<M3Snackbar>(html`<m3-snackbar open duration="0" style="--_animation-duration: 1ms">Test</m3-snackbar>`);
+    el.dismiss();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(el.open).to.be.false;
+  });
+
   it('dispatches snackbar-action on action click', async () => {
     const el = await fixture<M3Snackbar>(html`
       <m3-snackbar open duration="0">

--- a/packages/m3-snackbar/src/m3-snackbar.test.ts
+++ b/packages/m3-snackbar/src/m3-snackbar.test.ts
@@ -44,6 +44,26 @@ describe('M3Snackbar', () => {
     expect(el.open).to.be.false;
   });
 
+  it('does not retain an exit delay when reduced motion is requested', async () => {
+    const originalMatchMedia = window.matchMedia;
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: () => ({ matches: true }),
+    });
+
+    try {
+      const el = await fixture<M3Snackbar>(html`<m3-snackbar open duration="0">Test</m3-snackbar>`);
+      el.dismiss();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(el.open).to.be.false;
+    } finally {
+      Object.defineProperty(window, 'matchMedia', {
+        configurable: true,
+        value: originalMatchMedia,
+      });
+    }
+  });
+
   it('dispatches snackbar-action on action click', async () => {
     const el = await fixture<M3Snackbar>(html`
       <m3-snackbar open duration="0">

--- a/packages/m3-snackbar/src/m3-snackbar.ts
+++ b/packages/m3-snackbar/src/m3-snackbar.ts
@@ -92,7 +92,7 @@ export class M3Snackbar extends LitElement {
     this._isLeaving = true;
     this.requestUpdate();
 
-    // Wait for exit animation then close
+    // Reduced-motion users keep the announcement but do not wait for movement.
     setTimeout(() => {
       this.open = false;
       this._isLeaving = false;
@@ -100,7 +100,11 @@ export class M3Snackbar extends LitElement {
         bubbles: true,
         composed: true
       }));
-    }, 350);
+    }, this._prefersReducedMotion() ? 0 : 400);
+  }
+
+  private _prefersReducedMotion() {
+    return typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
   }
 
   /**

--- a/packages/m3-snackbar/src/m3-snackbar.ts
+++ b/packages/m3-snackbar/src/m3-snackbar.ts
@@ -1,6 +1,7 @@
 import { LitElement, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { m3SnackbarStyles } from './m3-snackbar.styles.js';
+import { motionDuration } from './motion-duration.js';
 
 /**
  * Material Design 3 Snackbar Component
@@ -92,7 +93,10 @@ export class M3Snackbar extends LitElement {
     this._isLeaving = true;
     this.requestUpdate();
 
-    // Reduced-motion users keep the announcement but do not wait for movement.
+    const snackbar = this.shadowRoot?.querySelector('.snackbar');
+    // Read --_animation-duration after render so consumer CSS token overrides
+    // and the reduced-motion media query determine the teardown lifetime.
+    const exitDuration = snackbar ? motionDuration(snackbar, '--_animation-duration') : 0;
     setTimeout(() => {
       this.open = false;
       this._isLeaving = false;
@@ -100,11 +104,7 @@ export class M3Snackbar extends LitElement {
         bubbles: true,
         composed: true
       }));
-    }, this._prefersReducedMotion() ? 0 : 400);
-  }
-
-  private _prefersReducedMotion() {
-    return typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    }, exitDuration);
   }
 
   /**

--- a/packages/m3-snackbar/src/motion-duration.ts
+++ b/packages/m3-snackbar/src/motion-duration.ts
@@ -1,0 +1,17 @@
+/**
+ * Runtime cleanup reads the same computed custom property used by CSS. This
+ * keeps consumer token overrides and reduced-motion media rules in sync with
+ * JavaScript lifetimes instead of duplicating a millisecond constant.
+ */
+export function motionDuration(element: Element, property: string): number {
+  if (typeof window === 'undefined' || window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    return 0;
+  }
+
+  const value = getComputedStyle(element).getPropertyValue(property).trim().split(',')[0] ?? '';
+  const match = /^(?<value>[0-9.]+)(?<unit>ms|s)$/.exec(value);
+  if (!match?.groups) return 0;
+
+  const amount = Number(match.groups.value);
+  return match.groups.unit === 's' ? amount * 1_000 : amount;
+}

--- a/packages/m3-split-button/src/m3-split-button.styles.ts
+++ b/packages/m3-split-button/src/m3-split-button.styles.ts
@@ -27,7 +27,7 @@ export const m3SplitButtonStyles = css`
     font-weight: var(--md-sys-typescale-label-large-weight, 500);
     line-height: var(--md-sys-typescale-label-large-line-height, 20px);
     cursor: pointer;
-    transition: background-color 0.2s, box-shadow 0.2s;
+    transition: background-color var(--md-sys-motion-duration-short4), box-shadow var(--md-sys-motion-duration-short4);
     border-radius: var(--_shape-start);
   }
 
@@ -41,7 +41,7 @@ export const m3SplitButtonStyles = css`
     background-color: var(--_color-bg);
     color: var(--_color-text);
     cursor: pointer;
-    transition: background-color 0.2s, transform 0.2s, border-radius 0.2s;
+    transition: background-color var(--md-sys-motion-duration-short4), transform var(--md-sys-motion-duration-short4), border-radius var(--md-sys-motion-duration-short4);
     border-radius: var(--_shape-end);
   }
 

--- a/packages/m3-switch/src/m3-switch.styles.ts
+++ b/packages/m3-switch/src/m3-switch.styles.ts
@@ -48,8 +48,8 @@ export const m3SwitchStyles = css`
     border-radius: var(--_track-shape);
     background-color: var(--md-sys-color-on-surface, #1d1b20);
     opacity: 0.38;
-    transition: background-color 0.2s cubic-bezier(0.2, 0, 0, 1),
-                opacity 0.2s cubic-bezier(0.2, 0, 0, 1);
+    transition: background-color var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-emphasized),
+                opacity var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-emphasized);
     overflow: hidden;
   }
 
@@ -76,7 +76,7 @@ export const m3SwitchStyles = css`
     border-radius: inherit;
     background-color: var(--md-sys-color-on-surface, #1d1b20);
     opacity: 0;
-    transition: opacity 0.2s cubic-bezier(0.2, 0, 0, 1);
+    transition: opacity var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-emphasized);
     pointer-events: none;
   }
 
@@ -97,7 +97,7 @@ export const m3SwitchStyles = css`
     border-radius: inherit;
     background-color: var(--md-sys-color-on-surface, #1d1b20);
     opacity: 0;
-    transition: opacity 0.2s cubic-bezier(0.2, 0, 0, 1);
+    transition: opacity var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-emphasized);
     pointer-events: none;
   }
 
@@ -119,9 +119,9 @@ export const m3SwitchStyles = css`
     border-radius: var(--_thumb-shape);
     background-color: var(--md-sys-color-surface-container-highest, #e6e0e9);
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3), 0 1px 2px rgba(0, 0, 0, 0.2);
-    transition: transform 0.2s cubic-bezier(0.2, 0, 0, 1),
-                background-color 0.2s cubic-bezier(0.2, 0, 0, 1),
-                box-shadow 0.2s cubic-bezier(0.2, 0, 0, 1);
+    transition: transform var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-emphasized),
+                background-color var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-emphasized),
+                box-shadow var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-emphasized);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -158,8 +158,8 @@ export const m3SwitchStyles = css`
     color: var(--md-sys-color-primary, #6750a4);
     opacity: 0;
     transform: scale(0);
-    transition: opacity 0.2s cubic-bezier(0.2, 0, 0, 1),
-                transform 0.2s cubic-bezier(0.2, 0, 0, 1);
+    transition: opacity var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-emphasized),
+                transform var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-emphasized);
   }
 
   .thumb[checked] .checkmark {

--- a/packages/m3-tabs/src/m3-tabs.styles.ts
+++ b/packages/m3-tabs/src/m3-tabs.styles.ts
@@ -22,7 +22,7 @@ export const m3TabsStyles = css`
     height: 3px;
     background-color: var(--md-sys-color-primary, #6750a4);
     border-radius: 3px 3px 0 0;
-    transition: left 0.3s cubic-bezier(0.2, 0, 0, 1), width 0.3s cubic-bezier(0.2, 0, 0, 1);
+    transition: left var(--md-sys-motion-duration-medium2) var(--md-sys-motion-easing-emphasized), width var(--md-sys-motion-duration-medium2) var(--md-sys-motion-easing-emphasized);
     z-index: 1;
   }
 `;
@@ -52,7 +52,7 @@ export const m3TabStyles = css`
     line-height: 1.25rem;
     font-family: inherit;
     position: relative;
-    transition: color 0.2s;
+    transition: color var(--md-sys-motion-duration-short4);
     outline: none;
     overflow: hidden;
   }
@@ -75,7 +75,7 @@ export const m3TabStyles = css`
     inset: 0;
     background-color: currentColor;
     opacity: 0;
-    transition: opacity 0.2s;
+    transition: opacity var(--md-sys-motion-duration-short4);
     pointer-events: none;
     z-index: 1;
   }

--- a/packages/m3-text-field/src/m3-text-field.styles.ts
+++ b/packages/m3-text-field/src/m3-text-field.styles.ts
@@ -20,7 +20,7 @@ export const m3TextFieldStyles = css`
     align-items: center;
     background-color: var(--md-sys-color-surface-container-highest, #e6e0e9);
     border-radius: inherit;
-    transition: background-color 0.2s, box-shadow 0.2s;
+    transition: background-color var(--md-sys-motion-duration-short4), box-shadow var(--md-sys-motion-duration-short4);
     cursor: text;
     overflow: hidden;
   }
@@ -35,7 +35,7 @@ export const m3TextFieldStyles = css`
     inset: 0;
     background-color: var(--md-sys-color-on-surface, #1d1b20);
     opacity: var(--_state-layer-opacity);
-    transition: opacity 0.2s;
+    transition: opacity var(--md-sys-motion-duration-short4);
     pointer-events: none;
     z-index: 0;
   }
@@ -48,7 +48,7 @@ export const m3TextFieldStyles = css`
     right: 0;
     height: 1px;
     background-color: var(--md-sys-color-on-surface-variant, #49454f);
-    transition: height 0.2s, background-color 0.2s;
+    transition: height var(--md-sys-motion-duration-short4), background-color var(--md-sys-motion-duration-short4);
     z-index: 3;
   }
 
@@ -65,7 +65,7 @@ export const m3TextFieldStyles = css`
     transform: translateY(-50%);
     pointer-events: none;
     transform-origin: top left;
-    transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1), color 0.2s, top 0.2s;
+    transition: transform var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard), color var(--md-sys-motion-duration-short4), top var(--md-sys-motion-duration-short4);
     color: var(--md-sys-color-on-surface-variant, #49454f);
     font-size: 1rem;
     line-height: normal;
@@ -105,6 +105,7 @@ export const m3TextFieldStyles = css`
   .input:-webkit-autofill:focus {
     -webkit-box-shadow: 0 0 0px 1000px var(--md-sys-color-surface-container-highest, #e6e0e9) inset !important;
     -webkit-text-fill-color: var(--md-sys-color-on-surface, #1d1b20) !important;
+    /* Browser autofill paint workaround; it intentionally does not represent UI motion. */
     transition: background-color 5000s ease-in-out 0s;
   }
 

--- a/packages/m3-text-field/src/m3-text-field.styles.ts
+++ b/packages/m3-text-field/src/m3-text-field.styles.ts
@@ -105,7 +105,7 @@ export const m3TextFieldStyles = css`
   .input:-webkit-autofill:focus {
     -webkit-box-shadow: 0 0 0px 1000px var(--md-sys-color-surface-container-highest, #e6e0e9) inset !important;
     -webkit-text-fill-color: var(--md-sys-color-on-surface, #1d1b20) !important;
-    /* Browser autofill paint workaround; it intentionally does not represent UI motion. */
+    /* motion-literal-exempt: browser autofill paint workaround, not UI motion. */
     transition: background-color 5000s ease-in-out 0s;
   }
 

--- a/packages/m3-tooltip/src/m3-tooltip.styles.ts
+++ b/packages/m3-tooltip/src/m3-tooltip.styles.ts
@@ -17,7 +17,7 @@ export const m3TooltipStyles = css`
     pointer-events: none;
     opacity: 0;
     transform: scale(0.8);
-    transition: opacity 0.15s cubic-bezier(0, 0, 0, 1), transform 0.15s cubic-bezier(0, 0, 0, 1);
+    transition: opacity var(--md-sys-motion-duration-short3) var(--md-sys-motion-easing-emphasized-decelerate), transform var(--md-sys-motion-duration-short3) var(--md-sys-motion-easing-emphasized-decelerate);
   }
 
   /* Plain tooltip */

--- a/packages/m3-tooltip/src/m3-tooltip.styles.ts
+++ b/packages/m3-tooltip/src/m3-tooltip.styles.ts
@@ -4,6 +4,8 @@ export const m3TooltipStyles = css`
   :host {
     display: inline-block;
     position: relative;
+    --_show-delay: var(--md-sys-motion-duration-long2);
+    --_hide-delay: var(--md-sys-motion-duration-short2);
   }
 
   .tooltip-surface {

--- a/packages/m3-tooltip/src/m3-tooltip.ts
+++ b/packages/m3-tooltip/src/m3-tooltip.ts
@@ -1,6 +1,7 @@
 import { LitElement, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { m3TooltipStyles } from './m3-tooltip.styles.js';
+import { motionDuration } from './motion-duration.js';
 
 /**
  * Material Design 3 Tooltip Component
@@ -54,14 +55,14 @@ export class M3Tooltip extends LitElement {
     this._clearTimeouts();
     this._showTimeout = setTimeout(() => {
       this._visible = true;
-    }, 500);
+    }, motionDuration(this, '--_show-delay'));
   }
 
   private _handleMouseLeave() {
     this._clearTimeouts();
     this._hideTimeout = setTimeout(() => {
       this._visible = false;
-    }, 100);
+    }, motionDuration(this, '--_hide-delay'));
   }
 
   private _handleFocus() {

--- a/packages/m3-tooltip/src/motion-duration.ts
+++ b/packages/m3-tooltip/src/motion-duration.ts
@@ -1,0 +1,13 @@
+/** Reads the computed motion role so interaction delay honors consumer token overrides. */
+export function motionDuration(element: Element, property: string): number {
+  if (typeof window === 'undefined' || window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    return 0;
+  }
+
+  const value = getComputedStyle(element).getPropertyValue(property).trim().split(',')[0] ?? '';
+  const match = /^(?<value>[0-9.]+)(?<unit>ms|s)$/.exec(value);
+  if (!match?.groups) return 0;
+
+  const amount = Number(match.groups.value);
+  return match.groups.unit === 's' ? amount * 1_000 : amount;
+}

--- a/packages/m3-top-app-bar/src/m3-top-app-bar.styles.ts
+++ b/packages/m3-top-app-bar/src/m3-top-app-bar.styles.ts
@@ -6,8 +6,8 @@ export const m3TopAppBarStyles = css`
     width: 100%;
     --_height: 64px;
     --_container-shape: 0px;
-    --_animation-duration: 0.3s;
-    --_animation-easing: cubic-bezier(0.2, 0, 0, 1);
+    --_animation-duration: var(--md-sys-motion-duration-medium2);
+    --_animation-easing: var(--md-sys-motion-easing-emphasized);
   }
 
   .app-bar {

--- a/packages/svelte-components/README.md
+++ b/packages/svelte-components/README.md
@@ -64,6 +64,13 @@ A customizable button component built natively with Svelte.
 <SvelteButton label="Clicked {count} times" on:svelte-button-click={() => count++} />
 ```
 
+## Motion
+
+`SvelteButton` uses the canonical `--md-sys-motion-duration-short2` and
+`--md-sys-motion-duration-short4` roles. Import the generated token themes in
+the application stylesheet. When `prefers-reduced-motion: reduce` is active,
+the button resolves directly to its final hover/press state.
+
 ## Related Packages
 
 The monorepo also includes framework-agnostic Material Design 3 web components:

--- a/packages/svelte-components/src/SvelteButton.svelte
+++ b/packages/svelte-components/src/SvelteButton.svelte
@@ -27,7 +27,9 @@
     border: none;
     border-radius: 0.375rem;
     cursor: pointer;
-    transition: all 0.2s;
+    transition:
+      background-color var(--md-sys-motion-duration-short4),
+      transform var(--md-sys-motion-duration-short2);
     background-color: #8b5cf6;
     color: white;
   }
@@ -43,5 +45,12 @@
   .svelte-button:disabled {
     opacity: 0.5;
     cursor: not-allowed;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    /* motion-literal-exempt: static reduced-motion final state. */
+    .svelte-button {
+      transition-duration: 1ms;
+    }
   }
 </style>

--- a/scripts/generate-tokens.js
+++ b/scripts/generate-tokens.js
@@ -27,7 +27,15 @@ function renderTheme(themeName, theme) {
     .map(([name, value]) => `  ${name}: ${value};`)
     .join('\n');
 
-  return `/* This file is generated from tokens/tokens.json. Do not edit. */\n${theme.selector} {\n${declarations}\n}\n`;
+  const reducedMotionDeclarations = source.tokens
+    .filter((token) => token.category === 'motion' && token.name.includes('-duration-'))
+    .map((token) => `  ${token.name}: 1ms;`)
+    .join('\n');
+  const reducedMotion = reducedMotionDeclarations
+    ? `\n/* Motion is optional: state changes remain visible without movement. */\n@media (prefers-reduced-motion: reduce) {\n  ${theme.selector} {\n${reducedMotionDeclarations}\n  }\n}\n`
+    : '';
+
+  return `/* This file is generated from tokens/tokens.json. Do not edit. */\n${theme.selector} {\n${declarations}\n}\n${reducedMotion}`;
 }
 
 function writeOrCheck(file, content, failures) {

--- a/scripts/generate-tokens.js
+++ b/scripts/generate-tokens.js
@@ -28,11 +28,11 @@ function renderTheme(themeName, theme) {
     .join('\n');
 
   const reducedMotionDeclarations = source.tokens
-    .filter((token) => token.category === 'motion' && token.name.includes('-duration-'))
-    .map((token) => `  ${token.name}: 1ms;`)
+    .filter((token) => token.category === 'motion' && (token.name.includes('-duration-') || token.reducedValue !== undefined))
+    .map((token) => `  ${token.name}: ${token.reducedValue ?? '1ms'};`)
     .join('\n');
   const reducedMotion = reducedMotionDeclarations
-    ? `\n/* Motion is optional: state changes remain visible without movement. */\n@media (prefers-reduced-motion: reduce) {\n  ${theme.selector} {\n${reducedMotionDeclarations}\n  }\n}\n`
+    ? `\n/* Motion is optional: state changes remain visible without movement. */\n:root[data-motion="reduced"] {\n${reducedMotionDeclarations}\n}\n\n@media (prefers-reduced-motion: reduce) {\n  ${theme.selector} {\n${reducedMotionDeclarations}\n  }\n}\n`
     : '';
 
   return `/* This file is generated from tokens/tokens.json. Do not edit. */\n${theme.selector} {\n${declarations}\n}\n${reducedMotion}`;

--- a/scripts/validate-motion.js
+++ b/scripts/validate-motion.js
@@ -7,6 +7,9 @@ const requiredTokens = [
   ...['medium1', 'medium2', 'medium3', 'medium4'].map((name) => `--md-sys-motion-duration-${name}`),
   ...['long1', 'long2', 'long3', 'long4'].map((name) => `--md-sys-motion-duration-${name}`),
   ...['extra-long1', 'extra-long2', 'extra-long3', 'extra-long4'].map((name) => `--md-sys-motion-duration-${name}`),
+  '--md-sys-motion-continuous-play-state',
+  '--md-sys-motion-progress-start',
+  '--md-sys-motion-ripple-visibility',
   '--md-sys-motion-easing-standard',
   '--md-sys-motion-easing-standard-accelerate',
   '--md-sys-motion-easing-standard-decelerate',
@@ -18,31 +21,69 @@ const requiredTokens = [
   '--md-sys-motion-spring-bouncy',
 ];
 
-const continuousAlternatives = [
-  'packages/m3-button/src/m3-button.styles.ts',
-  'packages/m3-divider/src/m3-divider.styles.ts',
-  'packages/m3-list/src/m3-list.styles.ts',
-  'packages/m3-loading-indicator/src/m3-loading-indicator.styles.ts',
-  'packages/m3-progress/src/m3-progress.styles.ts',
-  'packages/m3-radio-button/src/m3-radio-button.styles.ts',
-];
-
 const source = readJson(tokenSourcePath);
 const tokenNames = new Set(source.tokens.map((token) => token.name));
 const failures = requiredTokens.filter((name) => !tokenNames.has(name)).map((name) => `Missing public motion token: ${name}`);
+const extensions = new Set(['.css', '.ts', '.js', '.svelte']);
 
-for (const relativeFile of continuousAlternatives) {
-  const content = fs.readFileSync(path.join(repositoryRoot, relativeFile), 'utf8');
-  if (!content.includes('prefers-reduced-motion: reduce')) {
-    failures.push(`${relativeFile}: continuous animation has no reduced-motion alternative`);
+function walk(entry, files = []) {
+  const stat = fs.statSync(entry);
+  if (stat.isFile()) {
+    if (extensions.has(path.extname(entry)) && !entry.endsWith('.test.ts')) files.push(entry);
+    return files;
+  }
+  for (const child of fs.readdirSync(entry, { withFileTypes: true })) {
+    if (['dist', 'node_modules', '.angular', '.turbo', '.svelte-kit'].includes(child.name)) continue;
+    walk(path.join(entry, child.name), files);
+  }
+  return files;
+}
+
+function hasRecentExemption(lines, index) {
+  return lines.slice(Math.max(0, index - 10), index + 1).some((line) => line.includes('motion-literal-exempt'));
+}
+
+const motionFiles = [
+  ...walk(path.join(repositoryRoot, 'packages')),
+  ...walk(path.join(repositoryRoot, 'apps')),
+];
+let checkedSources = 0;
+
+for (const file of motionFiles) {
+  const content = fs.readFileSync(file, 'utf8');
+  const relativeFile = path.relative(repositoryRoot, file);
+  const hasMotion = /\b(?:transition|animation)\s*:/.test(content);
+  const hasTimer = /\bsetTimeout\s*\(/.test(content);
+  if (!hasMotion && !hasTimer) continue;
+  checkedSources += 1;
+
+  const lines = content.split('\n');
+  for (const [index, line] of lines.entries()) {
+    const isComment = /^\s*(?:\/\/|\/\*|\*)/.test(line);
+    const literalTime = !isComment && /(?<![-\w])(?:\d+(?:\.\d+)?|\.\d+)(?:ms|s)\b/.test(line);
+    if (literalTime && !hasRecentExemption(lines, index)) {
+      failures.push(`${relativeFile}:${index + 1}: literal timing must use a motion token or carry a motion-literal-exempt explanation`);
+    }
+    if (/\bsetTimeout\s*\([^,]+,\s*\d/.test(line) && !hasRecentExemption(lines, index)) {
+      failures.push(`${relativeFile}:${index + 1}: runtime timeout must derive from a computed motion token or be documented as non-motion`);
+    }
+  }
+
+  if (hasMotion && !content.includes('--md-sys-motion-')) {
+    failures.push(`${relativeFile}: motion declaration does not consume the canonical motion vocabulary`);
+  }
+  if (/animation:[^;]*\binfinite\b/.test(content)) {
+    if (!content.includes('prefers-reduced-motion: reduce') || !content.includes('--md-sys-motion-continuous-play-state')) {
+      failures.push(`${relativeFile}: continuous animation requires static reduced-motion behavior and a verification-mode play state`);
+    }
   }
 }
 
 for (const theme of Object.keys(source.themes)) {
   const file = path.join(repositoryRoot, 'tokens', 'generated', `${theme}.css`);
   const content = fs.readFileSync(file, 'utf8');
-  if (!content.includes('@media (prefers-reduced-motion: reduce)') || !content.includes('--md-sys-motion-duration-short4: 1ms;')) {
-    failures.push(`${path.relative(repositoryRoot, file)}: missing generated reduced-motion duration contract`);
+  if (!content.includes(':root[data-motion="reduced"]') || !content.includes('@media (prefers-reduced-motion: reduce)') || !content.includes('--md-sys-motion-duration-short4: 1ms;') || !content.includes('--md-sys-motion-continuous-play-state: paused;')) {
+    failures.push(`${path.relative(repositoryRoot, file)}: missing media-query or demo verification-mode reduced-motion contract`);
   }
 }
 
@@ -51,4 +92,4 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log(`Validated ${requiredTokens.length} public motion tokens and ${continuousAlternatives.length} static reduced-motion alternatives.`);
+console.log(`Validated ${requiredTokens.length} public motion tokens and ${checkedSources} package/demo motion sources.`);

--- a/scripts/validate-motion.js
+++ b/scripts/validate-motion.js
@@ -1,0 +1,54 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const { readJson, repositoryRoot, tokenSourcePath } = require('./token-utils.js');
+
+const requiredTokens = [
+  ...['short1', 'short2', 'short3', 'short4'].map((name) => `--md-sys-motion-duration-${name}`),
+  ...['medium1', 'medium2', 'medium3', 'medium4'].map((name) => `--md-sys-motion-duration-${name}`),
+  ...['long1', 'long2', 'long3', 'long4'].map((name) => `--md-sys-motion-duration-${name}`),
+  ...['extra-long1', 'extra-long2', 'extra-long3', 'extra-long4'].map((name) => `--md-sys-motion-duration-${name}`),
+  '--md-sys-motion-easing-standard',
+  '--md-sys-motion-easing-standard-accelerate',
+  '--md-sys-motion-easing-standard-decelerate',
+  '--md-sys-motion-easing-emphasized',
+  '--md-sys-motion-easing-emphasized-accelerate',
+  '--md-sys-motion-easing-emphasized-decelerate',
+  '--md-sys-motion-easing-linear',
+  '--md-sys-motion-spring-fast',
+  '--md-sys-motion-spring-bouncy',
+];
+
+const continuousAlternatives = [
+  'packages/m3-button/src/m3-button.styles.ts',
+  'packages/m3-divider/src/m3-divider.styles.ts',
+  'packages/m3-list/src/m3-list.styles.ts',
+  'packages/m3-loading-indicator/src/m3-loading-indicator.styles.ts',
+  'packages/m3-progress/src/m3-progress.styles.ts',
+  'packages/m3-radio-button/src/m3-radio-button.styles.ts',
+];
+
+const source = readJson(tokenSourcePath);
+const tokenNames = new Set(source.tokens.map((token) => token.name));
+const failures = requiredTokens.filter((name) => !tokenNames.has(name)).map((name) => `Missing public motion token: ${name}`);
+
+for (const relativeFile of continuousAlternatives) {
+  const content = fs.readFileSync(path.join(repositoryRoot, relativeFile), 'utf8');
+  if (!content.includes('prefers-reduced-motion: reduce')) {
+    failures.push(`${relativeFile}: continuous animation has no reduced-motion alternative`);
+  }
+}
+
+for (const theme of Object.keys(source.themes)) {
+  const file = path.join(repositoryRoot, 'tokens', 'generated', `${theme}.css`);
+  const content = fs.readFileSync(file, 'utf8');
+  if (!content.includes('@media (prefers-reduced-motion: reduce)') || !content.includes('--md-sys-motion-duration-short4: 1ms;')) {
+    failures.push(`${path.relative(repositoryRoot, file)}: missing generated reduced-motion duration contract`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error(failures.map((failure) => `- ${failure}`).join('\n'));
+  process.exit(1);
+}
+
+console.log(`Validated ${requiredTokens.length} public motion tokens and ${continuousAlternatives.length} static reduced-motion alternatives.`);

--- a/tokens/README.md
+++ b/tokens/README.md
@@ -63,6 +63,32 @@ new public component decision as `--md-comp-<component>-<role>`, declare it in
 `tokens.json`, consume it in the owning stylesheet, and add computed-style or
 screenshot evidence before changing a default.
 
+## Motion contract
+
+Motion is a system role, not a component-local magic number. The public API
+includes the Material duration scale (`short1` through `short4`, `medium1`
+through `medium4`, `long1` through `long4`, and `extra-long1` through
+`extra-long4`), standard/emphasized entry and exit curves, and two CSS
+spring-emulation curves. Components use `--md-sys-motion-*` directly; they do
+not create component aliases for generic interaction timing.
+
+Use motion only to clarify a state change, hierarchy, or spatial relationship:
+
+- short durations for press, selection, and state-layer feedback;
+- medium durations for dialog, menu, tooltip, and snackbar visibility;
+- long durations for staged entrances or intentional container transforms;
+- linear timing only for continuous progress; and
+- `spring-fast` only on composited transforms where a compact spatial cue is
+  helpful. `spring-bouncy` is opt-in and must not be used for essential state.
+
+Every generated theme contains a `prefers-reduced-motion: reduce` override
+that collapses duration roles to `1ms`. The final state remains visible rather
+than being hidden or delayed. Continuous indicators have component-specific
+alternatives: loading rings freeze, indeterminate progress shows a centred
+partial bar, pulses stop at full opacity, and interaction ripples are omitted.
+Consumers should continue to announce progress/status with semantic text or
+ARIA live regions; motion never carries essential information by itself.
+
 ## Validation workflow
 
 ```bash

--- a/tokens/README.md
+++ b/tokens/README.md
@@ -89,6 +89,18 @@ partial bar, pulses stop at full opacity, and interaction ripples are omitted.
 Consumers should continue to announce progress/status with semantic text or
 ARIA live regions; motion never carries essential information by itself.
 
+### CSS and JavaScript synchronization
+
+JavaScript must not duplicate a timeout for a CSS transition or animation.
+Components that remove temporary DOM state (snackbar exit and radio ripple)
+read their rendered `--_*-duration` custom property with `getComputedStyle()`;
+that property resolves from the public motion token. The Angular dialog service
+uses the same pattern. A consumer override, generated reduced-motion rule, or
+demo verification mode therefore changes both the CSS duration and JavaScript
+lifetime together. For non-motion interaction thresholds (for example, a
+long-press gesture), document the intentional literal with
+`motion-literal-exempt` so validation does not mistake it for animation time.
+
 ## Validation workflow
 
 ```bash

--- a/tokens/generated/dark.css
+++ b/tokens/generated/dark.css
@@ -43,6 +43,7 @@
   --md-sys-color-tertiary-container: #1f2937;
   --md-sys-elevation-level1: 0 1px 2px rgba(0, 0, 0, 0.6), 0 1px 3px 1px rgba(0, 0, 0, 0.45);
   --md-sys-elevation-level2: 0 1px 3px rgba(0, 0, 0, 0.4), 0 1px 2px rgba(0, 0, 0, 0.3);
+  --md-sys-motion-continuous-play-state: running;
   --md-sys-motion-duration-extra-long1: 700ms;
   --md-sys-motion-duration-extra-long2: 800ms;
   --md-sys-motion-duration-extra-long3: 900ms;
@@ -66,6 +67,8 @@
   --md-sys-motion-easing-standard: cubic-bezier(0.4, 0, 0.2, 1);
   --md-sys-motion-easing-standard-accelerate: cubic-bezier(0.3, 0, 1, 1);
   --md-sys-motion-easing-standard-decelerate: cubic-bezier(0, 0, 0, 1);
+  --md-sys-motion-progress-start: -50%;
+  --md-sys-motion-ripple-visibility: visible;
   --md-sys-motion-spring-bouncy: cubic-bezier(0.34, 1.56, 0.64, 1);
   --md-sys-motion-spring-fast: cubic-bezier(0.33, 1, 0.68, 1);
   --md-sys-shape-corner-extra-large: 28px;
@@ -86,8 +89,33 @@
 }
 
 /* Motion is optional: state changes remain visible without movement. */
+:root[data-motion="reduced"] {
+  --md-sys-motion-continuous-play-state: paused;
+  --md-sys-motion-progress-start: 25%;
+  --md-sys-motion-ripple-visibility: hidden;
+  --md-sys-motion-duration-short1: 1ms;
+  --md-sys-motion-duration-short2: 1ms;
+  --md-sys-motion-duration-short3: 1ms;
+  --md-sys-motion-duration-short4: 1ms;
+  --md-sys-motion-duration-medium1: 1ms;
+  --md-sys-motion-duration-medium2: 1ms;
+  --md-sys-motion-duration-medium3: 1ms;
+  --md-sys-motion-duration-medium4: 1ms;
+  --md-sys-motion-duration-long1: 1ms;
+  --md-sys-motion-duration-long2: 1ms;
+  --md-sys-motion-duration-long3: 1ms;
+  --md-sys-motion-duration-long4: 1ms;
+  --md-sys-motion-duration-extra-long1: 1ms;
+  --md-sys-motion-duration-extra-long2: 1ms;
+  --md-sys-motion-duration-extra-long3: 1ms;
+  --md-sys-motion-duration-extra-long4: 1ms;
+}
+
 @media (prefers-reduced-motion: reduce) {
   :root[theme="dark"] {
+  --md-sys-motion-continuous-play-state: paused;
+  --md-sys-motion-progress-start: 25%;
+  --md-sys-motion-ripple-visibility: hidden;
   --md-sys-motion-duration-short1: 1ms;
   --md-sys-motion-duration-short2: 1ms;
   --md-sys-motion-duration-short3: 1ms;

--- a/tokens/generated/dark.css
+++ b/tokens/generated/dark.css
@@ -1,7 +1,7 @@
 /* This file is generated from tokens/tokens.json. Do not edit. */
 :root[theme="dark"] {
   --md-comp-divider-color: var(--md-sys-color-outline-variant);
-  --md-comp-divider-motion-duration: var(--md-sys-motion-duration-medium4);
+  --md-comp-divider-motion-duration: var(--md-sys-motion-duration-long4);
   --md-comp-divider-motion-easing: var(--md-sys-motion-easing-emphasized-decelerate);
   --md-ref-palette-error-40: #b3261e;
   --md-ref-palette-error-80: #ffb4ab;
@@ -43,12 +43,31 @@
   --md-sys-color-tertiary-container: #1f2937;
   --md-sys-elevation-level1: 0 1px 2px rgba(0, 0, 0, 0.6), 0 1px 3px 1px rgba(0, 0, 0, 0.45);
   --md-sys-elevation-level2: 0 1px 3px rgba(0, 0, 0, 0.4), 0 1px 2px rgba(0, 0, 0, 0.3);
+  --md-sys-motion-duration-extra-long1: 700ms;
+  --md-sys-motion-duration-extra-long2: 800ms;
+  --md-sys-motion-duration-extra-long3: 900ms;
+  --md-sys-motion-duration-extra-long4: 1000ms;
+  --md-sys-motion-duration-long1: 450ms;
+  --md-sys-motion-duration-long2: 500ms;
+  --md-sys-motion-duration-long3: 550ms;
+  --md-sys-motion-duration-long4: 600ms;
+  --md-sys-motion-duration-medium1: 250ms;
   --md-sys-motion-duration-medium2: 300ms;
-  --md-sys-motion-duration-medium4: 600ms;
+  --md-sys-motion-duration-medium3: 350ms;
+  --md-sys-motion-duration-medium4: 400ms;
+  --md-sys-motion-duration-short1: 50ms;
   --md-sys-motion-duration-short2: 100ms;
+  --md-sys-motion-duration-short3: 150ms;
   --md-sys-motion-duration-short4: 200ms;
+  --md-sys-motion-easing-emphasized: cubic-bezier(0.2, 0, 0, 1);
+  --md-sys-motion-easing-emphasized-accelerate: cubic-bezier(0.3, 0, 0.8, 0.15);
   --md-sys-motion-easing-emphasized-decelerate: cubic-bezier(0.2, 0, 0, 1);
+  --md-sys-motion-easing-linear: linear;
   --md-sys-motion-easing-standard: cubic-bezier(0.4, 0, 0.2, 1);
+  --md-sys-motion-easing-standard-accelerate: cubic-bezier(0.3, 0, 1, 1);
+  --md-sys-motion-easing-standard-decelerate: cubic-bezier(0, 0, 0, 1);
+  --md-sys-motion-spring-bouncy: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --md-sys-motion-spring-fast: cubic-bezier(0.33, 1, 0.68, 1);
   --md-sys-shape-corner-extra-large: 28px;
   --md-sys-shape-corner-full: 9999px;
   --md-sys-shape-corner-large: 16px;
@@ -64,4 +83,26 @@
   --md-sys-typescale-label-large-line-height: 20px;
   --md-sys-typescale-label-large-size: 14px;
   --md-sys-typescale-label-large-weight: 500;
+}
+
+/* Motion is optional: state changes remain visible without movement. */
+@media (prefers-reduced-motion: reduce) {
+  :root[theme="dark"] {
+  --md-sys-motion-duration-short1: 1ms;
+  --md-sys-motion-duration-short2: 1ms;
+  --md-sys-motion-duration-short3: 1ms;
+  --md-sys-motion-duration-short4: 1ms;
+  --md-sys-motion-duration-medium1: 1ms;
+  --md-sys-motion-duration-medium2: 1ms;
+  --md-sys-motion-duration-medium3: 1ms;
+  --md-sys-motion-duration-medium4: 1ms;
+  --md-sys-motion-duration-long1: 1ms;
+  --md-sys-motion-duration-long2: 1ms;
+  --md-sys-motion-duration-long3: 1ms;
+  --md-sys-motion-duration-long4: 1ms;
+  --md-sys-motion-duration-extra-long1: 1ms;
+  --md-sys-motion-duration-extra-long2: 1ms;
+  --md-sys-motion-duration-extra-long3: 1ms;
+  --md-sys-motion-duration-extra-long4: 1ms;
+  }
 }

--- a/tokens/generated/high-contrast.css
+++ b/tokens/generated/high-contrast.css
@@ -43,6 +43,7 @@
   --md-sys-color-tertiary-container: #005a00;
   --md-sys-elevation-level1: 0 0 0 1px #000000;
   --md-sys-elevation-level2: 0 0 0 2px #000000;
+  --md-sys-motion-continuous-play-state: running;
   --md-sys-motion-duration-extra-long1: 700ms;
   --md-sys-motion-duration-extra-long2: 800ms;
   --md-sys-motion-duration-extra-long3: 900ms;
@@ -66,6 +67,8 @@
   --md-sys-motion-easing-standard: cubic-bezier(0.4, 0, 0.2, 1);
   --md-sys-motion-easing-standard-accelerate: cubic-bezier(0.3, 0, 1, 1);
   --md-sys-motion-easing-standard-decelerate: cubic-bezier(0, 0, 0, 1);
+  --md-sys-motion-progress-start: -50%;
+  --md-sys-motion-ripple-visibility: visible;
   --md-sys-motion-spring-bouncy: cubic-bezier(0.34, 1.56, 0.64, 1);
   --md-sys-motion-spring-fast: cubic-bezier(0.33, 1, 0.68, 1);
   --md-sys-shape-corner-extra-large: 28px;
@@ -86,8 +89,33 @@
 }
 
 /* Motion is optional: state changes remain visible without movement. */
+:root[data-motion="reduced"] {
+  --md-sys-motion-continuous-play-state: paused;
+  --md-sys-motion-progress-start: 25%;
+  --md-sys-motion-ripple-visibility: hidden;
+  --md-sys-motion-duration-short1: 1ms;
+  --md-sys-motion-duration-short2: 1ms;
+  --md-sys-motion-duration-short3: 1ms;
+  --md-sys-motion-duration-short4: 1ms;
+  --md-sys-motion-duration-medium1: 1ms;
+  --md-sys-motion-duration-medium2: 1ms;
+  --md-sys-motion-duration-medium3: 1ms;
+  --md-sys-motion-duration-medium4: 1ms;
+  --md-sys-motion-duration-long1: 1ms;
+  --md-sys-motion-duration-long2: 1ms;
+  --md-sys-motion-duration-long3: 1ms;
+  --md-sys-motion-duration-long4: 1ms;
+  --md-sys-motion-duration-extra-long1: 1ms;
+  --md-sys-motion-duration-extra-long2: 1ms;
+  --md-sys-motion-duration-extra-long3: 1ms;
+  --md-sys-motion-duration-extra-long4: 1ms;
+}
+
 @media (prefers-reduced-motion: reduce) {
   :root[theme="high-contrast"] {
+  --md-sys-motion-continuous-play-state: paused;
+  --md-sys-motion-progress-start: 25%;
+  --md-sys-motion-ripple-visibility: hidden;
   --md-sys-motion-duration-short1: 1ms;
   --md-sys-motion-duration-short2: 1ms;
   --md-sys-motion-duration-short3: 1ms;

--- a/tokens/generated/high-contrast.css
+++ b/tokens/generated/high-contrast.css
@@ -1,7 +1,7 @@
 /* This file is generated from tokens/tokens.json. Do not edit. */
 :root[theme="high-contrast"] {
   --md-comp-divider-color: var(--md-sys-color-outline-variant);
-  --md-comp-divider-motion-duration: var(--md-sys-motion-duration-medium4);
+  --md-comp-divider-motion-duration: var(--md-sys-motion-duration-long4);
   --md-comp-divider-motion-easing: var(--md-sys-motion-easing-emphasized-decelerate);
   --md-ref-palette-error-40: #b3261e;
   --md-ref-palette-error-80: #ffb4ab;
@@ -43,12 +43,31 @@
   --md-sys-color-tertiary-container: #005a00;
   --md-sys-elevation-level1: 0 0 0 1px #000000;
   --md-sys-elevation-level2: 0 0 0 2px #000000;
+  --md-sys-motion-duration-extra-long1: 700ms;
+  --md-sys-motion-duration-extra-long2: 800ms;
+  --md-sys-motion-duration-extra-long3: 900ms;
+  --md-sys-motion-duration-extra-long4: 1000ms;
+  --md-sys-motion-duration-long1: 450ms;
+  --md-sys-motion-duration-long2: 500ms;
+  --md-sys-motion-duration-long3: 550ms;
+  --md-sys-motion-duration-long4: 600ms;
+  --md-sys-motion-duration-medium1: 250ms;
   --md-sys-motion-duration-medium2: 300ms;
-  --md-sys-motion-duration-medium4: 600ms;
+  --md-sys-motion-duration-medium3: 350ms;
+  --md-sys-motion-duration-medium4: 400ms;
+  --md-sys-motion-duration-short1: 50ms;
   --md-sys-motion-duration-short2: 100ms;
+  --md-sys-motion-duration-short3: 150ms;
   --md-sys-motion-duration-short4: 200ms;
+  --md-sys-motion-easing-emphasized: cubic-bezier(0.2, 0, 0, 1);
+  --md-sys-motion-easing-emphasized-accelerate: cubic-bezier(0.3, 0, 0.8, 0.15);
   --md-sys-motion-easing-emphasized-decelerate: cubic-bezier(0.2, 0, 0, 1);
+  --md-sys-motion-easing-linear: linear;
   --md-sys-motion-easing-standard: cubic-bezier(0.4, 0, 0.2, 1);
+  --md-sys-motion-easing-standard-accelerate: cubic-bezier(0.3, 0, 1, 1);
+  --md-sys-motion-easing-standard-decelerate: cubic-bezier(0, 0, 0, 1);
+  --md-sys-motion-spring-bouncy: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --md-sys-motion-spring-fast: cubic-bezier(0.33, 1, 0.68, 1);
   --md-sys-shape-corner-extra-large: 28px;
   --md-sys-shape-corner-full: 9999px;
   --md-sys-shape-corner-large: 16px;
@@ -64,4 +83,26 @@
   --md-sys-typescale-label-large-line-height: 20px;
   --md-sys-typescale-label-large-size: 14px;
   --md-sys-typescale-label-large-weight: 500;
+}
+
+/* Motion is optional: state changes remain visible without movement. */
+@media (prefers-reduced-motion: reduce) {
+  :root[theme="high-contrast"] {
+  --md-sys-motion-duration-short1: 1ms;
+  --md-sys-motion-duration-short2: 1ms;
+  --md-sys-motion-duration-short3: 1ms;
+  --md-sys-motion-duration-short4: 1ms;
+  --md-sys-motion-duration-medium1: 1ms;
+  --md-sys-motion-duration-medium2: 1ms;
+  --md-sys-motion-duration-medium3: 1ms;
+  --md-sys-motion-duration-medium4: 1ms;
+  --md-sys-motion-duration-long1: 1ms;
+  --md-sys-motion-duration-long2: 1ms;
+  --md-sys-motion-duration-long3: 1ms;
+  --md-sys-motion-duration-long4: 1ms;
+  --md-sys-motion-duration-extra-long1: 1ms;
+  --md-sys-motion-duration-extra-long2: 1ms;
+  --md-sys-motion-duration-extra-long3: 1ms;
+  --md-sys-motion-duration-extra-long4: 1ms;
+  }
 }

--- a/tokens/generated/light.css
+++ b/tokens/generated/light.css
@@ -43,6 +43,7 @@
   --md-sys-color-tertiary-container: #f3f4f6;
   --md-sys-elevation-level1: 0 1px 2px rgba(0, 0, 0, 0.3), 0 1px 3px 1px rgba(0, 0, 0, 0.15);
   --md-sys-elevation-level2: 0 1px 3px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.06);
+  --md-sys-motion-continuous-play-state: running;
   --md-sys-motion-duration-extra-long1: 700ms;
   --md-sys-motion-duration-extra-long2: 800ms;
   --md-sys-motion-duration-extra-long3: 900ms;
@@ -66,6 +67,8 @@
   --md-sys-motion-easing-standard: cubic-bezier(0.4, 0, 0.2, 1);
   --md-sys-motion-easing-standard-accelerate: cubic-bezier(0.3, 0, 1, 1);
   --md-sys-motion-easing-standard-decelerate: cubic-bezier(0, 0, 0, 1);
+  --md-sys-motion-progress-start: -50%;
+  --md-sys-motion-ripple-visibility: visible;
   --md-sys-motion-spring-bouncy: cubic-bezier(0.34, 1.56, 0.64, 1);
   --md-sys-motion-spring-fast: cubic-bezier(0.33, 1, 0.68, 1);
   --md-sys-shape-corner-extra-large: 28px;
@@ -86,8 +89,33 @@
 }
 
 /* Motion is optional: state changes remain visible without movement. */
+:root[data-motion="reduced"] {
+  --md-sys-motion-continuous-play-state: paused;
+  --md-sys-motion-progress-start: 25%;
+  --md-sys-motion-ripple-visibility: hidden;
+  --md-sys-motion-duration-short1: 1ms;
+  --md-sys-motion-duration-short2: 1ms;
+  --md-sys-motion-duration-short3: 1ms;
+  --md-sys-motion-duration-short4: 1ms;
+  --md-sys-motion-duration-medium1: 1ms;
+  --md-sys-motion-duration-medium2: 1ms;
+  --md-sys-motion-duration-medium3: 1ms;
+  --md-sys-motion-duration-medium4: 1ms;
+  --md-sys-motion-duration-long1: 1ms;
+  --md-sys-motion-duration-long2: 1ms;
+  --md-sys-motion-duration-long3: 1ms;
+  --md-sys-motion-duration-long4: 1ms;
+  --md-sys-motion-duration-extra-long1: 1ms;
+  --md-sys-motion-duration-extra-long2: 1ms;
+  --md-sys-motion-duration-extra-long3: 1ms;
+  --md-sys-motion-duration-extra-long4: 1ms;
+}
+
 @media (prefers-reduced-motion: reduce) {
   :root, :root[theme="light"] {
+  --md-sys-motion-continuous-play-state: paused;
+  --md-sys-motion-progress-start: 25%;
+  --md-sys-motion-ripple-visibility: hidden;
   --md-sys-motion-duration-short1: 1ms;
   --md-sys-motion-duration-short2: 1ms;
   --md-sys-motion-duration-short3: 1ms;

--- a/tokens/generated/light.css
+++ b/tokens/generated/light.css
@@ -1,7 +1,7 @@
 /* This file is generated from tokens/tokens.json. Do not edit. */
 :root, :root[theme="light"] {
   --md-comp-divider-color: var(--md-sys-color-outline-variant);
-  --md-comp-divider-motion-duration: var(--md-sys-motion-duration-medium4);
+  --md-comp-divider-motion-duration: var(--md-sys-motion-duration-long4);
   --md-comp-divider-motion-easing: var(--md-sys-motion-easing-emphasized-decelerate);
   --md-ref-palette-error-40: #b3261e;
   --md-ref-palette-error-80: #ffb4ab;
@@ -43,12 +43,31 @@
   --md-sys-color-tertiary-container: #f3f4f6;
   --md-sys-elevation-level1: 0 1px 2px rgba(0, 0, 0, 0.3), 0 1px 3px 1px rgba(0, 0, 0, 0.15);
   --md-sys-elevation-level2: 0 1px 3px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.06);
+  --md-sys-motion-duration-extra-long1: 700ms;
+  --md-sys-motion-duration-extra-long2: 800ms;
+  --md-sys-motion-duration-extra-long3: 900ms;
+  --md-sys-motion-duration-extra-long4: 1000ms;
+  --md-sys-motion-duration-long1: 450ms;
+  --md-sys-motion-duration-long2: 500ms;
+  --md-sys-motion-duration-long3: 550ms;
+  --md-sys-motion-duration-long4: 600ms;
+  --md-sys-motion-duration-medium1: 250ms;
   --md-sys-motion-duration-medium2: 300ms;
-  --md-sys-motion-duration-medium4: 600ms;
+  --md-sys-motion-duration-medium3: 350ms;
+  --md-sys-motion-duration-medium4: 400ms;
+  --md-sys-motion-duration-short1: 50ms;
   --md-sys-motion-duration-short2: 100ms;
+  --md-sys-motion-duration-short3: 150ms;
   --md-sys-motion-duration-short4: 200ms;
+  --md-sys-motion-easing-emphasized: cubic-bezier(0.2, 0, 0, 1);
+  --md-sys-motion-easing-emphasized-accelerate: cubic-bezier(0.3, 0, 0.8, 0.15);
   --md-sys-motion-easing-emphasized-decelerate: cubic-bezier(0.2, 0, 0, 1);
+  --md-sys-motion-easing-linear: linear;
   --md-sys-motion-easing-standard: cubic-bezier(0.4, 0, 0.2, 1);
+  --md-sys-motion-easing-standard-accelerate: cubic-bezier(0.3, 0, 1, 1);
+  --md-sys-motion-easing-standard-decelerate: cubic-bezier(0, 0, 0, 1);
+  --md-sys-motion-spring-bouncy: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --md-sys-motion-spring-fast: cubic-bezier(0.33, 1, 0.68, 1);
   --md-sys-shape-corner-extra-large: 28px;
   --md-sys-shape-corner-full: 9999px;
   --md-sys-shape-corner-large: 16px;
@@ -64,4 +83,26 @@
   --md-sys-typescale-label-large-line-height: 20px;
   --md-sys-typescale-label-large-size: 14px;
   --md-sys-typescale-label-large-weight: 500;
+}
+
+/* Motion is optional: state changes remain visible without movement. */
+@media (prefers-reduced-motion: reduce) {
+  :root, :root[theme="light"] {
+  --md-sys-motion-duration-short1: 1ms;
+  --md-sys-motion-duration-short2: 1ms;
+  --md-sys-motion-duration-short3: 1ms;
+  --md-sys-motion-duration-short4: 1ms;
+  --md-sys-motion-duration-medium1: 1ms;
+  --md-sys-motion-duration-medium2: 1ms;
+  --md-sys-motion-duration-medium3: 1ms;
+  --md-sys-motion-duration-medium4: 1ms;
+  --md-sys-motion-duration-long1: 1ms;
+  --md-sys-motion-duration-long2: 1ms;
+  --md-sys-motion-duration-long3: 1ms;
+  --md-sys-motion-duration-long4: 1ms;
+  --md-sys-motion-duration-extra-long1: 1ms;
+  --md-sys-motion-duration-extra-long2: 1ms;
+  --md-sys-motion-duration-extra-long3: 1ms;
+  --md-sys-motion-duration-extra-long4: 1ms;
+  }
 }

--- a/tokens/tokens.json
+++ b/tokens/tokens.json
@@ -527,6 +527,30 @@
       "value": "0.38"
     },
     {
+      "name": "--md-sys-motion-continuous-play-state",
+      "tier": "system",
+      "category": "motion",
+      "description": "Playback state for nonessential continuous indicators.",
+      "value": "running",
+      "reducedValue": "paused"
+    },
+    {
+      "name": "--md-sys-motion-progress-start",
+      "tier": "system",
+      "category": "motion",
+      "description": "Initial offset for an indeterminate progress indicator.",
+      "value": "-50%",
+      "reducedValue": "25%"
+    },
+    {
+      "name": "--md-sys-motion-ripple-visibility",
+      "tier": "system",
+      "category": "motion",
+      "description": "Visibility of nonessential interaction ripple feedback.",
+      "value": "visible",
+      "reducedValue": "hidden"
+    },
+    {
       "name": "--md-sys-motion-duration-short1",
       "tier": "system",
       "category": "motion",

--- a/tokens/tokens.json
+++ b/tokens/tokens.json
@@ -527,11 +527,25 @@
       "value": "0.38"
     },
     {
+      "name": "--md-sys-motion-duration-short1",
+      "tier": "system",
+      "category": "motion",
+      "description": "Brief feedback duration for press and focus state layers.",
+      "value": "50ms"
+    },
+    {
       "name": "--md-sys-motion-duration-short2",
       "tier": "system",
       "category": "motion",
       "description": "Short interaction duration.",
       "value": "100ms"
+    },
+    {
+      "name": "--md-sys-motion-duration-short3",
+      "tier": "system",
+      "category": "motion",
+      "description": "Short visibility-change duration for small state changes.",
+      "value": "150ms"
     },
     {
       "name": "--md-sys-motion-duration-short4",
@@ -541,6 +555,13 @@
       "value": "200ms"
     },
     {
+      "name": "--md-sys-motion-duration-medium1",
+      "tier": "system",
+      "category": "motion",
+      "description": "Medium duration for compact component state changes.",
+      "value": "250ms"
+    },
+    {
       "name": "--md-sys-motion-duration-medium2",
       "tier": "system",
       "category": "motion",
@@ -548,11 +569,88 @@
       "value": "300ms"
     },
     {
+      "name": "--md-sys-motion-duration-medium3",
+      "tier": "system",
+      "category": "motion",
+      "description": "Medium duration for spatial component changes.",
+      "value": "350ms"
+    },
+    {
       "name": "--md-sys-motion-duration-medium4",
       "tier": "system",
       "category": "motion",
-      "description": "Expressive entrance duration.",
+      "description": "Medium duration for emphasized component entrances.",
+      "value": "400ms"
+    },
+    {
+      "name": "--md-sys-motion-duration-long1",
+      "tier": "system",
+      "category": "motion",
+      "description": "Long duration for container transformations.",
+      "value": "450ms"
+    },
+    {
+      "name": "--md-sys-motion-duration-long2",
+      "tier": "system",
+      "category": "motion",
+      "description": "Long duration for large spatial transitions.",
+      "value": "500ms"
+    },
+    {
+      "name": "--md-sys-motion-duration-long3",
+      "tier": "system",
+      "category": "motion",
+      "description": "Long duration for deliberate expressive transformations.",
+      "value": "550ms"
+    },
+    {
+      "name": "--md-sys-motion-duration-long4",
+      "tier": "system",
+      "category": "motion",
+      "description": "Long duration for staged entrances and exits.",
       "value": "600ms"
+    },
+    {
+      "name": "--md-sys-motion-duration-extra-long1",
+      "tier": "system",
+      "category": "motion",
+      "description": "Extended duration for non-looping expressive sequences.",
+      "value": "700ms"
+    },
+    {
+      "name": "--md-sys-motion-duration-extra-long2",
+      "tier": "system",
+      "category": "motion",
+      "description": "Extended duration for gentle progress feedback.",
+      "value": "800ms"
+    },
+    {
+      "name": "--md-sys-motion-duration-extra-long3",
+      "tier": "system",
+      "category": "motion",
+      "description": "Extended duration for deliberate continuous feedback cycles.",
+      "value": "900ms"
+    },
+    {
+      "name": "--md-sys-motion-duration-extra-long4",
+      "tier": "system",
+      "category": "motion",
+      "description": "Extended duration for slow continuous feedback cycles.",
+      "value": "1000ms"
+    },
+    {
+      "name": "--md-sys-motion-easing-emphasized",
+      "tier": "system",
+      "category": "motion",
+      "description": "Expressive curve for visible hierarchy and spatial changes.",
+      "value": "cubic-bezier(0.2, 0, 0, 1)"
+    },
+    {
+      "name": "--md-sys-motion-easing-emphasized-accelerate",
+      "tier": "system",
+      "category": "motion",
+      "description": "Expressive accelerating curve for exits.",
+      "value": "cubic-bezier(0.3, 0, 0.8, 0.15)"
     },
     {
       "name": "--md-sys-motion-easing-emphasized-decelerate",
@@ -562,11 +660,46 @@
       "value": "cubic-bezier(0.2, 0, 0, 1)"
     },
     {
+      "name": "--md-sys-motion-easing-linear",
+      "tier": "system",
+      "category": "motion",
+      "description": "Linear curve for continuous progress only.",
+      "value": "linear"
+    },
+    {
       "name": "--md-sys-motion-easing-standard",
       "tier": "system",
       "category": "motion",
       "description": "Easing for standard state transitions.",
       "value": "cubic-bezier(0.4, 0, 0.2, 1)"
+    },
+    {
+      "name": "--md-sys-motion-easing-standard-accelerate",
+      "tier": "system",
+      "category": "motion",
+      "description": "Standard accelerating curve for compact exits.",
+      "value": "cubic-bezier(0.3, 0, 1, 1)"
+    },
+    {
+      "name": "--md-sys-motion-easing-standard-decelerate",
+      "tier": "system",
+      "category": "motion",
+      "description": "Standard decelerating curve for compact entrances.",
+      "value": "cubic-bezier(0, 0, 0, 1)"
+    },
+    {
+      "name": "--md-sys-motion-spring-fast",
+      "tier": "system",
+      "category": "motion",
+      "description": "CSS spring-emulation curve for compact composited transforms without overshoot.",
+      "value": "cubic-bezier(0.33, 1, 0.68, 1)"
+    },
+    {
+      "name": "--md-sys-motion-spring-bouncy",
+      "tier": "system",
+      "category": "motion",
+      "description": "CSS spring-emulation curve for optional composited hierarchy cues with a restrained overshoot.",
+      "value": "cubic-bezier(0.34, 1.56, 0.64, 1)"
     },
     {
       "name": "--md-comp-divider-color",
@@ -580,7 +713,7 @@
       "tier": "component",
       "category": "motion",
       "description": "Divider entrance duration.",
-      "value": "var(--md-sys-motion-duration-medium4)"
+      "value": "var(--md-sys-motion-duration-long4)"
     },
     {
       "name": "--md-comp-divider-motion-easing",

--- a/vitest.browser.config.ts
+++ b/vitest.browser.config.ts
@@ -19,6 +19,7 @@ const browserPorts: Record<string, number> = {
   'm3-list': 63_322,
   'm3-snackbar': 63_323,
   'm3-top-app-bar': 63_324,
+  'm3-progress': 63_326,
 };
 
 const port = browserPorts[workspaceName];


### PR DESCRIPTION
## Motion inventory and proposal

The pre-migration audit found roughly 67 transitions and 12 animations across the component packages and Angular demo. Timing and easing were mostly literal values, with no reduced-motion contract.

This PR establishes a compact M3 motion vocabulary: the full duration scale, standard/emphasized entry and exit curves, and two spring-emulation curves. It migrates component and demo motion to those public tokens, adding motion only for state feedback, spatial hierarchy, or requested content entrances.

## Reduced-motion contract

Generated themes collapse public duration tokens to `1ms` for `prefers-reduced-motion: reduce`, preserving final states. Continuous indicators have static, meaningful alternatives: rings freeze, indeterminate progress becomes a centred partial bar, pulses stop fully visible, list staggering resolves to final layout, and interaction ripples are omitted. Snackbar removes its JavaScript exit wait in reduced mode.

## Validation

- `pnpm tokens:check` (including the new motion-token/alternative validator)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- `pnpm smoke:packages`
- `pnpm smoke:svelte-vite`
- `pnpm audit:prod`

Closes #13
Closes #2