### PR TITLE
ci: add required pull-request quality gate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,12 +17,16 @@ on:
         default: 'none'
 
 jobs:
+  quality:
+    uses: ./.github/workflows/quality.yml
+
   publish:
+    needs: quality
     runs-on: ubuntu-latest
     permissions:
       contents: write
       packages: write
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -68,7 +72,7 @@ jobs:
           git add .
           git commit -m "chore: bump version (${{ github.event.inputs.version_type }})"
           git push
-      
+
       - name: Publish to NPM Registry
         run: pnpm run publish:npm
         env:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -92,10 +92,13 @@ jobs:
         run: pnpm audit:prod
 
       - name: Packed package smoke test
+        timeout-minutes: 5
         run: pnpm smoke:packages
 
       - name: Svelte Vite consumer smoke test
+        timeout-minutes: 5
         run: pnpm smoke:svelte-vite
 
       - name: Verify package licenses
+        timeout-minutes: 5
         run: pnpm verify:package-licenses

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,101 @@
+name: Quality
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_call:
+
+# The PR gate only reads repository content. Release publishing declares its
+# separate write permissions in the calling workflow.
+permissions:
+  contents: read
+
+concurrency:
+  group: quality-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: quality
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24.18.0'
+
+      - name: Enable pinned pnpm with Corepack
+        run: |
+          npm install --global corepack@0.35.0
+          corepack enable
+          corepack install --global pnpm@11.12.0
+          test "$(node --version)" = "v24.18.0"
+          test "$(pnpm --version)" = "11.12.0"
+
+      - name: Resolve pnpm store path
+        id: pnpm-store
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore pnpm store cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: pnpm-store-${{ runner.os }}-${{ runner.arch }}-node-24.18-pnpm-11.12-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-store-${{ runner.os }}-${{ runner.arch }}-node-24.18-pnpm-11.12-
+
+      # Turbo verifies task hashes before reusing restored outputs. The source
+      # and lockfile are part of its task hash, so this cache cannot hide a
+      # changed input or a failed command.
+      - name: Restore Turbo cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .turbo
+          key: turbo-${{ runner.os }}-${{ runner.arch }}-${{ github.ref_name }}-${{ hashFiles('pnpm-lock.yaml', 'turbo.json', 'package.json', 'apps/**/package.json', 'packages/**/package.json') }}
+          restore-keys: |
+            turbo-${{ runner.os }}-${{ runner.arch }}-${{ github.ref_name }}-
+            turbo-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Chromium is installed from the Playwright version locked in
+      # pnpm-lock.yaml. `--with-deps` makes the Ubuntu system dependencies
+      # explicit rather than relying on the image's preinstalled browser.
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test
+
+      - name: Token and motion guard
+        run: pnpm tokens:check
+
+      - name: Build
+        run: pnpm exec turbo run build
+
+      - name: Production dependency audit
+        run: pnpm audit:prod
+
+      - name: Packed package smoke test
+        run: pnpm smoke:packages
+
+      - name: Svelte Vite consumer smoke test
+        run: pnpm smoke:svelte-vite
+
+      - name: Verify package licenses
+        run: pnpm verify:package-licenses

--- a/README.md
+++ b/README.md
@@ -159,6 +159,21 @@ pnpm dev
 
 ## 🛠️ Development
 
+### Pull-request quality gate
+
+Every pull request to `main` runs the immutable, least-privilege `Quality`
+workflow. Its required status check is **`Quality / quality`**. It verifies the
+pinned Node 24.18.0/pnpm 11.12.0 install, linting, type checks, Chromium
+Vitest and Angular tests, generated token and motion files, build output,
+production dependency audit, packed-package imports (including the Svelte Vite
+consumer), and package licenses. It keeps only dependency and Turbo caches—no
+test artifacts or coverage archives are retained.
+
+Configure `main` branch protection to require **`Quality / quality`** before
+merging, require the branch to be up to date, and restrict bypasses to
+maintainers. GitHub branch-protection settings are repository administration,
+so they must be applied by a maintainer in **Settings → Branches**.
+
 ### Build Commands
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -162,14 +162,14 @@ pnpm dev
 ### Pull-request quality gate
 
 Every pull request to `main` runs the immutable, least-privilege `Quality`
-workflow. Its required status check is **`Quality / quality`**. It verifies the
+ workflow. Its required status check is **`quality`**. It verifies the
 pinned Node 24.18.0/pnpm 11.12.0 install, linting, type checks, Chromium
 Vitest and Angular tests, generated token and motion files, build output,
 production dependency audit, packed-package imports (including the Svelte Vite
 consumer), and package licenses. It keeps only dependency and Turbo caches—no
 test artifacts or coverage archives are retained.
 
-Configure `main` branch protection to require **`Quality / quality`** before
+Configure `main` branch protection to require **`quality`** before
 merging, require the branch to be up to date, and restrict bypasses to
 maintainers. GitHub branch-protection settings are repository administration,
 so they must be applied by a maintainer in **Settings → Branches**.

--- a/scripts/smoke-svelte-vite.mjs
+++ b/scripts/smoke-svelte-vite.mjs
@@ -226,15 +226,44 @@ async function waitForServer(server, url) {
 
 async function stopServer(server) {
   if (server.exitCode !== null) return;
+
+  const waitForExit = (timeoutMs) => {
+    if (server.exitCode !== null) return Promise.resolve(true);
+    return new Promise((resolve) => {
+      const onExit = () => {
+        clearTimeout(timeout);
+        resolve(true);
+      };
+      const timeout = setTimeout(() => {
+        server.off('exit', onExit);
+        resolve(false);
+      }, timeoutMs);
+      server.once('exit', onExit);
+    });
+  };
+
   server.kill('SIGTERM');
-  const exitedAfterTerm = await Promise.race([
-    once(server, 'exit').then(() => true),
-    new Promise((resolve) => setTimeout(() => resolve(false), 5_000)),
-  ]);
+  const exitedAfterTerm = await waitForExit(5_000);
   if (exitedAfterTerm || server.exitCode !== null) return;
 
   server.kill('SIGKILL');
-  await once(server, 'exit');
+  if (!(await waitForExit(5_000))) {
+    throw new Error('Timed out stopping the Vite smoke-test server.');
+  }
+}
+
+async function closeBrowser(browser) {
+  let timeout;
+  const closed = await Promise.race([
+    browser.close().then(() => true),
+    new Promise((resolve) => {
+      timeout = setTimeout(() => resolve(false), 10_000);
+    }),
+  ]).finally(() => clearTimeout(timeout));
+
+  if (!closed) {
+    throw new Error('Timed out closing the Vite smoke-test browser.');
+  }
 }
 
 async function startServer(fixture) {
@@ -328,9 +357,27 @@ async function main() {
       'Svelte Vite smoke test passed for package-root and .svelte subpath exports.',
     );
   } finally {
-    await browser?.close();
-    if (server) await stopServer(server);
-    await rm(temporaryRoot, { recursive: true, force: true });
+    let cleanupFailure;
+    if (browser) {
+      try {
+        await closeBrowser(browser);
+      } catch (error) {
+        cleanupFailure = error;
+      }
+    }
+    if (server) {
+      try {
+        await stopServer(server);
+      } catch (error) {
+        cleanupFailure ??= error;
+      }
+    }
+    try {
+      await rm(temporaryRoot, { recursive: true, force: true });
+    } catch (error) {
+      cleanupFailure ??= error;
+    }
+    if (cleanupFailure) throw cleanupFailure;
   }
 }
 

--- a/scripts/smoke-svelte-vite.mjs
+++ b/scripts/smoke-svelte-vite.mjs
@@ -268,22 +268,14 @@ async function closeBrowser(browser) {
 
 async function startServer(fixture) {
   let lastPortError;
+  const viteCli = join(fixture, 'node_modules', 'vite', 'bin', 'vite.js');
 
   for (let attempt = 1; attempt <= 3; attempt += 1) {
     const port = await availablePort();
     const url = `http://127.0.0.1:${port}`;
     const server = spawn(
-      'npm',
-      [
-        'exec',
-        '--',
-        'vite',
-        '--host',
-        '127.0.0.1',
-        '--port',
-        String(port),
-        '--strictPort',
-      ],
+      process.execPath,
+      [viteCli, '--host', '127.0.0.1', '--port', String(port), '--strictPort'],
       {
         cwd: fixture,
         stdio: ['ignore', 'pipe', 'pipe'],


### PR DESCRIPTION
## Summary

- add a reusable `Quality` workflow for pull requests and pushes to `main`, with the single required check `quality`
- pin the Node 24.18.0 / Corepack 0.35.0 / pnpm 11.12.0 toolchain and immutable GitHub Action SHAs
- gate release publishing on the same quality workflow and document the branch-protection configuration
- bound packed-consumer cleanup so a successful Svelte verification cannot hold CI open indefinitely

## Acceptance criteria

- [x] Every pull request to `main` runs the quality gate.
- [x] Lint, typecheck, test, token/motion, build, production-audit, package smoke, Svelte Vite smoke, and license failures stop the job.
- [x] The workflow has read-only permissions, keyed pnpm/Turbo caches, redundancy cancellation, and no retained artifacts.
- [x] The publish workflow cannot run its publish job until the equivalent quality gate succeeds.
- [x] README documents the exact required status check: `quality`.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (Chromium Vitest plus Angular tests)
- `pnpm tokens:check`
- `pnpm exec turbo run build`
- `pnpm audit:prod`
- `pnpm smoke:packages`
- `pnpm smoke:svelte-vite`
- `pnpm verify:package-licenses`
- Prettier and Ruby YAML parse validation for both workflows
- Introduced a temporary TypeScript parse error and confirmed the package lint command exited non-zero; removed it before committing.
- Reproduced the Svelte packed-consumer smoke after fixing its server/browser teardown; it completed in 9.69 seconds under Node 24.18.

## Risk and compatibility

No runtime or package API changes. Chromium is installed from the lockfile-pinned Playwright version with `--with-deps`; only pnpm store and Turbo task caches persist. No artifacts or coverage archives are uploaded. The three archive/consumer verifiers have five-minute step limits, and the Svelte smoke preserves packed root/subpath declarations plus runtime rendering verification.

Closes #6