### PR TITLE
feat(dialog): make modal interactions accessible

### DIFF
--- a/apps/angular-app/src/pages/dialog/dialog.component.html
+++ b/apps/angular-app/src/pages/dialog/dialog.component.html
@@ -6,17 +6,42 @@
 
   <section class="demo-section">
     <h2>Usage</h2>
-    <p>A dialog is a modal window that appears in front of app content to provide critical information or ask for a decision.</p>
+    <p>
+      A dialog is a modal window that appears in front of app content to provide
+      critical information or ask for a decision. It traps keyboard focus, makes
+      the page background inert, and restores focus to its opener after closing.
+    </p>
     <div class="interactive-demo">
       <div class="demo-row">
         <m3-button (click)="openDialog()">Open Dialog</m3-button>
-        <m3-dialog [open]="dialogOpen" headline="Confirm Action" (dialog-close)="closeDialog()">
+        <m3-dialog
+          #dialog
+          [open]="dialogOpen"
+          headline="Confirm Action"
+          (dialog-close)="closeDialog($event)"
+        >
           <p>Are you sure you want to proceed with this action?</p>
-          <m3-button slot="actions" variant="text" (click)="closeDialog()">Cancel</m3-button>
-          <m3-button slot="actions" (click)="closeDialog()">Confirm</m3-button>
+          <m3-button
+            slot="actions"
+            variant="text"
+            (click)="closeFromAction(dialog)"
+            >Cancel</m3-button
+          >
+          <m3-button slot="actions" (click)="closeFromAction(dialog)"
+            >Confirm</m3-button
+          >
         </m3-dialog>
       </div>
-      <app-code-block [code]="basicExample" language="html" variant="sample"></app-code-block>
+      <p class="demo-note">
+        Last close reason: <code>{{ lastCloseReason }}</code
+        >. Escape and scrim clicks can be cancelled with
+        <code>dialog-request-close</code>.
+      </p>
+      <app-code-block
+        [code]="basicExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 </div>

--- a/apps/angular-app/src/pages/dialog/dialog.component.ts
+++ b/apps/angular-app/src/pages/dialog/dialog.component.ts
@@ -1,5 +1,9 @@
-import { Component, ChangeDetectionStrategy, CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
-import { CodeBlockComponent } from "../../app/components/code-block/code-block.component";
+import {
+  Component,
+  ChangeDetectionStrategy,
+  CUSTOM_ELEMENTS_SCHEMA,
+} from '@angular/core';
+import { CodeBlockComponent } from '../../app/components/code-block/code-block.component';
 import '@banegasn/m3-dialog';
 import '@banegasn/m3-button';
 import '@banegasn/m3-card';
@@ -14,13 +18,28 @@ import '@banegasn/m3-card';
 })
 export class DialogComponent {
   dialogOpen = false;
+  lastCloseReason = '—';
 
   readonly basicExample = `<m3-dialog open headline="Dialog Title">
   <p>Dialog body text goes here.</p>
-  <m3-button slot="actions" variant="text">Cancel</m3-button>
-  <m3-button slot="actions">Confirm</m3-button>
+  <button slot="actions" onclick="this.closest('m3-dialog').close('action')">Cancel</button>
+  <button slot="actions" onclick="this.closest('m3-dialog').close('action')">Confirm</button>
 </m3-dialog>`;
 
-  openDialog() { this.dialogOpen = true; }
-  closeDialog() { this.dialogOpen = false; }
+  openDialog() {
+    this.dialogOpen = true;
+  }
+
+  closeFromAction(dialog: HTMLElement) {
+    (dialog as HTMLElement & { close(reason: 'action'): boolean }).close(
+      'action',
+    );
+  }
+
+  closeDialog(event: Event) {
+    this.dialogOpen = false;
+    this.lastCloseReason = (
+      event as CustomEvent<{ reason: string }>
+    ).detail.reason;
+  }
 }

--- a/packages/m3-dialog/README.md
+++ b/packages/m3-dialog/README.md
@@ -47,6 +47,7 @@ When open, the component:
 
 - Moves focus to an `[autofocus]` descendant, otherwise the first focusable descendant (including controls in slotted content and open component shadow roots).
 - Wraps Tab and Shift+Tab within the topmost dialog. If there are no focusable descendants, the dialog surface itself receives focus.
+- Uses the native `<dialog>` top layer, so visual and pointer-event stacking follows open order even when dialogs originate in different DOM or CSS stacking contexts.
 - Uses the platform `inert` property on background sibling branches up to `body` and locks document scrolling. Original inert and overflow values are restored after the final dialog closes.
 - Handles Escape and scrim clicks only for the topmost dialog. Both become cancelable close requests.
 - Restores focus to the element that opened the dialog when it is still connected. Removed openers are safely ignored.

--- a/packages/m3-dialog/README.md
+++ b/packages/m3-dialog/README.md
@@ -2,147 +2,159 @@
 
 ![Preview](images/preview.png)
 
-
-> Material Design 3 Dialog web component — framework-agnostic, built with Lit.
-
-[![npm version](https://img.shields.io/npm/v/@banegasn/m3-dialog.svg)](https://www.npmjs.com/package/@banegasn/m3-dialog)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](../../LICENSE)
-
-An accessible **M3 Dialog** web component following the [Material Design 3 dialog specifications](https://m3.material.io/components/dialogs/overview). Features expressive open/close animations, headline, content, and action slots. Works in Angular, React, Vue, Svelte, or plain HTML — no build step required.
-
-## Features
-
-- Basic and full-screen dialog variants
-- Expressive open/close animations
-- Headline, content, and actions slots
-- Focus trap and scroll lock when open
-- Keyboard accessible (Escape to close)
-- Accessible with ARIA `dialog` role
-- Framework-agnostic custom element
+Material Design 3 modal dialog web component built with Lit. `m3-dialog` is a self-contained, keyboard-safe modal primitive: it does not require a framework dialog service.
 
 ## Installation
 
 ```bash
-npm install @banegasn/m3-dialog
-# or
 pnpm add @banegasn/m3-dialog
-# or
-yarn add @banegasn/m3-dialog
 ```
-
-## CDN Usage (no build step)
-
-```html
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <title>M3 Dialog Demo</title>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@banegasn/m3-dialog/+esm"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@banegasn/m3-button/+esm"></script>
-  <style>
-    body { font-family: Roboto, sans-serif; padding: 32px; background: #fef7ff; }
-  </style>
-</head>
-<body>
-  <m3-button id="open-btn" variant="filled">Open Dialog</m3-button>
-
-  <m3-dialog id="my-dialog" headline="Confirm action">
-    <p>Are you sure you want to delete this item? This action cannot be undone.</p>
-    <m3-button slot="actions" variant="text" id="cancel-btn">Cancel</m3-button>
-    <m3-button slot="actions" variant="filled" id="confirm-btn">Delete</m3-button>
-  </m3-dialog>
-
-  <script>
-    const dialog = document.getElementById('my-dialog');
-    document.getElementById('open-btn').addEventListener('button-click', () => dialog.open = true);
-    document.getElementById('cancel-btn').addEventListener('button-click', () => dialog.open = false);
-    document.getElementById('confirm-btn').addEventListener('button-click', () => {
-      console.log('Confirmed!');
-      dialog.open = false;
-    });
-  </script>
-</body>
-</html>
-```
-
-## npm Usage
 
 ```js
 import '@banegasn/m3-dialog';
 ```
 
+## Basic usage
+
 ```html
-<m3-dialog open headline="Dialog Title">
-  <p>Dialog content goes here.</p>
-  <m3-button slot="actions" variant="text">Cancel</m3-button>
-  <m3-button slot="actions" variant="filled">Confirm</m3-button>
+<button id="open">Delete item</button>
+
+<m3-dialog id="delete-dialog" headline="Delete item">
+  <p>This action cannot be undone.</p>
+  <button slot="actions" id="cancel">Cancel</button>
+  <button slot="actions" id="confirm">Delete</button>
+</m3-dialog>
+
+<script type="module">
+  const dialog = document.querySelector('#delete-dialog');
+  document
+    .querySelector('#open')
+    .addEventListener('click', () => dialog.show());
+  document
+    .querySelector('#cancel')
+    .addEventListener('click', () => dialog.close('action'));
+  document
+    .querySelector('#confirm')
+    .addEventListener('click', () => dialog.close('action'));
+</script>
+```
+
+Action slots do not close the dialog automatically. Explicitly calling `close('action')` makes the completed action observable and lets the application decide what each action means.
+
+## Modal contract
+
+When open, the component:
+
+- Moves focus to an `[autofocus]` descendant, otherwise the first focusable descendant (including controls in slotted content and open component shadow roots).
+- Wraps Tab and Shift+Tab within the topmost dialog. If there are no focusable descendants, the dialog surface itself receives focus.
+- Uses the platform `inert` property on background sibling branches up to `body` and locks document scrolling. Original inert and overflow values are restored after the final dialog closes.
+- Handles Escape and scrim clicks only for the topmost dialog. Both become cancelable close requests.
+- Restores focus to the element that opened the dialog when it is still connected. Removed openers are safely ignored.
+
+Multiple open dialogs are supported; only the most recently opened dialog owns focus and keyboard dismissal. The component uses the platform `inert` primitive and does not bundle an inert polyfill.
+
+## Accessible naming
+
+`headline` creates an internal heading and connects it with `aria-labelledby`. Non-empty default-slot content is connected with `aria-describedby`. Neither ARIA attribute is emitted when there is no corresponding value.
+
+Use the canonical ARIA attributes when your application owns the label or description elsewhere:
+
+```html
+<h2 id="invite-title">Invite collaborator</h2>
+<p id="invite-help">They will receive an email invitation.</p>
+
+<m3-dialog aria-labelledby="invite-title" aria-describedby="invite-help">
+  <button>Send invitation</button>
 </m3-dialog>
 ```
+
+An explicit `aria-labelledby` or `aria-describedby` overrides the generated relationship.
+
+## Close lifecycle
+
+Use `requestClose(reason)` or `close(reason)` to get cancelable close behavior. The available reasons are `"escape"`, `"scrim"`, `"action"`, and `"programmatic"`.
+
+```js
+dialog.addEventListener('dialog-request-close', (event) => {
+  if (event.detail.reason === 'scrim' && formIsDirty()) {
+    event.preventDefault();
+  }
+});
+
+dialog.addEventListener('dialog-close', (event) => {
+  console.log(`Closed via ${event.detail.reason}`);
+});
+```
+
+Changing `open` to `false` is supported for declarative framework bindings and reports a `"programmatic"` `dialog-close`; use `close()` when the close must be cancelable.
 
 ## API
 
 ### Properties
 
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `open` | `boolean` | `false` | Whether the dialog is open |
-| `headline` | `string` | `''` | Dialog title text |
+| Property / attribute                   | Type             | Default | Description                                                            |
+| -------------------------------------- | ---------------- | ------- | ---------------------------------------------------------------------- |
+| `open`                                 | `boolean`        | `false` | Whether the dialog is modal and visible.                               |
+| `headline`                             | `string`         | `''`    | Generated visible heading and accessible name.                         |
+| `closeOnScrim` / `close-on-scrim`      | `boolean`        | `true`  | Allows a scrim click to request a close.                               |
+| `closeOnEscape` / `close-on-escape`    | `boolean`        | `true`  | Allows Escape to request a close.                                      |
+| `ariaLabelledBy` / `aria-labelledby`   | `string \| null` | `null`  | External label ID; overrides the generated heading relationship.       |
+| `ariaDescribedBy` / `aria-describedby` | `string \| null` | `null`  | External description ID; overrides the generated content relationship. |
+
+HTML boolean attributes are presence-based. To disable scrim or Escape dismissal from markup-driven code, set the matching DOM property (for example `dialog.closeOnScrim = false`).
+
+### Methods
+
+| Method                           | Description                                                                                         |
+| -------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `show()`                         | Opens the dialog and resolves after Lit renders the open state.                                     |
+| `close(reason = 'programmatic')` | Dispatches a cancelable close request and closes if it is accepted. Returns whether it closed.      |
+| `requestClose(reason)`           | Same close-request path when the caller wants its intent to be explicit. Returns whether it closed. |
 
 ### Events
 
-| Event | Detail | Description |
-|-------|--------|-------------|
-| `dialog-close` | `{}` | Fired when the dialog is closed |
+| Event                  | Detail       | Description                                                                   |
+| ---------------------- | ------------ | ----------------------------------------------------------------------------- |
+| `dialog-open`          | `{ opener }` | Fired after the dialog enters the modal stack.                                |
+| `dialog-request-close` | `{ reason }` | Bubbles, is composed and cancelable. Prevent default to keep the dialog open. |
+| `dialog-close`         | `{ reason }` | Bubbles and is composed after the dialog closes.                              |
 
 ### Slots
 
-| Slot | Description |
-|------|-------------|
-| (default) | Dialog body content |
-| `actions` | Action buttons (displayed at the bottom) |
+| Slot      | Description                                   |
+| --------- | --------------------------------------------- |
+| Default   | Dialog body content.                          |
+| `icon`    | Optional icon above the headline.             |
+| `actions` | Controls aligned at the bottom of the dialog. |
 
-### CSS Custom Properties
+### CSS custom properties
 
-| Property | Default | Description |
-|----------|---------|-------------|
-| `--md-sys-color-surface-container-high` | `#ece6f0` | Dialog background |
-| `--md-sys-color-on-surface` | `#1d1b20` | Dialog text color |
-| `--md-comp-dialog-container-shape` | `28px` | Dialog border radius |
+| Property                                | Default   | Description           |
+| --------------------------------------- | --------- | --------------------- |
+| `--md-sys-color-surface-container-high` | `#ece6f0` | Dialog background.    |
+| `--md-sys-color-on-surface`             | `#1d1b20` | Heading color.        |
+| `--md-comp-dialog-container-shape`      | `28px`    | Dialog border radius. |
 
-## Framework Usage
+## Framework bindings
 
-### Angular
-```typescript
-import '@banegasn/m3-dialog';
-```
+Frameworks can bind `open` declaratively and listen for the composed close notification. For close actions, call the dialog method with a reason rather than only setting the bound state.
+
 ```html
+<!-- Angular -->
 <m3-dialog [open]="isOpen" headline="Confirm" (dialog-close)="isOpen = false">
   <p>Are you sure?</p>
-  <m3-button slot="actions" variant="text" (button-click)="isOpen = false">Cancel</m3-button>
-  <m3-button slot="actions" variant="filled" (button-click)="confirm()">OK</m3-button>
+  <button slot="actions" (click)="dialog.close('action')">Confirm</button>
 </m3-dialog>
 ```
 
-### React
 ```jsx
-import '@banegasn/m3-dialog';
-// <m3-dialog open={isOpen} headline="Confirm" ondialog-close={() => setOpen(false)}>...</m3-dialog>
+// React
+<m3-dialog
+  open={isOpen}
+  headline="Confirm"
+  ondialog-close={() => setOpen(false)}
+/>
 ```
-
-### Vue
-```vue
-<m3-dialog :open="isOpen" headline="Confirm" @dialog-close="isOpen = false">
-  <p>Are you sure?</p>
-  <m3-button slot="actions" variant="text" @button-click="isOpen = false">Cancel</m3-button>
-  <m3-button slot="actions" variant="filled" @button-click="confirm">OK</m3-button>
-</m3-dialog>
-```
-
-## Resources
-
-- [Material Design 3 Dialogs](https://m3.material.io/components/dialogs/overview)
-- [GitHub Repository](https://github.com/banegasn/components)
 
 ## License
 

--- a/packages/m3-dialog/package.json
+++ b/packages/m3-dialog/package.json
@@ -24,7 +24,7 @@
     "clean": "rm -rf dist",
     "lint": "eslint src --max-warnings 0",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node ../../scripts/no-tests.mjs"
+    "test": "vitest run --config ../../vitest.browser.config.ts"
   },
   "repository": {
     "type": "git",

--- a/packages/m3-dialog/src/m3-dialog.styles.ts
+++ b/packages/m3-dialog/src/m3-dialog.styles.ts
@@ -5,52 +5,38 @@ export const m3DialogStyles = css`
     display: contents;
   }
 
-  .scrim {
-    position: fixed;
-    inset: 0;
-    z-index: 1000;
+  .dialog::backdrop {
     background-color: rgba(0, 0, 0, 0.32);
-    opacity: 0;
-    transition: opacity var(--md-sys-motion-duration-short3) var(--md-sys-motion-easing-standard);
-    pointer-events: none;
-  }
-
-  .scrim[open] {
-    opacity: 1;
-    pointer-events: auto;
-  }
-
-  .dialog-container {
-    position: fixed;
-    inset: 0;
-    z-index: 1001;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    pointer-events: none;
   }
 
   .dialog {
-    position: relative;
+    border: 0;
+    padding: 0;
     min-width: 280px;
     max-width: 560px;
     width: calc(100% - 48px);
     max-height: calc(100% - 48px);
     background-color: var(--md-sys-color-surface-container-high, #ece6f0);
     border-radius: var(--md-comp-dialog-container-shape, 28px);
-    box-shadow: 0 8px 12px 6px rgba(0, 0, 0, 0.15), 0 4px 4px rgba(0, 0, 0, 0.3);
+    box-shadow:
+      0 8px 12px 6px rgba(0, 0, 0, 0.15),
+      0 4px 4px rgba(0, 0, 0, 0.3);
     display: flex;
     flex-direction: column;
-    transform: scale(0.9);
-    opacity: 0;
-    transition: transform var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-emphasized-decelerate), opacity var(--md-sys-motion-duration-short3) var(--md-sys-motion-easing-emphasized-decelerate);
-    pointer-events: none;
+    animation: m3-dialog-enter var(--md-sys-motion-duration-short4)
+      var(--md-sys-motion-easing-emphasized-decelerate);
   }
 
-  .dialog[open] {
-    transform: scale(1);
-    opacity: 1;
-    pointer-events: auto;
+  @keyframes m3-dialog-enter {
+    from {
+      transform: scale(0.9);
+      opacity: 0;
+    }
+
+    to {
+      transform: scale(1);
+      opacity: 1;
+    }
   }
 
   .icon-slot {

--- a/packages/m3-dialog/src/m3-dialog.test.ts
+++ b/packages/m3-dialog/src/m3-dialog.test.ts
@@ -1,0 +1,259 @@
+import { expect, fixture, html } from '@open-wc/testing';
+import { describe, it } from 'vitest';
+import './m3-dialog.js';
+import '../../m3-button/src/m3-button.js';
+import type {
+  M3Dialog,
+  M3DialogCloseDetail,
+  M3DialogCloseReason,
+} from './m3-dialog.js';
+
+const nextFrame = () =>
+  new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+async function settleDialog(dialog: M3Dialog) {
+  await dialog.updateComplete;
+  await nextFrame();
+}
+
+describe('M3Dialog modal contract', () => {
+  it('focuses the first slotted control and contains Tab and Shift+Tab', async () => {
+    const dialog = await fixture<M3Dialog>(html`
+      <m3-dialog open headline="Remove item">
+        <button id="first">Cancel</button>
+        <input id="last" aria-label="Name" />
+      </m3-dialog>
+    `);
+    await settleDialog(dialog);
+
+    const first = dialog.querySelector<HTMLButtonElement>('#first')!;
+    const last = dialog.querySelector<HTMLInputElement>('#last')!;
+    expect(document.activeElement).to.equal(first);
+
+    last.focus();
+    const tab = new KeyboardEvent('keydown', {
+      key: 'Tab',
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+    });
+    last.dispatchEvent(tab);
+    expect(tab.defaultPrevented).to.equal(true);
+    expect(document.activeElement).to.equal(first);
+
+    const reverseTab = new KeyboardEvent('keydown', {
+      key: 'Tab',
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+    });
+    first.dispatchEvent(reverseTab);
+    expect(reverseTab.defaultPrevented).to.equal(true);
+    expect(document.activeElement).to.equal(last);
+  });
+
+  it('uses autofocus when supplied and focuses the dialog container when it has no focusable content', async () => {
+    const autofocusDialog = await fixture<M3Dialog>(html`
+      <m3-dialog open
+        ><button>First</button
+        ><button autofocus id="preferred">Preferred</button></m3-dialog
+      >
+    `);
+    await settleDialog(autofocusDialog);
+    expect(document.activeElement).to.equal(
+      autofocusDialog.querySelector('#preferred'),
+    );
+
+    autofocusDialog.close();
+    await autofocusDialog.updateComplete;
+    const noFocusableDialog = await fixture<M3Dialog>(
+      html`<m3-dialog open>Read this message.</m3-dialog>`,
+    );
+    await settleDialog(noFocusableDialog);
+    expect(noFocusableDialog.shadowRoot!.activeElement).to.equal(
+      noFocusableDialog.shadowRoot!.querySelector('.dialog'),
+    );
+  });
+
+  it('includes focusable controls exposed from slotted component shadow roots', async () => {
+    const dialog = await fixture<M3Dialog>(html`
+      <m3-dialog open headline="Save changes"
+        ><m3-button slot="actions" id="save">Save</m3-button></m3-dialog
+      >
+    `);
+    await settleDialog(dialog);
+
+    const action = dialog.querySelector<HTMLElement>('#save')!;
+    expect(action.shadowRoot!.activeElement).to.equal(
+      action.shadowRoot!.querySelector('button'),
+    );
+  });
+
+  it('uses one cancelable close request for Escape and reports its close reason', async () => {
+    const dialog = await fixture<M3Dialog>(
+      html`<m3-dialog open><button>Dismiss</button></m3-dialog>`,
+    );
+    await settleDialog(dialog);
+
+    const preventEscape = (event: Event) => event.preventDefault();
+    dialog.addEventListener('dialog-request-close', preventEscape, {
+      once: true,
+    });
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    expect(dialog.open).to.equal(true);
+
+    let closeDetail: M3DialogCloseDetail | undefined;
+    dialog.addEventListener('dialog-close', (event) => {
+      closeDetail = (event as CustomEvent<M3DialogCloseDetail>).detail;
+    });
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    await dialog.updateComplete;
+    expect(dialog.open).to.equal(false);
+    expect(closeDetail).to.deep.equal({ reason: 'escape' });
+  });
+
+  it('honours scrim policy and reports scrim and action close reasons', async () => {
+    const dialog = await fixture<M3Dialog>(
+      html`<m3-dialog open><button>Dismiss</button></m3-dialog>`,
+    );
+    await settleDialog(dialog);
+    dialog.closeOnScrim = false;
+    await dialog.updateComplete;
+
+    const scrim = dialog.shadowRoot!.querySelector<HTMLElement>('.scrim')!;
+    scrim.click();
+    expect(dialog.open).to.equal(true);
+
+    dialog.closeOnScrim = true;
+    await dialog.updateComplete;
+    scrim.click();
+    await dialog.updateComplete;
+    expect(dialog.open).to.equal(false);
+
+    await dialog.show();
+    await settleDialog(dialog);
+    let reason: M3DialogCloseReason | undefined;
+    dialog.addEventListener(
+      'dialog-close',
+      (event) => {
+        reason = (event as CustomEvent<M3DialogCloseDetail>).detail.reason;
+      },
+      { once: true },
+    );
+    expect(dialog.close('action')).to.equal(true);
+    await dialog.updateComplete;
+    expect(reason).to.equal('action');
+  });
+
+  it('generates accessible name and description hooks without empty ARIA attributes', async () => {
+    const dialog = await fixture<M3Dialog>(html`
+      <m3-dialog open headline="Delete item"
+        ><p>This cannot be undone.</p>
+        <button>Delete</button></m3-dialog
+      >
+    `);
+    await settleDialog(dialog);
+
+    const surface =
+      dialog.shadowRoot!.querySelector<HTMLElement>('[role="dialog"]')!;
+    expect(surface.getAttribute('aria-labelledby')).to.equal(
+      surface.querySelector('.headline')!.id,
+    );
+    expect(surface.getAttribute('aria-describedby')).to.equal(
+      surface.querySelector('.content')!.id,
+    );
+    expect(surface).to.be.accessible();
+
+    dialog.close();
+    await dialog.updateComplete;
+    const unnamedDialog = await fixture<M3Dialog>(
+      html`<m3-dialog open></m3-dialog>`,
+    );
+    await settleDialog(unnamedDialog);
+    const unnamedSurface =
+      unnamedDialog.shadowRoot!.querySelector<HTMLElement>('[role="dialog"]')!;
+    expect(unnamedSurface.hasAttribute('aria-labelledby')).to.equal(false);
+    expect(unnamedSurface.hasAttribute('aria-describedby')).to.equal(false);
+  });
+
+  it('restores focus to the connected opener and safely handles an opener that was removed', async () => {
+    const container = await fixture<HTMLDivElement>(html`
+      <div>
+        <button id="opener">Open</button
+        ><m3-dialog><button>Dismiss</button></m3-dialog>
+      </div>
+    `);
+    const opener = container.querySelector<HTMLButtonElement>('#opener')!;
+    const dialog = container.querySelector<M3Dialog>('m3-dialog')!;
+
+    opener.focus();
+    dialog.open = true;
+    await settleDialog(dialog);
+    dialog.close();
+    await dialog.updateComplete;
+    expect(document.activeElement).to.equal(opener);
+
+    opener.focus();
+    dialog.open = true;
+    await settleDialog(dialog);
+    opener.remove();
+    expect(() => dialog.close()).not.to.throw();
+    await dialog.updateComplete;
+    expect(dialog.open).to.equal(false);
+  });
+
+  it('keeps only the topmost of multiple dialogs interactive and restores the page after the final close', async () => {
+    const wrapper = await fixture<HTMLDivElement>(html`
+      <div>
+        <button id="inside-background">Background</button>
+        <m3-dialog id="first"><button>First</button></m3-dialog>
+        <m3-dialog id="second"><button>Second</button></m3-dialog>
+      </div>
+    `);
+    const first = wrapper.querySelector<M3Dialog>('#first')!;
+    const second = wrapper.querySelector<M3Dialog>('#second')!;
+    const insideBackground =
+      wrapper.querySelector<HTMLButtonElement>('#inside-background')!;
+    const background = document.createElement('button');
+    document.body.append(background);
+
+    first.open = true;
+    await settleDialog(first);
+    expect(background.inert).to.equal(true);
+    expect(insideBackground.inert).to.equal(true);
+    expect(document.body.style.overflow).to.equal('hidden');
+
+    second.open = true;
+    await settleDialog(second);
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    await second.updateComplete;
+    expect(second.open).to.equal(false);
+    expect(first.open).to.equal(true);
+
+    first.close();
+    await first.updateComplete;
+    expect(background.inert).to.equal(false);
+    expect(insideBackground.inert).to.equal(false);
+    expect(document.body.style.overflow).to.equal('');
+    background.remove();
+  });
+});

--- a/packages/m3-dialog/src/m3-dialog.test.ts
+++ b/packages/m3-dialog/src/m3-dialog.test.ts
@@ -133,13 +133,14 @@ describe('M3Dialog modal contract', () => {
     dialog.closeOnScrim = false;
     await dialog.updateComplete;
 
-    const scrim = dialog.shadowRoot!.querySelector<HTMLElement>('.scrim')!;
-    scrim.click();
+    const surface =
+      dialog.shadowRoot!.querySelector<HTMLDialogElement>('.dialog')!;
+    surface.click();
     expect(dialog.open).to.equal(true);
 
     dialog.closeOnScrim = true;
     await dialog.updateComplete;
-    scrim.click();
+    surface.click();
     await dialog.updateComplete;
     expect(dialog.open).to.equal(false);
 
@@ -255,5 +256,57 @@ describe('M3Dialog modal contract', () => {
     expect(insideBackground.inert).to.equal(false);
     expect(document.body.style.overflow).to.equal('');
     background.remove();
+  });
+
+  it('puts the most recently opened dialog above an earlier DOM sibling across stacking contexts', async () => {
+    const wrapper = await fixture<HTMLDivElement>(html`
+      <div>
+        <div style="position: relative; z-index: 1; transform: translateZ(0)">
+          <m3-dialog id="newer" headline="Newer"
+            ><button>Newer</button></m3-dialog
+          >
+        </div>
+        <div style="position: relative; z-index: 2; transform: translateZ(0)">
+          <m3-dialog id="older" headline="Older"
+            ><button>Older</button></m3-dialog
+          >
+        </div>
+      </div>
+    `);
+    const newer = wrapper.querySelector<M3Dialog>('#newer')!;
+    const older = wrapper.querySelector<M3Dialog>('#older')!;
+
+    older.open = true;
+    await settleDialog(older);
+    newer.open = true;
+    await settleDialog(newer);
+
+    const newerSurface =
+      newer.shadowRoot!.querySelector<HTMLDialogElement>('.dialog')!;
+    const newerBounds = newerSurface.getBoundingClientRect();
+    expect(
+      document.elementFromPoint(newerBounds.x + 8, newerBounds.y + 8),
+    ).to.equal(newer);
+  });
+
+  it('inerts sibling branches in a ShadowRoot before ascending to the host', async () => {
+    const host = document.createElement('div');
+    const root = host.attachShadow({ mode: 'open' });
+    root.innerHTML =
+      '<button id="shadow-background">Background</button><m3-dialog><button>Dismiss</button></m3-dialog>';
+    document.body.append(host);
+
+    const shadowBackground =
+      root.querySelector<HTMLButtonElement>('#shadow-background')!;
+    const dialog = root.querySelector<M3Dialog>('m3-dialog')!;
+    await customElements.whenDefined('m3-dialog');
+    dialog.open = true;
+    await settleDialog(dialog);
+    expect(shadowBackground.inert).to.equal(true);
+
+    dialog.close();
+    await dialog.updateComplete;
+    expect(shadowBackground.inert).to.equal(false);
+    host.remove();
   });
 });

--- a/packages/m3-dialog/src/m3-dialog.ts
+++ b/packages/m3-dialog/src/m3-dialog.ts
@@ -122,30 +122,24 @@ export class M3Dialog extends LitElement {
       (this.hasDescription ? this.descriptionId : undefined);
 
     return html`
-      <div
-        class="scrim"
-        ?open=${this.open}
-        @click=${this.handleScrimClick}
-      ></div>
-      <div class="dialog-container" ?open=${this.open}>
-        <div
-          class="dialog"
-          ?open=${this.open}
-          role="dialog"
-          tabindex="-1"
-          aria-modal=${this.open ? 'true' : nothing}
-          aria-hidden=${this.open ? nothing : 'true'}
-          aria-labelledby=${labelledBy ?? nothing}
-          aria-describedby=${describedBy ?? nothing}
-        >
-          <div class="icon-slot"><slot name="icon"></slot></div>
-          ${this.headline ? html`<h2 class="headline" id=${this.headlineId}>${this.headline}</h2>` : nothing}
-          <div class="content" id=${this.descriptionId}>
-            <slot @slotchange=${this.handleContentSlotChange}></slot>
-          </div>
-          <div class="actions"><slot name="actions"></slot></div>
+      <dialog
+        class="dialog"
+        role="dialog"
+        tabindex="-1"
+        aria-modal=${this.open ? 'true' : nothing}
+        aria-hidden=${this.open ? nothing : 'true'}
+        aria-labelledby=${labelledBy ?? nothing}
+        aria-describedby=${describedBy ?? nothing}
+        @cancel=${this.handleNativeCancel}
+        @click=${this.handleDialogClick}
+      >
+        <div class="icon-slot"><slot name="icon"></slot></div>
+        ${this.headline ? html`<h2 class="headline" id=${this.headlineId}>${this.headline}</h2>` : nothing}
+        <div class="content" id=${this.descriptionId}>
+          <slot @slotchange=${this.handleContentSlotChange}></slot>
         </div>
-      </div>
+        <div class="actions"><slot name="actions"></slot></div>
+      </dialog>
     `;
   }
 
@@ -222,6 +216,7 @@ export class M3Dialog extends LitElement {
     );
 
     void this.updateComplete.then(() => {
+      this.showNativeModal();
       requestAnimationFrame(() => {
         if (this.open && M3Dialog.topDialog === this) {
           this.focusInitial();
@@ -238,6 +233,7 @@ export class M3Dialog extends LitElement {
     }
 
     M3Dialog.openDialogs.splice(dialogIndex, 1);
+    this.closeNativeModal();
     M3Dialog.updatePageContainment();
 
     const reason = this.closeReason;
@@ -255,8 +251,20 @@ export class M3Dialog extends LitElement {
     }
   }
 
-  private handleScrimClick() {
-    if (this.closeOnScrim && M3Dialog.topDialog === this) {
+  private handleNativeCancel(event: Event) {
+    event.preventDefault();
+
+    if (this.closeOnEscape && M3Dialog.topDialog === this) {
+      this.requestClose('escape');
+    }
+  }
+
+  private handleDialogClick(event: MouseEvent) {
+    if (
+      event.target === event.currentTarget &&
+      this.closeOnScrim &&
+      M3Dialog.topDialog === this
+    ) {
       this.requestClose('scrim');
     }
   }
@@ -295,8 +303,27 @@ export class M3Dialog extends LitElement {
     this.opener.focus({ preventScroll: true });
   }
 
-  private get dialogElement(): HTMLElement | null {
-    return this.shadowRoot?.querySelector<HTMLElement>('.dialog') ?? null;
+  private get dialogElement(): HTMLDialogElement | null {
+    return this.shadowRoot?.querySelector<HTMLDialogElement>('.dialog') ?? null;
+  }
+
+  /**
+   * The native modal dialog top layer is ordered by showModal() calls, not DOM
+   * order or ancestor stacking contexts. Calling it from the modal stack makes
+   * the most recently opened component the visual and pointer-event topmost.
+   */
+  private showNativeModal() {
+    const dialog = this.dialogElement;
+    if (dialog && !dialog.open) {
+      dialog.showModal();
+    }
+  }
+
+  private closeNativeModal() {
+    const dialog = this.dialogElement;
+    if (dialog?.open) {
+      dialog.close();
+    }
   }
 
   /** Finds focusable descendants across the light DOM and open component shadows. */
@@ -449,20 +476,33 @@ export class M3Dialog extends LitElement {
     let branch: HTMLElement = topDialog;
 
     while (branch !== document.body) {
+      const parent = branch.parentElement;
+      if (parent instanceof HTMLElement) {
+        for (const sibling of Array.from(parent.children) as HTMLElement[]) {
+          if (sibling !== branch) {
+            targets.add(sibling);
+          }
+        }
+
+        branch = parent;
+        continue;
+      }
+
       const root = branch.getRootNode();
-      const parent =
-        branch.parentElement ?? (root instanceof ShadowRoot ? root.host : null);
-      if (!(parent instanceof HTMLElement)) {
+      if (
+        !(root instanceof ShadowRoot) ||
+        !(root.host instanceof HTMLElement)
+      ) {
         break;
       }
 
-      for (const sibling of Array.from(parent.children) as HTMLElement[]) {
+      for (const sibling of Array.from(root.children) as HTMLElement[]) {
         if (sibling !== branch) {
           targets.add(sibling);
         }
       }
 
-      branch = parent;
+      branch = root.host;
     }
 
     return targets;

--- a/packages/m3-dialog/src/m3-dialog.ts
+++ b/packages/m3-dialog/src/m3-dialog.ts
@@ -1,108 +1,492 @@
-import { LitElement, html } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { LitElement, html, nothing } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
 import { m3DialogStyles } from './m3-dialog.styles.js';
 
+/** The action that initiated a dialog close request. */
+export type M3DialogCloseReason =
+  'action' | 'escape' | 'programmatic' | 'scrim';
+
+export interface M3DialogCloseDetail {
+  reason: M3DialogCloseReason;
+}
+
+const focusableSelector = [
+  'a[href]',
+  'area[href]',
+  'button:not([disabled])',
+  'input:not([disabled]):not([type="hidden"])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  'iframe',
+  'object',
+  'embed',
+  '[contenteditable]:not([contenteditable="false"])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+let dialogInstanceCount = 0;
+
+function getDeepActiveElement(
+  root: Document | ShadowRoot = document,
+): Element | null {
+  let activeElement = root.activeElement;
+
+  while (activeElement?.shadowRoot?.activeElement) {
+    activeElement = activeElement.shadowRoot.activeElement;
+  }
+
+  return activeElement;
+}
+
+function isFocusable(element: HTMLElement): boolean {
+  return (
+    !element.matches('[disabled], [inert], [aria-hidden="true"]') &&
+    element.getClientRects().length > 0 &&
+    getComputedStyle(element).visibility !== 'hidden'
+  );
+}
+
 /**
- * Material Design 3 Dialog Component
+ * Material Design 3 modal dialog.
  *
- * A modal dialog following Material Design 3 specifications.
+ * `m3-dialog` is deliberately a self-contained modal primitive. It does not
+ * require a framework dialog service: opening it establishes focus and page
+ * containment, and closing it restores the previous focus when possible.
  *
- * @fires dialog-open - Fired when the dialog opens
- * @fires dialog-close - Fired when the dialog closes
+ * @fires dialog-open - Fired after the dialog becomes modal.
+ * @fires dialog-request-close - A cancelable close request. Detail contains a close reason.
+ * @fires dialog-close - Fired after the dialog closes. Detail contains a close reason.
  *
- * @slot - Default slot for dialog body content
- * @slot icon - Optional icon displayed above the headline
- * @slot actions - Action buttons at the bottom
- *
- * @cssprop --md-sys-color-surface-container-high - Dialog surface color
- * @cssprop --md-sys-color-on-surface - Text color
+ * @slot - Dialog body content.
+ * @slot icon - An optional icon above the headline.
+ * @slot actions - Dialog actions.
  */
 @customElement('m3-dialog')
 export class M3Dialog extends LitElement {
   static styles = m3DialogStyles;
 
-  /** Whether the dialog is open */
+  private static readonly openDialogs: M3Dialog[] = [];
+  private static readonly inertStates = new Map<HTMLElement, boolean>();
+  private static pageStyleSnapshot:
+    { bodyOverflow: string; documentOverflow: string } | undefined;
+  private static bodyObserver: MutationObserver | undefined;
+
+  /** Whether the dialog is open. Prefer show(), close(), or requestClose() for lifecycle events. */
   @property({ type: Boolean, reflect: true }) open = false;
 
-  /** Headline text */
+  /** Text used for the generated dialog heading and accessible name. */
   @property({ type: String }) headline = '';
 
-  /** Close dialog when clicking the scrim */
+  /** Whether a scrim click requests close. */
   @property({ type: Boolean, attribute: 'close-on-scrim' }) closeOnScrim = true;
 
+  /** Whether Escape requests close. */
+  @property({ type: Boolean, attribute: 'close-on-escape' }) closeOnEscape =
+    true;
+
+  /** An external element ID that labels the dialog, overriding its headline. */
+  @property({ type: String, attribute: 'aria-labelledby' }) ariaLabelledBy:
+    string | null = null;
+
+  /** An external element ID that describes the dialog, overriding its body content. */
+  @property({ type: String, attribute: 'aria-describedby' }) ariaDescribedBy:
+    string | null = null;
+
+  @state() private hasDescription = false;
+
+  private readonly instanceId = ++dialogInstanceCount;
+  private readonly headlineId = `m3-dialog-headline-${this.instanceId}`;
+  private readonly descriptionId = `m3-dialog-description-${this.instanceId}`;
+  private opener: HTMLElement | null = null;
+  private closeReason: M3DialogCloseReason = 'programmatic';
+
+  connectedCallback() {
+    super.connectedCallback();
+
+    if (this.open) {
+      this.activate();
+    }
+  }
+
+  disconnectedCallback() {
+    this.deactivate(false);
+    super.disconnectedCallback();
+  }
+
   render() {
+    const labelledBy =
+      this.ariaLabelledBy?.trim() ||
+      (this.headline ? this.headlineId : undefined);
+    const describedBy =
+      this.ariaDescribedBy?.trim() ||
+      (this.hasDescription ? this.descriptionId : undefined);
+
     return html`
-      <div class="scrim" ?open=${this.open} @click=${this._handleScrimClick}></div>
-      <div class="dialog-container">
+      <div
+        class="scrim"
+        ?open=${this.open}
+        @click=${this.handleScrimClick}
+      ></div>
+      <div class="dialog-container" ?open=${this.open}>
         <div
           class="dialog"
           ?open=${this.open}
           role="dialog"
-          aria-modal="true"
-          aria-label=${this.headline || ''}
-          @keydown=${this._handleKeyDown}
+          tabindex="-1"
+          aria-modal=${this.open ? 'true' : nothing}
+          aria-hidden=${this.open ? nothing : 'true'}
+          aria-labelledby=${labelledBy ?? nothing}
+          aria-describedby=${describedBy ?? nothing}
         >
-          <div class="icon-slot">
-            <slot name="icon"></slot>
+          <div class="icon-slot"><slot name="icon"></slot></div>
+          ${this.headline ? html`<h2 class="headline" id=${this.headlineId}>${this.headline}</h2>` : nothing}
+          <div class="content" id=${this.descriptionId}>
+            <slot @slotchange=${this.handleContentSlotChange}></slot>
           </div>
-          ${this.headline ? html`<h2 class="headline">${this.headline}</h2>` : ''}
-          <div class="content">
-            <slot></slot>
-          </div>
-          <div class="actions">
-            <slot name="actions"></slot>
-          </div>
+          <div class="actions"><slot name="actions"></slot></div>
         </div>
       </div>
     `;
   }
 
   updated(changedProperties: Map<string, unknown>) {
-    if (changedProperties.has('open')) {
-      if (this.open) {
-        this._onOpen();
-      } else if (changedProperties.get('open') === true) {
-        this._onClose();
-      }
+    if (!changedProperties.has('open')) {
+      return;
+    }
+
+    if (this.open) {
+      this.activate();
+    } else if (changedProperties.get('open') === true) {
+      this.deactivate();
     }
   }
 
-  private _onOpen() {
-    this.dispatchEvent(new CustomEvent('dialog-open', { bubbles: true, composed: true }));
-    // Trap focus
-    requestAnimationFrame(() => {
-      const firstFocusable = this.shadowRoot?.querySelector<HTMLElement>(
-        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-      );
-      firstFocusable?.focus();
+  /** Opens the dialog and returns after Lit has rendered the open state. */
+  async show(): Promise<void> {
+    this.open = true;
+    await this.updateComplete;
+  }
+
+  /**
+   * Requests a close. Consumers can prevent `dialog-request-close` to keep
+   * the dialog open. Use `close('action')` for a button that completed an
+   * action; action buttons are otherwise ordinary slotted controls.
+   */
+  close(reason: M3DialogCloseReason = 'programmatic'): boolean {
+    return this.requestClose(reason);
+  }
+
+  /** Dispatches the cancelable close request and closes when it is accepted. */
+  requestClose(reason: M3DialogCloseReason): boolean {
+    if (!this.open) {
+      return false;
+    }
+
+    const accepted = this.dispatchEvent(
+      new CustomEvent<M3DialogCloseDetail>('dialog-request-close', {
+        bubbles: true,
+        composed: true,
+        cancelable: true,
+        detail: { reason },
+      }),
+    );
+
+    if (!accepted) {
+      return false;
+    }
+
+    this.closeReason = reason;
+    this.open = false;
+    return true;
+  }
+
+  private activate() {
+    if (M3Dialog.openDialogs.includes(this)) {
+      return;
+    }
+
+    const activeElement = getDeepActiveElement();
+    this.opener =
+      activeElement instanceof HTMLElement && !this.contains(activeElement)
+        ? activeElement
+        : null;
+    M3Dialog.openDialogs.push(this);
+
+    M3Dialog.updatePageContainment();
+    this.dispatchEvent(
+      new CustomEvent('dialog-open', {
+        bubbles: true,
+        composed: true,
+        detail: { opener: this.opener },
+      }),
+    );
+
+    void this.updateComplete.then(() => {
+      requestAnimationFrame(() => {
+        if (this.open && M3Dialog.topDialog === this) {
+          this.focusInitial();
+        }
+      });
     });
   }
 
-  private _onClose() {
-    this.dispatchEvent(new CustomEvent('dialog-close', { bubbles: true, composed: true }));
-  }
+  private deactivate(restoreFocus = true) {
+    const dialogIndex = M3Dialog.openDialogs.indexOf(this);
 
-  private _handleScrimClick() {
-    if (this.closeOnScrim) {
-      this.open = false;
+    if (dialogIndex === -1) {
+      return;
+    }
+
+    M3Dialog.openDialogs.splice(dialogIndex, 1);
+    M3Dialog.updatePageContainment();
+
+    const reason = this.closeReason;
+    this.closeReason = 'programmatic';
+    this.dispatchEvent(
+      new CustomEvent<M3DialogCloseDetail>('dialog-close', {
+        bubbles: true,
+        composed: true,
+        detail: { reason },
+      }),
+    );
+
+    if (restoreFocus) {
+      this.restoreFocus();
     }
   }
 
-  private _handleKeyDown(e: KeyboardEvent) {
-    if (e.key === 'Escape') {
-      e.preventDefault();
-      this.open = false;
+  private handleScrimClick() {
+    if (this.closeOnScrim && M3Dialog.topDialog === this) {
+      this.requestClose('scrim');
     }
   }
 
-  /** Opens the dialog */
-  show() {
-    this.open = true;
+  private handleContentSlotChange(event: Event) {
+    const slot = event.target as HTMLSlotElement;
+    this.hasDescription = slot
+      .assignedNodes({ flatten: true })
+      .some(
+        (node) =>
+          node.nodeType === Node.ELEMENT_NODE || node.textContent?.trim(),
+      );
   }
 
-  /** Closes the dialog */
-  close() {
-    this.open = false;
+  private focusInitial() {
+    const focusableElements = this.getFocusableElements();
+    const autofocusElement = focusableElements.find((element) =>
+      element.hasAttribute('autofocus'),
+    );
+    (autofocusElement ?? focusableElements[0] ?? this.dialogElement)?.focus({
+      preventScroll: true,
+    });
+  }
+
+  private restoreFocus() {
+    if (!this.opener?.isConnected) {
+      return;
+    }
+
+    const activeDialog = M3Dialog.topDialog;
+    if (activeDialog && !activeDialog.contains(this.opener)) {
+      activeDialog.focusInitial();
+      return;
+    }
+
+    this.opener.focus({ preventScroll: true });
+  }
+
+  private get dialogElement(): HTMLElement | null {
+    return this.shadowRoot?.querySelector<HTMLElement>('.dialog') ?? null;
+  }
+
+  /** Finds focusable descendants across the light DOM and open component shadows. */
+  private getFocusableElements(): HTMLElement[] {
+    const focusableElements: HTMLElement[] = [];
+    const visited = new Set<Element>();
+
+    const visit = (root: ParentNode) => {
+      for (const element of Array.from(root.children)) {
+        if (
+          visited.has(element) ||
+          (element instanceof M3Dialog && element !== this)
+        ) {
+          continue;
+        }
+
+        visited.add(element);
+        if (
+          element instanceof HTMLElement &&
+          element.matches(focusableSelector) &&
+          isFocusable(element)
+        ) {
+          focusableElements.push(element);
+        }
+
+        visit(element);
+        if (element.shadowRoot) {
+          visit(element.shadowRoot);
+        }
+      }
+    };
+
+    visit(this);
+    return focusableElements;
+  }
+
+  private containsComposedTarget(event: FocusEvent): boolean {
+    return event.composedPath().includes(this);
+  }
+
+  private handleTabKey(event: KeyboardEvent) {
+    const focusableElements = this.getFocusableElements();
+    if (focusableElements.length === 0) {
+      event.preventDefault();
+      this.dialogElement?.focus({ preventScroll: true });
+      return;
+    }
+
+    const activeElement = getDeepActiveElement();
+    const activeIndex = activeElement
+      ? focusableElements.indexOf(activeElement as HTMLElement)
+      : -1;
+    const nextElement = event.shiftKey
+      ? focusableElements.at(-1)!
+      : focusableElements[0];
+
+    if (
+      activeIndex === -1 ||
+      (event.shiftKey && activeIndex === 0) ||
+      (!event.shiftKey && activeIndex === focusableElements.length - 1)
+    ) {
+      event.preventDefault();
+      nextElement.focus({ preventScroll: true });
+    }
+  }
+
+  private static get topDialog(): M3Dialog | undefined {
+    return M3Dialog.openDialogs.at(-1);
+  }
+
+  private static updatePageContainment() {
+    const topDialog = M3Dialog.topDialog;
+
+    if (!topDialog) {
+      for (const [element, wasInert] of M3Dialog.inertStates) {
+        element.inert = wasInert;
+      }
+      M3Dialog.inertStates.clear();
+      M3Dialog.bodyObserver?.disconnect();
+      M3Dialog.bodyObserver = undefined;
+
+      if (M3Dialog.pageStyleSnapshot) {
+        document.body.style.overflow = M3Dialog.pageStyleSnapshot.bodyOverflow;
+        document.documentElement.style.overflow =
+          M3Dialog.pageStyleSnapshot.documentOverflow;
+        M3Dialog.pageStyleSnapshot = undefined;
+      }
+
+      document.removeEventListener(
+        'keydown',
+        M3Dialog.handleDocumentKeyDown,
+        true,
+      );
+      document.removeEventListener(
+        'focusin',
+        M3Dialog.handleDocumentFocusIn,
+        true,
+      );
+      return;
+    }
+
+    if (!M3Dialog.pageStyleSnapshot) {
+      M3Dialog.pageStyleSnapshot = {
+        bodyOverflow: document.body.style.overflow,
+        documentOverflow: document.documentElement.style.overflow,
+      };
+      document.body.style.overflow = 'hidden';
+      document.documentElement.style.overflow = 'hidden';
+      document.addEventListener(
+        'keydown',
+        M3Dialog.handleDocumentKeyDown,
+        true,
+      );
+      document.addEventListener(
+        'focusin',
+        M3Dialog.handleDocumentFocusIn,
+        true,
+      );
+      M3Dialog.bodyObserver = new MutationObserver(() =>
+        M3Dialog.updatePageContainment(),
+      );
+      M3Dialog.bodyObserver.observe(document.body, {
+        childList: true,
+        subtree: true,
+      });
+    }
+
+    const inertTargets = M3Dialog.getInertTargets(topDialog);
+    for (const [element, wasInert] of M3Dialog.inertStates) {
+      if (!inertTargets.has(element)) {
+        element.inert = wasInert;
+      }
+    }
+
+    for (const element of inertTargets) {
+      if (!M3Dialog.inertStates.has(element)) {
+        M3Dialog.inertStates.set(element, element.inert);
+      }
+      element.inert = true;
+    }
+  }
+
+  /**
+   * Inert every sibling branch on the route from the active dialog to body.
+   * This works both for a body-level dialog and for a dialog rendered inside a
+   * framework application root without making an ancestor of the dialog inert.
+   */
+  private static getInertTargets(topDialog: M3Dialog): Set<HTMLElement> {
+    const targets = new Set<HTMLElement>();
+    let branch: HTMLElement = topDialog;
+
+    while (branch !== document.body) {
+      const root = branch.getRootNode();
+      const parent =
+        branch.parentElement ?? (root instanceof ShadowRoot ? root.host : null);
+      if (!(parent instanceof HTMLElement)) {
+        break;
+      }
+
+      for (const sibling of Array.from(parent.children) as HTMLElement[]) {
+        if (sibling !== branch) {
+          targets.add(sibling);
+        }
+      }
+
+      branch = parent;
+    }
+
+    return targets;
+  }
+
+  private static handleDocumentKeyDown(event: KeyboardEvent) {
+    const topDialog = M3Dialog.topDialog;
+    if (!topDialog) {
+      return;
+    }
+
+    if (event.key === 'Escape' && topDialog.closeOnEscape) {
+      event.preventDefault();
+      topDialog.requestClose('escape');
+    } else if (event.key === 'Tab') {
+      topDialog.handleTabKey(event);
+    }
+  }
+
+  private static handleDocumentFocusIn(event: FocusEvent) {
+    const topDialog = M3Dialog.topDialog;
+    if (topDialog && !topDialog.containsComposedTarget(event)) {
+      topDialog.focusInitial();
+    }
   }
 }
 

--- a/vitest.browser.config.ts
+++ b/vitest.browser.config.ts
@@ -24,6 +24,7 @@ const browserPorts: Record<string, number> = {
   'm3-menu': 63_328,
   'm3-fab-menu': 63_329,
   'm3-split-button': 63_330,
+  'm3-dialog': 63_331,
 };
 
 const port = browserPorts[workspaceName];


### PR DESCRIPTION
Closes #8

## Summary

- Rebuild `m3-dialog` as a stack-aware modal primitive with focus placement, Tab/Shift+Tab containment, opener restoration, Escape and scrim handling, background inertness, and scroll containment.
- Replace the empty/redundant ARIA label with generated heading/content relationships and canonical `aria-labelledby` / `aria-describedby` hooks.
- Add the cancelable `dialog-request-close` lifecycle event and documented close reasons (`escape`, `scrim`, `action`, `programmatic`); retain declarative `open` bindings without compatibility aliases.
- Add an Angular docs demo that displays close reason and uses `close('action')`, plus complete package API documentation.

## Acceptance mapping

- **Focus cannot leave the modal:** Chromium tests cover initial focus, `[autofocus]`, regular and shadow-root slotted controls, Tab and Shift+Tab wrapping, and no-focusable fallback.
- **Slotted controls participate:** focus traversal recursively includes light DOM and open component shadow roots; tested with `m3-button`.
- **Consistent, cancelable dismissal:** topmost Escape and scrim create cancelable `dialog-request-close` events; post-close events include a typed close reason.
- **Focus restoration:** tests cover a connected opener and an opener removed before close.
- **Accessible naming:** generated `aria-labelledby` / `aria-describedby` omit empty attributes; a Chromium axe assertion covers the rendered dialog.
- **Containment and multiple dialogs:** sibling branches from the dialog to `body` use native `inert`, scrolling is locked/restored, and tests verify topmost-only Escape plus restoration after the final close.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (including 8 real Chromium dialog interaction/accessibility tests)
- `pnpm tokens:check`
- `pnpm exec turbo run build`
- `pnpm audit:prod`
- `pnpm smoke:packages`
- `pnpm smoke:svelte-vite`
- `pnpm verify:package-licenses`