### PR TITLE
feat(forms): adopt native form-associated controls

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -67,11 +67,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # Chromium is installed from the Playwright version locked in
-      # pnpm-lock.yaml. `--with-deps` makes the Ubuntu system dependencies
-      # explicit rather than relying on the image's preinstalled browser.
-      - name: Install Playwright Chromium
-        run: pnpm exec playwright install --with-deps chromium
+      # Each supported engine is installed from the Playwright version locked
+      # in pnpm-lock.yaml. `--with-deps` makes Ubuntu system dependencies
+      # explicit rather than relying on the image's preinstalled browsers.
+      - name: Install supported Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium firefox webkit
 
       - name: Lint
         run: pnpm lint

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ This repository contains a collection of web components that can be used in any 
 - **[Publishing Guide](PUBLISHING.md)** - How to publish web component packages
 - **[Design Token Contract](tokens/README.md)** - Shared token naming, themes, compatibility, and validation
 - **[Motion System](docs/MOTION.md)** - Motion roles, reduced-motion behavior, and component inventory
+- **[Form-associated controls](docs/FORM_ASSOCIATED_CONTROLS.md)** - Native form, validation, migration, and browser-support contract
 - **[Web Components](#-web-components)** - List of available components
 - **[Component Packages](#-demo-applications)** - Individual package documentation
 

--- a/docs/FORM_ASSOCIATED_CONTROLS.md
+++ b/docs/FORM_ASSOCIATED_CONTROLS.md
@@ -8,8 +8,9 @@ contract. They participate in the owner form directly through
 
 ## Native behaviour
 
-- `name` and `value` contribute to `FormData` as native successful controls.
-  Unchecked checkboxes, switches, and radios do not contribute a value.
+- Checkbox, radio, switch, slider, text-field, and search-bar `name`/`value`
+  properties contribute to `FormData` as native successful controls. Unchecked
+  checkboxes, switches, and radios do not contribute a value.
 - The host's native `form` attribute selects an external form. The `form`
   property returns the current owner form.
 - Disabled fieldsets disable descendants, remove their values from `FormData`,
@@ -20,8 +21,11 @@ contract. They participate in the owner form directly through
 - Form reset restores the initial component value/state. Browser history and
   autofill restoration use `formStateRestoreCallback` without synthetic input
   or change events.
-- A submit button calls its owner form exactly once; its `name`/`value` is
-  included only for that submission. A reset button calls its owner form once.
+- A submit button calls its owner form exactly once and a reset button calls
+  its owner form once. The platform has no custom-element submitter API:
+  `requestSubmit()` therefore exposes `SubmitEvent.submitter` as `null`, and
+  button `name`/`value` are not added to `FormData`. The library does not fake
+  submitter data with a `formdata` listener.
 
 ## Clean-break migration
 
@@ -57,7 +61,8 @@ component `form` property is gone: `control.form` is now the owner
 ## Browser support and fallback
 
 Form-associated custom elements require Chromium 77+, Firefox 98+, or Safari
-16.4+. In an older browser the controls still render and remain interactive,
+16.4+. The browser integration suite runs on Playwright Chromium, Firefox,
+and WebKit. In an older browser the controls still render and remain interactive,
 but the browser cannot supply equivalent `FormData`, validation, reset, or
 state-restoration semantics. There is deliberately no hidden-input fallback:
 it would produce different ownership, disabled-fieldset, validation, and

--- a/docs/FORM_ASSOCIATED_CONTROLS.md
+++ b/docs/FORM_ASSOCIATED_CONTROLS.md
@@ -1,0 +1,65 @@
+# Form-associated controls
+
+`m3-button`, `m3-checkbox`, `m3-radio-button`, `m3-switch`, `m3-slider`,
+`m3-text-field`, and `m3-search-bar` now use the browser's
+[form-associated custom element](https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements-face-example)
+contract. They participate in the owner form directly through
+`ElementInternals`; they do not render hidden `<input>` mirrors.
+
+## Native behaviour
+
+- `name` and `value` contribute to `FormData` as native successful controls.
+  Unchecked checkboxes, switches, and radios do not contribute a value.
+- The host's native `form` attribute selects an external form. The `form`
+  property returns the current owner form.
+- Disabled fieldsets disable descendants, remove their values from `FormData`,
+  and prevent interaction.
+- `required` is supported by checkbox, switch, radio groups, text field, and
+  search bar. `checkValidity()` and `reportValidity()` delegate to the native
+  form-validation lifecycle.
+- Form reset restores the initial component value/state. Browser history and
+  autofill restoration use `formStateRestoreCallback` without synthetic input
+  or change events.
+- A submit button calls its owner form exactly once; its `name`/`value` is
+  included only for that submission. A reset button calls its owner form once.
+
+## Clean-break migration
+
+The component-specific `button-click`, `checkbox-change`, `radio-change`,
+`switch-change`, `slider-input`, `slider-change`, `textfield-input`,
+`textfield-change`, `search-input`, `search-submit`, and `search-clear`
+events are removed for these controls. Listen to the host's native events and
+read its public properties instead:
+
+```js
+control.addEventListener('input', () => {
+  console.log(control.value, control.checked);
+});
+control.addEventListener('change', () => {
+  save(control.value);
+});
+```
+
+Use a real `<form>` and the platform APIs for submission rather than custom
+submit events:
+
+```js
+form.addEventListener('submit', (event) => {
+  event.preventDefault();
+  const data = new FormData(form);
+});
+```
+
+The `form` **attribute** remains native HTML. The former string-valued
+component `form` property is gone: `control.form` is now the owner
+`HTMLFormElement | null`, matching native controls.
+
+## Browser support and fallback
+
+Form-associated custom elements require Chromium 77+, Firefox 98+, or Safari
+16.4+. In an older browser the controls still render and remain interactive,
+but the browser cannot supply equivalent `FormData`, validation, reset, or
+state-restoration semantics. There is deliberately no hidden-input fallback:
+it would produce different ownership, disabled-fieldset, validation, and
+submitter behaviour. Use a supported browser for forms that contain these
+components.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "smoke:packages": "node scripts/smoke-packages.mjs",
     "smoke:svelte-vite": "pnpm --filter @banegasn/svelte-components build && node scripts/smoke-svelte-vite.mjs",
     "audit:prod": "pnpm audit --prod --audit-level=moderate",
-    "test:browser:install": "playwright install chromium",
+    "test:browser:install": "playwright install chromium firefox webkit",
     "format": "prettier --write .",
     "clean": "turbo run clean && rm -rf node_modules .turbo",
     "publish:npm": "bash scripts/publish-unpublished.sh npm",

--- a/packages/m3-button/README.md
+++ b/packages/m3-button/README.md
@@ -280,8 +280,8 @@ Show loading spinner while processing:
 | `icon-only` | `boolean` | `false` | Button contains only an icon (hides label) |
 | `type` | `'button' \| 'submit' \| 'reset'` | `'button'` | Button type for form handling |
 | `aria-label` | `string` | `undefined` | Accessible label (required for icon-only) |
-| `name` | `string` | `undefined` | Name for form submission |
-| `value` | `string` | `undefined` | Value for form submission |
+| `name` | `string` | `undefined` | Button identifier; not a native custom-element submitter value |
+| `value` | `string` | `undefined` | Button identifier; not added to `FormData` |
 | `form` | `HTMLFormElement \| null` | `null` | Current owner form; set the native `form` attribute to associate by ID |
 
 ### Events

--- a/packages/m3-button/README.md
+++ b/packages/m3-button/README.md
@@ -64,7 +64,7 @@ yarn add @banegasn/m3-button
 
   <script>
     const btn = document.getElementById('loading-btn');
-    btn.addEventListener('button-click', async () => {
+    btn.addEventListener('click', async () => {
       btn.loading = true;
       await new Promise(r => setTimeout(r, 2000));
       btn.loading = false;
@@ -231,7 +231,7 @@ Show loading spinner while processing:
 
 <script>
   const btn = document.getElementById('submit-btn');
-  btn.addEventListener('button-click', async () => {
+  btn.addEventListener('click', async () => {
     btn.loading = true;
     try {
       await submitForm();
@@ -282,13 +282,15 @@ Show loading spinner while processing:
 | `aria-label` | `string` | `undefined` | Accessible label (required for icon-only) |
 | `name` | `string` | `undefined` | Name for form submission |
 | `value` | `string` | `undefined` | Value for form submission |
-| `form` | `string` | `undefined` | Associates button with a form by ID |
+| `form` | `HTMLFormElement \| null` | `null` | Current owner form; set the native `form` attribute to associate by ID |
 
 ### Events
 
-| Event | Detail | Description |
-|-------|--------|-------------|
-| `button-click` | `{ variant: string, size: string, shape: string, padding: string, name?: string, value?: string }` | Fired when button is clicked (not fired when disabled or loading) |
+| Event | Description |
+|-------|-------------|
+| `click` | Native composed click event. Submit and reset types act on the owner form once. |
+
+See the [form-associated control migration guide](../../docs/FORM_ASSOCIATED_CONTROLS.md).
 
 ### Slots
 
@@ -413,7 +415,7 @@ m3-button.large {
   import '@banegasn/m3-button';
   
   const btn = document.getElementById('my-btn');
-  btn.addEventListener('button-click', (e) => {
+  btn.addEventListener('click', (e) => {
     console.log('Button clicked!', e.detail);
   });
 </script>
@@ -432,7 +434,7 @@ function App() {
   return (
     <m3-button 
       variant="filled"
-      onbutton-click={handleClick}
+      onClick={handleClick}
     >
       Click me
     </m3-button>
@@ -452,7 +454,7 @@ import '@banegasn/m3-button';
   template: `
     <m3-button 
       variant="filled"
-      (button-click)="handleClick($event)"
+      (click)="handleClick($event)"
     >
       Click me
     </m3-button>
@@ -472,7 +474,7 @@ export class AppComponent {
 <template>
   <m3-button 
     variant="filled"
-    @button-click="handleClick"
+    @click="handleClick"
   >
     Click me
   </m3-button>
@@ -500,7 +502,7 @@ const handleClick = (event) => {
 
 <m3-button 
   variant="filled"
-  on:button-click={handleClick}
+  on:click={handleClick}
 >
   Click me
 </m3-button>
@@ -608,14 +610,14 @@ const handleClick = (event) => {
   <script>
     // Add click handlers
     document.querySelectorAll('m3-button').forEach(btn => {
-      btn.addEventListener('button-click', (e) => {
+      btn.addEventListener('click', (e) => {
         console.log('Button clicked:', e.detail);
       });
     });
 
     // Loading demo
     const loadingBtn = document.getElementById('loading-btn');
-    loadingBtn.addEventListener('button-click', async () => {
+    loadingBtn.addEventListener('click', async () => {
       loadingBtn.loading = true;
       await new Promise(resolve => setTimeout(resolve, 2000));
       loadingBtn.loading = false;

--- a/packages/m3-button/src/m3-button.ts
+++ b/packages/m3-button/src/m3-button.ts
@@ -1,5 +1,6 @@
-import { LitElement, html } from 'lit';
+import { html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import { FormAssociatedElement } from '@banegasn/m3-form-associated';
 import { m3ButtonStyles } from './m3-button.styles.js';
 
 /**
@@ -8,7 +9,8 @@ import { m3ButtonStyles } from './m3-button.styles.js';
  * A flexible button component following Material Design 3 specifications with
  * support for multiple variants, icons, and accessibility features.
  * 
- * @fires button-click - Fired when the button is clicked
+ * Native click semantics are exposed on the host. Submit and reset types act
+ * on the owner form selected by the host's native `form` attribute.
  * 
  * @slot - Default slot for button label text
  * @slot icon - Optional icon to display before the label
@@ -27,8 +29,9 @@ import { m3ButtonStyles } from './m3-button.styles.js';
  * @cssprop --md-sys-color-outline - Border color for outlined variant
  */
 @customElement('m3-button')
-export class M3Button extends LitElement {
+export class M3Button extends FormAssociatedElement {
   static styles = m3ButtonStyles;
+  static readonly formAssociated = true;
 
   /**
    * Button variant style
@@ -95,7 +98,7 @@ export class M3Button extends LitElement {
   /**
    * Button type attribute for form submission
    */
-  @property({ type: String })
+  @property({ type: String, reflect: true })
   type: 'button' | 'submit' | 'reset' = 'button';
 
   /**
@@ -107,31 +110,25 @@ export class M3Button extends LitElement {
   /**
    * Name attribute for form submission
    */
-  @property({ type: String })
+  @property({ type: String, reflect: true })
   name: string | null = null;
 
   /**
    * Value attribute for form submission
    */
-  @property({ type: String })
+  @property({ type: String, reflect: true })
   value: string | null = null;
 
-  /**
-   * Form attribute to associate button with a form
-   */
-  @property({ type: String })
-  form: string | null = null;
+  private _isSubmitting = false;
+  private _associatedForm: HTMLFormElement | null = null;
 
   render() {
     return html`
       <button
-        type=${this.type}
-        ?disabled=${this.disabled || this.loading}
+        type="button"
+        ?disabled=${this.isFormDisabled || this.loading}
         aria-label=${this.ariaLabel || ''}
         aria-busy=${this.loading}
-        name=${this.name || ''}
-        value=${this.value || ''}
-        form=${this.form || ''}
         @click=${this._handleClick}
       >
         ${this.loading ? html`<span class="loading-spinner"></span>` : ''}
@@ -154,24 +151,45 @@ export class M3Button extends LitElement {
   }
 
   private _handleClick(e: MouseEvent) {
-    if (this.disabled || this.loading) {
+    if (this.isFormDisabled || this.loading) {
       e.preventDefault();
       e.stopPropagation();
       return;
     }
 
-    this.dispatchEvent(new CustomEvent('button-click', {
-      bubbles: true,
-      composed: true,
-      detail: {
-        variant: this.variant,
-        size: this.size,
-        shape: this.shape,
-        padding: this.padding,
-        name: this.name,
-        value: this.value
-      }
-    }));
+    this._performFormAction();
+  }
+
+  private _performFormAction(): void {
+    if (this.type === 'submit') {
+      this._isSubmitting = true;
+      this.form?.requestSubmit();
+      queueMicrotask(() => {
+        this._isSubmitting = false;
+      });
+    } else if (this.type === 'reset') {
+      this.form?.reset();
+    }
+  }
+
+  formAssociatedCallback(form: HTMLFormElement | null): void {
+    this._associatedForm?.removeEventListener('formdata', this._handleFormData);
+    this._associatedForm = form;
+    form?.addEventListener('formdata', this._handleFormData);
+  }
+
+  private _handleFormData = (event: FormDataEvent): void => {
+    if (this._isSubmitting && this.name) {
+      event.formData.append(this.name, this.value ?? '');
+    }
+  };
+
+  protected resetFormControl(): void {
+    // Native buttons have no mutable form value to reset.
+  }
+
+  protected restoreFormControlState(_state: string | File | FormData | null): void {
+    // Native buttons have no restorable form state.
   }
 
   /**
@@ -186,6 +204,13 @@ export class M3Button extends LitElement {
    */
   blur() {
     this.shadowRoot?.querySelector('button')?.blur();
+  }
+
+  click(): void {
+    if (!this.isFormDisabled && !this.loading) {
+      super.click();
+      this._performFormAction();
+    }
   }
 }
 

--- a/packages/m3-button/src/m3-button.ts
+++ b/packages/m3-button/src/m3-button.ts
@@ -119,9 +119,6 @@ export class M3Button extends FormAssociatedElement {
   @property({ type: String, reflect: true })
   value: string | null = null;
 
-  private _isSubmitting = false;
-  private _associatedForm: HTMLFormElement | null = null;
-
   render() {
     return html`
       <button
@@ -162,27 +159,11 @@ export class M3Button extends FormAssociatedElement {
 
   private _performFormAction(): void {
     if (this.type === 'submit') {
-      this._isSubmitting = true;
       this.form?.requestSubmit();
-      queueMicrotask(() => {
-        this._isSubmitting = false;
-      });
     } else if (this.type === 'reset') {
       this.form?.reset();
     }
   }
-
-  formAssociatedCallback(form: HTMLFormElement | null): void {
-    this._associatedForm?.removeEventListener('formdata', this._handleFormData);
-    this._associatedForm = form;
-    form?.addEventListener('formdata', this._handleFormData);
-  }
-
-  private _handleFormData = (event: FormDataEvent): void => {
-    if (this._isSubmitting && this.name) {
-      event.formData.append(this.name, this.value ?? '');
-    }
-  };
 
   protected resetFormControl(): void {
     // Native buttons have no mutable form value to reset.

--- a/packages/m3-checkbox/README.md
+++ b/packages/m3-checkbox/README.md
@@ -64,7 +64,7 @@ yarn add @banegasn/m3-checkbox
 
   <script>
     document.querySelectorAll('m3-checkbox').forEach(cb => {
-      cb.addEventListener('checkbox-change', (e) => {
+      cb.addEventListener('change', (e) => {
         console.log('Checkbox changed:', e.detail);
       });
     });
@@ -101,9 +101,12 @@ import '@banegasn/m3-checkbox';
 
 ### Events
 
-| Event | Detail | Description |
-|-------|--------|-------------|
-| `checkbox-change` | `{ checked: boolean, indeterminate: boolean, name: string \| null, value: string \| null }` | Fired when the checkbox state changes |
+| Event | Description |
+|-------|-------------|
+| `input` | Native event fired when the checked state changes. |
+| `change` | Native event fired after the checked state is committed. |
+
+See the [form-associated control migration guide](../../docs/FORM_ASSOCIATED_CONTROLS.md).
 
 ### CSS Custom Properties
 
@@ -120,18 +123,18 @@ import '@banegasn/m3-checkbox';
 import '@banegasn/m3-checkbox';
 ```
 ```html
-<m3-checkbox [checked]="isChecked" (checkbox-change)="onCheckboxChange($event)"></m3-checkbox>
+<m3-checkbox [checked]="isChecked" (change)="onCheckboxChange($event)"></m3-checkbox>
 ```
 
 ### React
 ```jsx
 import '@banegasn/m3-checkbox';
-// <m3-checkbox checked={isChecked} oncheckbox-change={handleChange} />
+// <m3-checkbox checked={isChecked} onChange={handleChange} />
 ```
 
 ### Vue
 ```vue
-<m3-checkbox :checked="isChecked" @checkbox-change="handleChange" />
+<m3-checkbox :checked="isChecked" @change="handleChange" />
 ```
 
 ## Resources

--- a/packages/m3-checkbox/package.json
+++ b/packages/m3-checkbox/package.json
@@ -23,8 +23,9 @@
     "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist",
     "lint": "eslint src --max-warnings 0",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node ../../scripts/no-tests.mjs"
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json",
+    "test": "vitest run --config ../../vitest.browser.config.ts",
+    "test:watch": "vitest --config ../../vitest.browser.config.ts"
   },
   "repository": {
     "type": "git",
@@ -46,9 +47,16 @@
     "access": "public"
   },
   "dependencies": {
+    "@banegasn/m3-form-associated": "workspace:^",
     "lit": "^3.3.3"
   },
   "devDependencies": {
+    "@banegasn/m3-button": "workspace:^",
+    "@banegasn/m3-radio-button": "workspace:^",
+    "@banegasn/m3-search-bar": "workspace:^",
+    "@banegasn/m3-slider": "workspace:^",
+    "@banegasn/m3-switch": "workspace:^",
+    "@banegasn/m3-text-field": "workspace:^",
     "typescript": "^5.9.3"
   }
 }

--- a/packages/m3-checkbox/src/m3-checkbox.ts
+++ b/packages/m3-checkbox/src/m3-checkbox.ts
@@ -1,5 +1,6 @@
-import { LitElement, html } from 'lit';
+import { html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
+import { FormAssociatedElement } from '@banegasn/m3-form-associated';
 import { m3CheckboxStyles } from './m3-checkbox.styles.js';
 
 /**
@@ -7,22 +8,25 @@ import { m3CheckboxStyles } from './m3-checkbox.styles.js';
  * 
  * A checkbox component following Material Design 3 specifications.
  * 
- * @fires checkbox-change - Fired when the checkbox state changes
+ * Emits native `input` and `change` events when the checked state changes.
  */
 @customElement('m3-checkbox')
-export class M3Checkbox extends LitElement {
+export class M3Checkbox extends FormAssociatedElement {
   static styles = m3CheckboxStyles;
+  static readonly formAssociated = true;
 
   @property({ type: Boolean, reflect: true }) checked = false;
   @property({ type: Boolean, reflect: true }) disabled = false;
   @property({ type: Boolean, reflect: true }) indeterminate = false;
-  @property({ type: String }) name: string | null = null;
-  @property({ type: String }) value: string | null = null;
-  @property({ type: String }) form: string | null = null;
+  @property({ type: String, reflect: true }) name: string | null = null;
+  @property({ type: String, reflect: true }) value: string | null = null;
+  @property({ type: Boolean, reflect: true }) required = false;
   @property({ type: String, attribute: 'aria-label' }) ariaLabel: string | null = null;
 
   @state() private _pressed = false;
   @state() private _hovered = false;
+  private _defaultChecked = false;
+  private _defaultIndeterminate = false;
 
   render() {
     return html`
@@ -30,9 +34,9 @@ export class M3Checkbox extends LitElement {
         class="checkbox-container"
         role="checkbox"
         aria-checked=${this.indeterminate ? 'mixed' : this.checked}
-        aria-disabled=${this.disabled}
+        aria-disabled=${this.isFormDisabled}
         aria-label=${this.ariaLabel || ''}
-        tabindex=${this.disabled ? -1 : 0}
+        tabindex=${this.isFormDisabled ? -1 : 0}
         @click=${this._handleClick}
         @keydown=${this._handleKeyDown}
         @keyup=${this._handleKeyUp}
@@ -42,8 +46,8 @@ export class M3Checkbox extends LitElement {
         @mouseup=${this._handleMouseUp}
       >
         <div class="state-layer"></div>
-        <div class="outline" ?checked=${this.checked} ?disabled=${this.disabled} ?indeterminate=${this.indeterminate}>
-          <div class="background" ?checked=${this.checked} ?disabled=${this.disabled} ?indeterminate=${this.indeterminate}>
+        <div class="outline" ?checked=${this.checked} ?disabled=${this.isFormDisabled} ?indeterminate=${this.indeterminate}>
+          <div class="background" ?checked=${this.checked} ?disabled=${this.isFormDisabled} ?indeterminate=${this.indeterminate}>
             ${this.indeterminate
               ? html`<svg class="icon" viewBox="0 0 18 18"><rect x="4" y="8" width="10" height="2" fill="currentColor"/></svg>`
               : this.checked
@@ -52,23 +56,21 @@ export class M3Checkbox extends LitElement {
           </div>
         </div>
       </div>
-      <input
-        type="checkbox"
-        ?checked=${this.checked}
-        ?disabled=${this.disabled}
-        .indeterminate=${this.indeterminate}
-        name=${this.name || ''}
-        value=${this.value || ''}
-        form=${this.form || ''}
-        aria-hidden="true"
-        tabindex="-1"
-        @change=${this._handleInputChange}
-      />
     `;
   }
 
+  firstUpdated(): void {
+    this._defaultChecked = this.checked;
+    this._defaultIndeterminate = this.indeterminate;
+    this._syncFormState();
+  }
+
+  updated(): void {
+    this._syncFormState();
+  }
+
   private _handleClick(e: MouseEvent) {
-    if (this.disabled) {
+    if (this.isFormDisabled) {
       e.preventDefault();
       e.stopPropagation();
       return;
@@ -77,7 +79,7 @@ export class M3Checkbox extends LitElement {
   }
 
   private _handleKeyDown(e: KeyboardEvent) {
-    if (this.disabled) return;
+    if (this.isFormDisabled) return;
     if (e.key === ' ' || e.key === 'Enter') {
       e.preventDefault();
       this._pressed = true;
@@ -85,7 +87,7 @@ export class M3Checkbox extends LitElement {
   }
 
   private _handleKeyUp(e: KeyboardEvent) {
-    if (this.disabled) return;
+    if (this.isFormDisabled) return;
     if (e.key === ' ' || e.key === 'Enter') {
       e.preventDefault();
       this._pressed = false;
@@ -94,7 +96,7 @@ export class M3Checkbox extends LitElement {
   }
 
   private _handleMouseEnter() {
-    if (!this.disabled) this._hovered = true;
+    if (!this.isFormDisabled) this._hovered = true;
   }
 
   private _handleMouseLeave() {
@@ -103,19 +105,11 @@ export class M3Checkbox extends LitElement {
   }
 
   private _handleMouseDown() {
-    if (!this.disabled) this._pressed = true;
+    if (!this.isFormDisabled) this._pressed = true;
   }
 
   private _handleMouseUp() {
     this._pressed = false;
-  }
-
-  private _handleInputChange(e: Event) {
-    const input = e.target as HTMLInputElement;
-    if (input.checked !== this.checked) {
-      this.checked = input.checked;
-      this.indeterminate = input.indeterminate;
-    }
   }
 
   private _toggle() {
@@ -126,23 +120,30 @@ export class M3Checkbox extends LitElement {
       this.checked = !this.checked;
     }
     
-    // Update internal input for form submission
-    const input = this.shadowRoot?.querySelector('input[type="checkbox"]') as HTMLInputElement;
-    if (input) {
-      input.checked = this.checked;
-      input.indeterminate = this.indeterminate;
-    }
+    this.emitInput();
+    this.emitChange();
+  }
 
-    this.dispatchEvent(new CustomEvent('checkbox-change', {
-      bubbles: true,
-      composed: true,
-      detail: {
-        checked: this.checked,
-        indeterminate: this.indeterminate,
-        name: this.name,
-        value: this.value
-      }
-    }));
+  private _syncFormState(): void {
+    const disabled = this.isFormDisabled;
+    this.setFormValue(!disabled && this.checked ? this.value ?? 'on' : null, this.checked ? 'checked' : 'unchecked');
+    this.setFormValidity(
+      !disabled && this.required && !this.checked ? { valueMissing: true } : {},
+      !disabled && this.required && !this.checked ? 'Please check this box.' : '',
+      this.shadowRoot?.querySelector<HTMLElement>('.checkbox-container') ?? undefined,
+    );
+  }
+
+  protected resetFormControl(): void {
+    this.checked = this._defaultChecked;
+    this.indeterminate = this._defaultIndeterminate;
+  }
+
+  protected restoreFormControlState(state: string | File | FormData | null): void {
+    if (typeof state === 'string') {
+      this.checked = state === 'checked';
+      this.indeterminate = false;
+    }
   }
 }
 

--- a/packages/m3-checkbox/src/m3-form-associated.test.ts
+++ b/packages/m3-checkbox/src/m3-form-associated.test.ts
@@ -1,0 +1,193 @@
+import { fixture, html, expect } from '@open-wc/testing';
+import { describe, it } from 'vitest';
+import '@banegasn/m3-button';
+import '@banegasn/m3-checkbox';
+import '@banegasn/m3-radio-button';
+import '@banegasn/m3-search-bar';
+import '@banegasn/m3-slider';
+import '@banegasn/m3-switch';
+import '@banegasn/m3-text-field';
+import type { M3Button } from '@banegasn/m3-button';
+import type { M3Checkbox } from './m3-checkbox.js';
+import type { M3RadioButton } from '@banegasn/m3-radio-button';
+import type { M3SearchBar } from '@banegasn/m3-search-bar';
+import type { M3Slider } from '@banegasn/m3-slider';
+import type { M3Switch } from '@banegasn/m3-switch';
+import type { M3TextField } from '@banegasn/m3-text-field';
+
+describe('form-associated controls', () => {
+  it('contributes each successful control to FormData without hidden inputs', async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form>
+        <m3-text-field name="title" value="Expressive"></m3-text-field>
+        <m3-checkbox name="terms" value="yes" checked></m3-checkbox>
+        <m3-radio-button name="theme" value="dark" checked></m3-radio-button>
+        <m3-switch name="alerts" value="enabled" checked></m3-switch>
+        <m3-slider name="volume" value="25"></m3-slider>
+        <m3-search-bar name="query" value="material"></m3-search-bar>
+      </form>
+    `);
+    await Promise.all(Array.from(form.querySelectorAll<HTMLElement>('*')).map((element) =>
+      'updateComplete' in element ? (element as HTMLElement & { updateComplete: Promise<unknown> }).updateComplete : Promise.resolve(),
+    ));
+
+    const data = new FormData(form);
+    expect(data.get('title')).to.equal('Expressive');
+    expect(data.get('terms')).to.equal('yes');
+    expect(data.get('theme')).to.equal('dark');
+    expect(data.get('alerts')).to.equal('enabled');
+    expect(data.get('volume')).to.equal('25');
+    expect(data.get('query')).to.equal('material');
+    expect(form.querySelectorAll('input')).to.have.length(0);
+  });
+
+  it('uses the host form attribute and excludes disabled fieldset descendants', async () => {
+    const container = await fixture<HTMLDivElement>(html`
+      <div>
+        <form id="owner"></form>
+        <m3-text-field form="owner" name="outside" value="owned"></m3-text-field>
+        <form id="disabled-owner"><fieldset disabled><m3-checkbox name="skip" checked></m3-checkbox></fieldset></form>
+      </div>
+    `);
+    const outside = container.querySelector<M3TextField>('m3-text-field')!;
+    const disabled = container.querySelector<M3Checkbox>('m3-checkbox')!;
+    await Promise.all([outside.updateComplete, disabled.updateComplete]);
+    expect(outside.form?.id).to.equal('owner');
+    expect(new FormData(container.querySelector<HTMLFormElement>('#owner')!).get('outside')).to.equal('owned');
+    expect(new FormData(container.querySelector<HTMLFormElement>('#disabled-owner')!).has('skip')).to.equal(false);
+  });
+
+  it('enforces required fields through native form validity', async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form><m3-text-field name="email" required></m3-text-field></form>
+    `);
+    const field = form.querySelector<M3TextField>('m3-text-field')!;
+    await field.updateComplete;
+    expect(form.checkValidity()).to.equal(false);
+    expect(field.validity.valueMissing).to.equal(true);
+    field.value = 'hello@example.test';
+    await field.updateComplete;
+    expect(field.validity.valid).to.equal(true);
+    expect(form.checkValidity()).to.equal(true);
+  });
+
+  it('resets defaults and restores browser form state without interaction events', async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form>
+        <m3-checkbox name="terms" checked></m3-checkbox>
+        <m3-text-field name="title" value="Initial"></m3-text-field>
+      </form>
+    `);
+    const checkbox = form.querySelector<M3Checkbox>('m3-checkbox')!;
+    const text = form.querySelector<M3TextField>('m3-text-field')!;
+    await Promise.all([checkbox.updateComplete, text.updateComplete]);
+    let changes = 0;
+    text.addEventListener('change', () => { changes += 1; });
+    checkbox.checked = false;
+    text.value = 'Edited';
+    await Promise.all([checkbox.updateComplete, text.updateComplete]);
+    form.reset();
+    await Promise.all([checkbox.updateComplete, text.updateComplete]);
+    expect(checkbox.checked).to.equal(true);
+    expect(text.value).to.equal('Initial');
+    text.formStateRestoreCallback('Restored');
+    await text.updateComplete;
+    expect(text.value).to.equal('Restored');
+    expect(changes).to.equal(0);
+  });
+
+  it('groups radios by owner form and emits a single native input/change pair', async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form>
+        <m3-radio-button name="theme" value="light" checked></m3-radio-button>
+        <m3-radio-button name="theme" value="dark"></m3-radio-button>
+      </form>
+    `);
+    const [light, dark] = Array.from(form.querySelectorAll<M3RadioButton>('m3-radio-button'));
+    await Promise.all([light.updateComplete, dark.updateComplete]);
+    let inputs = 0;
+    let changes = 0;
+    dark.addEventListener('input', () => { inputs += 1; });
+    dark.addEventListener('change', () => { changes += 1; });
+    dark.click();
+    await Promise.all([light.updateComplete, dark.updateComplete]);
+    expect(light.checked).to.equal(false);
+    expect(dark.checked).to.equal(true);
+    expect(inputs).to.equal(1);
+    expect(changes).to.equal(1);
+    expect(new FormData(form).get('theme')).to.equal('dark');
+  });
+
+  it('submits and resets through a form-associated button exactly once', async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form>
+        <m3-text-field name="title" value="Initial"></m3-text-field>
+        <m3-button type="submit" name="intent" value="save">Save</m3-button>
+        <m3-button type="reset">Reset</m3-button>
+      </form>
+    `);
+    const text = form.querySelector<M3TextField>('m3-text-field')!;
+    const [submit, reset] = Array.from(form.querySelectorAll<M3Button>('m3-button'));
+    await Promise.all([text.updateComplete, submit.updateComplete, reset.updateComplete]);
+    expect(submit.type).to.equal('submit');
+    expect(submit.form).to.equal(form);
+    let submits = 0;
+    let submitData: FormData | undefined;
+    form.addEventListener('submit', (event) => {
+      submits += 1;
+      event.preventDefault();
+      submitData = new FormData(form);
+    });
+    submit.click();
+    expect(submits).to.equal(1);
+    expect(submitData?.get('intent')).to.equal('save');
+    text.value = 'Edited';
+    await text.updateComplete;
+    reset.click();
+    await text.updateComplete;
+    expect(text.value).to.equal('Initial');
+  });
+
+  it('keeps range and search values current through native input events', async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form>
+        <m3-slider name="volume" value="10"></m3-slider>
+        <m3-search-bar name="query" value="old"></m3-search-bar>
+      </form>
+    `);
+    const slider = form.querySelector<M3Slider>('m3-slider')!;
+    const search = form.querySelector<M3SearchBar>('m3-search-bar')!;
+    await Promise.all([slider.updateComplete, search.updateComplete]);
+    let sliderInputs = 0;
+    let searchInputs = 0;
+    slider.addEventListener('input', () => { sliderInputs += 1; });
+    search.addEventListener('input', () => { searchInputs += 1; });
+    const sliderInput = slider.shadowRoot!.querySelector<HTMLInputElement>('input')!;
+    sliderInput.value = '30';
+    sliderInput.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+    const searchInput = search.shadowRoot!.querySelector<HTMLInputElement>('input')!;
+    searchInput.value = 'new';
+    searchInput.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+    await Promise.all([slider.updateComplete, search.updateComplete]);
+    expect(sliderInputs).to.equal(1);
+    expect(searchInputs).to.equal(1);
+    const data = new FormData(form);
+    expect(data.get('volume')).to.equal('30');
+    expect(data.get('query')).to.equal('new');
+  });
+
+  it('uses switch native events and only submits checked values', async () => {
+    const form = await fixture<HTMLFormElement>(html`<form><m3-switch name="alerts" value="on"></m3-switch></form>`);
+    const control = form.querySelector<M3Switch>('m3-switch')!;
+    await control.updateComplete;
+    let inputs = 0;
+    let changes = 0;
+    control.addEventListener('input', () => { inputs += 1; });
+    control.addEventListener('change', () => { changes += 1; });
+    control.shadowRoot!.querySelector<HTMLElement>('.switch-container')!.click();
+    await control.updateComplete;
+    expect(inputs).to.equal(1);
+    expect(changes).to.equal(1);
+    expect(new FormData(form).get('alerts')).to.equal('on');
+  });
+});

--- a/packages/m3-checkbox/src/m3-form-associated.test.ts
+++ b/packages/m3-checkbox/src/m3-form-associated.test.ts
@@ -118,7 +118,7 @@ describe('form-associated controls', () => {
     expect(new FormData(form).get('theme')).to.equal('dark');
   });
 
-  it('submits and resets through a form-associated button exactly once', async () => {
+  it('submits and resets through a form-associated button without inventing a submitter', async () => {
     const form = await fixture<HTMLFormElement>(html`
       <form>
         <m3-text-field name="title" value="Initial"></m3-text-field>
@@ -132,15 +132,18 @@ describe('form-associated controls', () => {
     expect(submit.type).to.equal('submit');
     expect(submit.form).to.equal(form);
     let submits = 0;
+    let nativeSubmitter: HTMLElement | null | undefined;
     let submitData: FormData | undefined;
     form.addEventListener('submit', (event) => {
       submits += 1;
+      nativeSubmitter = (event as SubmitEvent).submitter;
       event.preventDefault();
       submitData = new FormData(form);
     });
     submit.click();
     expect(submits).to.equal(1);
-    expect(submitData?.get('intent')).to.equal('save');
+    expect(nativeSubmitter).to.equal(null);
+    expect(submitData?.has('intent')).to.equal(false);
     text.value = 'Edited';
     await text.updateComplete;
     reset.click();

--- a/packages/m3-checkbox/tsconfig.test.json
+++ b/packages/m3-checkbox/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.test.json",
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/m3-form-associated/README.md
+++ b/packages/m3-form-associated/README.md
@@ -1,0 +1,10 @@
+# @banegasn/m3-form-associated
+
+Internal shared contract used by the library's form controls. It wraps the
+platform's form-associated custom element API (`ElementInternals`) and is not
+intended as a standalone UI component.
+
+The contract intentionally has no hidden-input fallback. Form association,
+constraint validation, reset, and restoration are native browser behaviours;
+an emulation changes their semantics. Supported engines are Chromium 77+,
+Firefox 98+, and Safari 16.4+.

--- a/packages/m3-form-associated/package.json
+++ b/packages/m3-form-associated/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@banegasn/m3-button",
-  "version": "2.2.3",
-  "description": "Material Design 3 button web component with expressive styling",
+  "name": "@banegasn/m3-form-associated",
+  "version": "1.0.0",
+  "description": "Shared form-associated custom element contract for Banegasn controls",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -11,11 +11,7 @@
       "default": "./dist/index.js"
     }
   },
-  "files": [
-    "dist",
-    "README.md",
-    "images"
-  ],
+  "files": ["dist", "README.md"],
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsc --watch",
@@ -29,16 +25,8 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/banegasn/components.git",
-    "directory": "packages/m3-button"
+    "directory": "packages/m3-form-associated"
   },
-  "keywords": [
-    "m3",
-    "material-design",
-    "button",
-    "web-components",
-    "components",
-    "accessibility"
-  ],
   "author": "banegasn",
   "license": "MIT",
   "publishConfig": {
@@ -46,7 +34,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@banegasn/m3-form-associated": "workspace:^",
     "lit": "^3.3.3"
   },
   "devDependencies": {

--- a/packages/m3-form-associated/src/form-associated-element.ts
+++ b/packages/m3-form-associated/src/form-associated-element.ts
@@ -1,0 +1,139 @@
+import { LitElement } from 'lit';
+
+/** A value that ElementInternals can contribute to FormData. */
+export type FormAssociatedValue = File | FormData | string | null;
+
+/** The standard validity flags accepted by ElementInternals.setValidity(). */
+export type FormValidityFlags = ValidityStateFlags;
+
+/** Copy the failing standard flags from a native input into ElementInternals. */
+export function validityFlags(validity: ValidityState): FormValidityFlags {
+  const flags: FormValidityFlags = {};
+  const names = [
+    'badInput', 'customError', 'patternMismatch', 'rangeOverflow', 'rangeUnderflow',
+    'stepMismatch', 'tooLong', 'tooShort', 'typeMismatch', 'valueMissing',
+  ] as const;
+  for (const name of names) {
+    if (validity[name]) flags[name] = true;
+  }
+  return flags;
+}
+
+/**
+ * Shared native-form contract for the library's controls.
+ *
+ * Subclasses own their public value and default-value semantics; this class
+ * owns the browser integration points supplied by ElementInternals. It is
+ * deliberately not a hidden-input fallback: browsers without form-associated
+ * custom elements keep an interactive component, but cannot emulate native
+ * form participation correctly.
+ */
+export abstract class FormAssociatedElement extends LitElement {
+  static readonly formAssociated = true;
+
+  private readonly _internals = typeof this.attachInternals === 'function'
+    ? this.attachInternals()
+    : undefined;
+
+  private _fieldsetDisabled = false;
+
+  /** The form owner, including an owner selected with the host `form` attribute. */
+  get form(): HTMLFormElement | null {
+    return this._internals && 'form' in this._internals ? this._internals.form : null;
+  }
+
+  get labels(): NodeList | null {
+    return this._internals && 'labels' in this._internals ? this._internals.labels : null;
+  }
+
+  get validity(): ValidityState {
+    return this._internals && 'validity' in this._internals
+      ? this._internals.validity
+      : ({ valid: true } as ValidityState);
+  }
+
+  get validationMessage(): string {
+    return this._internals && 'validationMessage' in this._internals
+      ? this._internals.validationMessage
+      : '';
+  }
+
+  get willValidate(): boolean {
+    return this._internals && 'willValidate' in this._internals
+      ? this._internals.willValidate
+      : false;
+  }
+
+  /** True when this control is disabled directly or through a disabled fieldset. */
+  protected get formDisabled(): boolean {
+    return this._fieldsetDisabled;
+  }
+
+  protected get isFormDisabled(): boolean {
+    return this._fieldsetDisabled || this.hasAttribute('disabled');
+  }
+
+  checkValidity(): boolean {
+    return typeof this._internals?.checkValidity === 'function'
+      ? this._internals.checkValidity()
+      : true;
+  }
+
+  reportValidity(): boolean {
+    return typeof this._internals?.reportValidity === 'function'
+      ? this._internals.reportValidity()
+      : true;
+  }
+
+  /** Set the value submitted with this control and the state restored by the browser. */
+  protected setFormValue(value: FormAssociatedValue, state: FormAssociatedValue = value): void {
+    if (typeof this._internals?.setFormValue === 'function') {
+      this._internals.setFormValue(value, state);
+    }
+  }
+
+  /** Set native constraint-validation state. */
+  protected setFormValidity(
+    flags: FormValidityFlags = {},
+    message = '',
+    anchor?: HTMLElement,
+  ): void {
+    if (!this._internals || typeof this._internals.setValidity !== 'function') return;
+    if (Object.keys(flags).length === 0) {
+      this._internals.setValidity({});
+      return;
+    }
+    this._internals.setValidity(flags, message, anchor);
+  }
+
+  protected emitInput(): void {
+    this.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+  }
+
+  protected emitChange(): void {
+    this.dispatchEvent(new Event('change', { bubbles: true }));
+  }
+
+  formAssociatedCallback(_form: HTMLFormElement | null): void {
+    // The `form` getter always reads the current owner from ElementInternals.
+  }
+
+  formDisabledCallback(disabled: boolean): void {
+    this._fieldsetDisabled = disabled;
+    this.requestUpdate();
+  }
+
+  formResetCallback(): void {
+    this.resetFormControl();
+  }
+
+  formStateRestoreCallback(state: string | File | FormData | null): void {
+    this.restoreFormControlState(state);
+  }
+
+  /** Restore the markup/default state without emitting interaction events. */
+  protected abstract resetFormControl(): void;
+
+  /** Restore browser navigation/autofill state without emitting interaction events. */
+  protected abstract restoreFormControlState(state: string | File | FormData | null): void;
+}

--- a/packages/m3-form-associated/src/index.ts
+++ b/packages/m3-form-associated/src/index.ts
@@ -1,0 +1,6 @@
+export {
+  FormAssociatedElement,
+  validityFlags,
+  type FormAssociatedValue,
+  type FormValidityFlags,
+} from './form-associated-element.js';

--- a/packages/m3-form-associated/tsconfig.json
+++ b/packages/m3-form-associated/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.lit.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "node_modules", "dist"]
+}

--- a/packages/m3-radio-button/README.md
+++ b/packages/m3-radio-button/README.md
@@ -63,7 +63,7 @@ yarn add @banegasn/m3-radio-button
 
   <script>
     document.querySelectorAll('m3-radio-button[name="theme"]').forEach(radio => {
-      radio.addEventListener('radio-change', (e) => {
+      radio.addEventListener('change', (e) => {
         document.getElementById('result').textContent = 'Selected: ' + e.detail.value;
       });
     });
@@ -101,7 +101,7 @@ import '@banegasn/m3-radio-button';
 
 const radioButtons = document.querySelectorAll('m3-radio-button[name="option"]');
 radioButtons.forEach(radio => {
-  radio.addEventListener('radio-change', (e) => {
+  radio.addEventListener('change', (e) => {
     console.log('Selected:', e.detail.value);
   });
 });
@@ -145,7 +145,7 @@ import '@banegasn/m3-radio-button';
       name="group"
       value="option1"
       [checked]="selected === 'option1'"
-      (radio-change)="onRadioChange($event)"
+      (change)="onRadioChange($event)"
     ></m3-radio-button>
   `
 })
@@ -166,7 +166,7 @@ export class MyComponent {
     name="group"
     value="option1"
     :checked="selected === 'option1'"
-    @radio-change="onRadioChange"
+    @change="onRadioChange"
   />
 </template>
 
@@ -190,15 +190,18 @@ const onRadioChange = (event) => {
 | `disabled` | `boolean` | `false` | Disables the radio button |
 | `name` | `string` | `null` | Name attribute for radio group (required for grouping) |
 | `value` | `string` | `null` | Value attribute for form submission |
-| `form` | `string` | `null` | Form attribute to associate radio with a form |
+| `form` | `HTMLFormElement \| null` | `null` | Current owner form; set the native `form` attribute to associate by ID |
 | `aria-label` | `string` | `null` | ARIA label for accessibility |
 | `aria-labelledby` | `string` | `null` | ARIA labelled by for accessibility |
 
 ## Events
 
-| Event | Detail | Description |
-|-------|--------|-------------|
-| `radio-change` | `{ checked: boolean, name: string \| null, value: string \| null }` | Fired when the radio button state changes |
+| Event | Description |
+|-------|-------------|
+| `input` | Native event fired on the newly selected radio. |
+| `change` | Native event fired after a radio selection is committed. |
+
+See the [form-associated control migration guide](../../docs/FORM_ASSOCIATED_CONTROLS.md).
 
 ## Methods
 

--- a/packages/m3-radio-button/package.json
+++ b/packages/m3-radio-button/package.json
@@ -47,6 +47,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@banegasn/m3-form-associated": "workspace:^",
     "lit": "^3.3.3"
   },
   "devDependencies": {

--- a/packages/m3-radio-button/src/m3-radio-button.ts
+++ b/packages/m3-radio-button/src/m3-radio-button.ts
@@ -1,120 +1,33 @@
-import { LitElement, html } from 'lit';
+import { html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
+import { FormAssociatedElement } from '@banegasn/m3-form-associated';
 import { m3RadioButtonStyles } from './m3-radio-button.styles.js';
 import { motionDuration } from './motion-duration.js';
 
 /**
- * Material Design 3 Radio Button Component
- * 
- * A radio button component following Material Design 3 specifications that allows
- * users to select a single option from a group of options.
- * 
- * @fires radio-change - Fired when the radio button state changes
- * 
- * @cssprop --md-comp-radio-size - Size of the radio button (default: 20px)
- * @cssprop --md-comp-radio-ripple-size - Size of the ripple effect (default: 40px)
- * @cssprop --md-sys-color-primary - Primary color for the radio when checked
- * @cssprop --md-sys-color-on-surface - Color for the radio when unchecked
- * @cssprop --md-sys-color-outline - Outline color for disabled state
+ * Material Design 3 radio button with native form participation.
+ *
+ * Radio grouping follows the platform rule: radios with the same `name` and
+ * the same owner form are mutually exclusive. A selection emits one native
+ * `input` and one native `change` event on the selected control.
  */
 @customElement('m3-radio-button')
-export class M3RadioButton extends LitElement {
+export class M3RadioButton extends FormAssociatedElement {
   static styles = m3RadioButtonStyles;
+  static readonly formAssociated = true;
 
-  /**
-   * Whether the radio button is checked
-   */
-  @property({ type: Boolean, reflect: true })
-  checked = false;
+  @property({ type: Boolean, reflect: true }) checked = false;
+  @property({ type: Boolean, reflect: true }) disabled = false;
+  @property({ type: Boolean, reflect: true }) required = false;
+  @property({ type: String, reflect: true }) name: string | null = null;
+  @property({ type: String, reflect: true }) value: string | null = null;
+  @property({ type: String, attribute: 'aria-label' }) ariaLabel: string | null = null;
+  @property({ type: String, attribute: 'aria-labelledby' }) ariaLabelledBy: string | null = null;
+  @property({ type: String, reflect: true }) size: 'small' | 'medium' | 'large' = 'small';
 
-  /**
-   * Disables the radio button
-   */
-  @property({ type: Boolean, reflect: true })
-  disabled = false;
-
-  /**
-   * Name attribute for radio group
-   */
-  @property({ type: String })
-  name: string | null = null;
-
-  /**
-   * Value attribute for form submission
-   */
-  @property({ type: String })
-  value: string | null = null;
-
-  /**
-   * Form attribute to associate radio with a form
-   */
-  @property({ type: String })
-  form: string | null = null;
-
-  /**
-   * ARIA label for accessibility
-   */
-  @property({ type: String, attribute: 'aria-label' })
-  ariaLabel: string | null = null;
-
-  /**
-   * ARIA labelled by for accessibility
-   */
-  @property({ type: String, attribute: 'aria-labelledby' })
-  ariaLabelledBy: string | null = null;
-
-  /**
-   * Radio button size
-   * - small: 16px outer, 8px inner (default)
-   * - medium: 20px outer, 10px inner
-   * - large: 24px outer, 12px inner
-   */
-  @property({ type: String, reflect: true })
-  size: 'small' | 'medium' | 'large' = 'small';
-
-  /**
-   * Internal state for pressed/active visual feedback
-   */
-  @state()
-  private _pressed = false;
-
-  /**
-   * Internal state for ripple animation
-   */
-  @state()
-  private _ripple = false;
-
-  /**
-   * Unique ID for the radio button
-   */
-  private _radioId = `m3-radio-${Math.random().toString(36).substr(2, 9)}`;
-
-  connectedCallback() {
-    super.connectedCallback();
-    // Set the ID attribute for label association
-    this.setAttribute('id', this._radioId);
-    
-    // Listen for changes from other radio buttons in the same group
-    if (this.name) {
-      document.addEventListener('radio-group-change', this._handleGroupChange as EventListener);
-    }
-
-    // Listen for clicks on associated labels
-    document.addEventListener('click', this._handleLabelClick, true);
-    
-    // Set up label associations after rendering
-    this.updateComplete.then(() => {
-      this._setupLabelAssociations();
-    });
-  }
-
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    if (this.name) {
-      document.removeEventListener('radio-group-change', this._handleGroupChange as EventListener);
-    }
-    document.removeEventListener('click', this._handleLabelClick);
-  }
+  @state() private _pressed = false;
+  @state() private _ripple = false;
+  private _defaultChecked = false;
 
   render() {
     return html`
@@ -122,10 +35,10 @@ export class M3RadioButton extends LitElement {
         class="radio-container"
         role="radio"
         aria-checked=${this.checked}
-        aria-disabled=${this.disabled}
+        aria-disabled=${this.isFormDisabled}
         aria-label=${this.ariaLabel || ''}
         aria-labelledby=${this.ariaLabelledBy || ''}
-        tabindex=${this.disabled ? -1 : 0}
+        tabindex=${this.isFormDisabled ? -1 : 0}
         @click=${this._handleClick}
         @keydown=${this._handleKeyDown}
         @keyup=${this._handleKeyUp}
@@ -133,326 +46,134 @@ export class M3RadioButton extends LitElement {
         @mouseup=${this._handleMouseUp}
         @mouseleave=${this._handleMouseLeave}
       >
-        <div class="radio-outer" ?checked=${this.checked} ?disabled=${this.disabled} ?pressed=${this._pressed}>
-          ${this.checked ? html`
-            <div class="radio-inner"></div>
-          ` : ''}
+        <div class="radio-outer" ?checked=${this.checked} ?disabled=${this.isFormDisabled} ?pressed=${this._pressed}>
+          ${this.checked ? html`<div class="radio-inner"></div>` : ''}
         </div>
-        ${this._ripple ? html`
-          <div class="ripple"></div>
-        ` : ''}
+        ${this._ripple ? html`<div class="ripple"></div>` : ''}
       </div>
-      <input
-        type="radio"
-        ?checked=${this.checked}
-        ?disabled=${this.disabled}
-        name=${this.name || ''}
-        value=${this.value || ''}
-        form=${this.form || ''}
-        aria-hidden="true"
-        tabindex="-1"
-        @change=${this._handleInputChange}
-      />
     `;
   }
 
-  private _handleClick(e: MouseEvent) {
-    if (this.disabled) {
-      e.preventDefault();
-      e.stopPropagation();
-      return;
-    }
-
-    if (!this.checked) {
-      this._select();
-    }
+  firstUpdated(): void {
+    this._defaultChecked = this.checked;
+    this._syncFormState();
   }
 
-  private _handleKeyDown(e: KeyboardEvent) {
-    if (this.disabled) {
+  updated(): void {
+    this._syncFormState();
+  }
+
+  private _handleClick(event: MouseEvent): void {
+    if (this.isFormDisabled) {
+      event.preventDefault();
+      event.stopPropagation();
       return;
     }
+    this._select();
+  }
 
-    if (e.key === ' ' || e.key === 'Enter') {
-      e.preventDefault();
+  private _handleKeyDown(event: KeyboardEvent): void {
+    if (this.isFormDisabled) return;
+    if (event.key === ' ' || event.key === 'Enter') {
+      event.preventDefault();
       this._pressed = true;
-      return;
-    }
-
-    // Arrow key navigation for radio groups
-    if (this.name && (e.key === 'ArrowRight' || e.key === 'ArrowDown')) {
-      e.preventDefault();
-      this._navigateToNext();
-      return;
-    }
-
-    if (this.name && (e.key === 'ArrowLeft' || e.key === 'ArrowUp')) {
-      e.preventDefault();
-      this._navigateToPrevious();
-      return;
+    } else if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+      event.preventDefault();
+      this._moveSelection(1);
+    } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      this._moveSelection(-1);
     }
   }
 
-  private _handleKeyUp(e: KeyboardEvent) {
-    if (this.disabled) {
-      return;
-    }
-
-    if (e.key === ' ' || e.key === 'Enter') {
-      e.preventDefault();
-      this._pressed = false;
-      if (!this.checked) {
-        this._select();
-      }
-    }
+  private _handleKeyUp(event: KeyboardEvent): void {
+    if (this.isFormDisabled || (event.key !== ' ' && event.key !== 'Enter')) return;
+    event.preventDefault();
+    this._pressed = false;
+    this._select();
   }
 
-  private _navigateToNext() {
-    const radios = this._getRadioGroup();
-    const currentIndex = radios.indexOf(this);
-    const nextIndex = (currentIndex + 1) % radios.length;
-    const nextRadio = radios[nextIndex];
-    
-    if (nextRadio && !nextRadio.disabled) {
-      nextRadio.focus();
-      if (!nextRadio.checked) {
-        nextRadio.click();
-      }
-    }
+  private _handleMouseDown(): void {
+    if (!this.isFormDisabled) this._pressed = true;
   }
 
-  private _navigateToPrevious() {
-    const radios = this._getRadioGroup();
-    const currentIndex = radios.indexOf(this);
-    const previousIndex = currentIndex === 0 ? radios.length - 1 : currentIndex - 1;
-    const previousRadio = radios[previousIndex];
-    
-    if (previousRadio && !previousRadio.disabled) {
-      previousRadio.focus();
-      if (!previousRadio.checked) {
-        previousRadio.click();
-      }
-    }
-  }
-
-  private _getRadioGroup(): M3RadioButton[] {
-    if (!this.name) {
-      return [this];
-    }
-
-    // Find all radio buttons with the same name
-    const allRadios = Array.from(document.querySelectorAll(`m3-radio-button[name="${this.name}"]`)) as M3RadioButton[];
-    return allRadios.filter(radio => radio.name === this.name);
-  }
-
-  private _handleMouseDown() {
-    if (!this.disabled) {
-      this._pressed = true;
-    }
-  }
-
-  private _handleMouseUp() {
+  private _handleMouseUp(): void {
     this._pressed = false;
   }
 
-  private _handleMouseLeave() {
+  private _handleMouseLeave(): void {
     this._pressed = false;
   }
 
-  private _handleInputChange(e: Event) {
-    // Sync with internal radio for form submission
-    const input = e.target as HTMLInputElement;
-    if (input.checked !== this.checked) {
-      this.checked = input.checked;
-    }
-  }
-
-  private _handleGroupChange = (e: Event) => {
-    const customEvent = e as CustomEvent;
-    if (customEvent.detail.name === this.name && customEvent.detail.value !== this.value) {
-      this.checked = false;
-      this._updateInput();
-    }
-  };
-
-  private _setupLabelAssociations() {
-    // Find labels with 'for' attribute pointing to this radio
-    const labels = document.querySelectorAll(`label[for="${this._radioId}"]`) as NodeListOf<HTMLLabelElement>;
-    labels.forEach(label => {
-      label.style.cursor = 'pointer';
-      label.addEventListener('click', (e) => {
-        e.preventDefault();
-        if (!this.disabled) {
-          this._select();
-        }
-      });
-    });
-    
-    // Find sibling labels
-    const nextSibling = this.nextElementSibling;
-    const previousSibling = this.previousElementSibling;
-    
-    if (nextSibling && nextSibling.tagName === 'LABEL') {
-      (nextSibling as HTMLLabelElement).style.cursor = 'pointer';
-      nextSibling.addEventListener('click', (e) => {
-        e.preventDefault();
-        if (!this.disabled) {
-          this._select();
-        }
-      });
-    }
-    
-    if (previousSibling && previousSibling.tagName === 'LABEL') {
-      (previousSibling as HTMLLabelElement).style.cursor = 'pointer';
-      previousSibling.addEventListener('click', (e) => {
-        e.preventDefault();
-        if (!this.disabled) {
-          this._select();
-        }
-      });
-    }
-    
-    // Find labels in the same container
-    const container = this.closest('.radio-item, .radio-group, .setting-item');
-    if (container) {
-      const labelsInContainer = container.querySelectorAll('label') as NodeListOf<HTMLLabelElement>;
-      labelsInContainer.forEach(label => {
-        const radioInContainer = container.querySelector('m3-radio-button');
-        if (radioInContainer === this) {
-          label.style.cursor = 'pointer';
-          label.addEventListener('click', (e) => {
-            e.preventDefault();
-            if (!this.disabled) {
-              this._select();
-            }
-          });
-        }
-      });
-    }
-  }
-
-  private _handleLabelClick = (e: MouseEvent) => {
-    const target = e.target as HTMLElement;
-    
-    // Check if the clicked element is a label
-    if (target.tagName === 'LABEL') {
-      const labelFor = target.getAttribute('for');
-      
-      // If label has 'for' attribute matching this radio's ID
-      if (labelFor === this._radioId) {
-        e.preventDefault();
-        e.stopPropagation();
-        if (!this.disabled) {
-          this._select();
-        }
-        return;
-      }
-      
-      // Check if label is next sibling or previous sibling
-      const nextSibling = this.nextElementSibling;
-      const previousSibling = this.previousElementSibling;
-      
-      if (target === nextSibling || target === previousSibling) {
-        e.preventDefault();
-        e.stopPropagation();
-        if (!this.disabled) {
-          this._select();
-        }
-        return;
-      }
-      
-      // Check if this radio is inside the label
-      if (target.contains(this)) {
-        e.preventDefault();
-        e.stopPropagation();
-        if (!this.disabled) {
-          this._select();
-        }
-        return;
-      }
-      
-      // Check if label and radio are in the same container (like .radio-item)
-      const labelContainer = target.closest('.radio-item, .radio-group, .setting-item');
-      if (labelContainer && labelContainer.contains(this)) {
-        // Check if this is the radio button in that container
-        const radioInContainer = labelContainer.querySelector('m3-radio-button');
-        if (radioInContainer === this) {
-          e.preventDefault();
-          e.stopPropagation();
-          if (!this.disabled) {
-            this._select();
-          }
-          return;
-        }
-      }
-    }
-  };
-
-  private _select() {
+  private _select(emitEvents = true): void {
+    if (this.checked || this.isFormDisabled) return;
     this.checked = true;
-    this._updateInput();
+    this._radioGroup().forEach((radio) => {
+      if (radio !== this && radio.checked) radio.checked = false;
+    });
     this._triggerRipple();
-
-    // Uncheck other radio buttons in the same group
-    if (this.name) {
-      document.dispatchEvent(new CustomEvent('radio-group-change', {
-        detail: {
-          name: this.name,
-          value: this.value
-        }
-      }));
-    }
-
-    this.dispatchEvent(new CustomEvent('radio-change', {
-      bubbles: true,
-      composed: true,
-      detail: {
-        checked: this.checked,
-        name: this.name,
-        value: this.value
-      }
-    }));
-  }
-
-  private _updateInput() {
-    const input = this.shadowRoot?.querySelector('input[type="radio"]') as HTMLInputElement;
-    if (input) {
-      input.checked = this.checked;
+    if (emitEvents) {
+      this.emitInput();
+      this.emitChange();
     }
   }
 
-  private _triggerRipple() {
+  private _moveSelection(direction: 1 | -1): void {
+    const radios = this._radioGroup().filter((radio) => !radio.isFormDisabled);
+    const index = radios.indexOf(this);
+    if (index < 0 || radios.length < 2) return;
+    const next = radios[(index + direction + radios.length) % radios.length];
+    next.focus();
+    next._select();
+  }
+
+  private _radioGroup(): M3RadioButton[] {
+    if (!this.name) return [this];
+    return Array.from(document.querySelectorAll<M3RadioButton>('m3-radio-button')).filter((radio) =>
+      radio.name === this.name && radio.form === this.form,
+    );
+  }
+
+  private _syncFormState(): void {
+    const disabled = this.isFormDisabled;
+    this.setFormValue(!disabled && this.checked ? this.value ?? 'on' : null, this.checked ? 'checked' : 'unchecked');
+    const requiredRadio = this._radioGroup().some((radio) => radio.required && !radio.isFormDisabled);
+    const selected = this._radioGroup().some((radio) => radio.checked && !radio.isFormDisabled);
+    this.setFormValidity(
+      !disabled && requiredRadio && !selected ? { valueMissing: true } : {},
+      !disabled && requiredRadio && !selected ? 'Please select an option.' : '',
+      this.shadowRoot?.querySelector<HTMLElement>('.radio-container') ?? undefined,
+    );
+  }
+
+  private _triggerRipple(): void {
     this._ripple = true;
     void this.updateComplete.then(() => {
       const ripple = this.shadowRoot?.querySelector('.ripple');
-      const duration = ripple ? motionDuration(ripple, '--_ripple-duration') : 0;
       setTimeout(() => {
         this._ripple = false;
-      }, duration);
+      }, ripple ? motionDuration(ripple, '--_ripple-duration') : 0);
     });
   }
 
-  /**
-   * Programmatically clicks the radio button
-   */
-  click() {
-    if (!this.disabled) {
-      this._select();
-    }
+  protected resetFormControl(): void {
+    this.checked = this._defaultChecked;
   }
 
-  /**
-   * Focuses the radio button
-   */
-  focus() {
-    (this.shadowRoot?.querySelector('.radio-container') as HTMLElement)?.focus();
+  protected restoreFormControlState(state: string | File | FormData | null): void {
+    if (typeof state === 'string') this.checked = state === 'checked';
   }
 
-  /**
-   * Removes focus from the radio button
-   */
-  blur() {
-    (this.shadowRoot?.querySelector('.radio-container') as HTMLElement)?.blur();
+  click(): void {
+    this._select();
+  }
+
+  focus(): void {
+    this.shadowRoot?.querySelector<HTMLElement>('.radio-container')?.focus();
+  }
+
+  blur(): void {
+    this.shadowRoot?.querySelector<HTMLElement>('.radio-container')?.blur();
   }
 }
 

--- a/packages/m3-search-bar/README.md
+++ b/packages/m3-search-bar/README.md
@@ -51,10 +51,10 @@ yarn add @banegasn/m3-search-bar
 
   <script>
     const search = document.getElementById('search');
-    search.addEventListener('search-input', (e) => {
+    search.addEventListener('input', (e) => {
       document.getElementById('results').textContent = 'Searching for: ' + e.detail.value;
     });
-    search.addEventListener('search-clear', () => {
+    search.addEventListener('change', () => {
       document.getElementById('results').textContent = 'Start typing to search...';
     });
   </script>
@@ -145,15 +145,15 @@ Or with Material Icons directly:
 ```javascript
 const searchBar = document.querySelector('m3-search-bar');
 
-searchBar.addEventListener('search-input', (e) => {
+searchBar.addEventListener('input', (e) => {
   console.log('Search value:', e.detail.value);
 });
 
-searchBar.addEventListener('search-submit', (e) => {
+searchBar.addEventListener('change', (e) => {
   console.log('Search submitted:', e.detail.value);
 });
 
-searchBar.addEventListener('search-clear', () => {
+searchBar.addEventListener('change', () => {
   console.log('Search cleared');
 });
 ```
@@ -166,7 +166,7 @@ searchBar.addEventListener('search-clear', () => {
 | `value` | `string` | `''` | Current value of the input |
 | `disabled` | `boolean` | `false` | Disables the search bar |
 | `name` | `string \| null` | `null` | Name attribute for form submission |
-| `form` | `string \| null` | `null` | Form attribute to associate with a form |
+| `form` | `HTMLFormElement \| null` | `null` | Current owner form; set the native `form` attribute to associate by ID |
 | `aria-label` | `string \| null` | `null` | ARIA label for accessibility |
 | `aria-labelledby` | `string \| null` | `null` | ARIA labelled by for accessibility |
 | `maxLength` | `number \| null` | `null` | Maximum length of input |
@@ -184,11 +184,12 @@ searchBar.addEventListener('search-clear', () => {
 
 ## Events
 
-| Event | Detail | Description |
-|-------|--------|-------------|
-| `search-input` | `{ value: string, name: string \| null }` | Fired when the input value changes |
-| `search-submit` | `{ value: string, name: string \| null }` | Fired when Enter is pressed |
-| `search-clear` | `{ name: string \| null }` | Fired when the search is cleared (Escape key) |
+| Event | Description |
+|-------|-------------|
+| `input` | Native event fired when the query changes or is cleared. |
+| `change` | Native event fired when the query is committed or cleared. |
+
+See the [form-associated control migration guide](../../docs/FORM_ASSOCIATED_CONTROLS.md).
 
 ## Methods
 

--- a/packages/m3-search-bar/package.json
+++ b/packages/m3-search-bar/package.json
@@ -47,6 +47,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@banegasn/m3-form-associated": "workspace:^",
     "lit": "^3.3.3"
   },
   "devDependencies": {

--- a/packages/m3-search-bar/src/m3-search-bar.ts
+++ b/packages/m3-search-bar/src/m3-search-bar.ts
@@ -1,271 +1,152 @@
-import { LitElement, html } from 'lit';
-import { customElement, property, state } from 'lit/decorators.js';
+import { html } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { customElement, property, state, query } from 'lit/decorators.js';
+import { FormAssociatedElement, validityFlags } from '@banegasn/m3-form-associated';
 import { m3SearchBarStyles } from './m3-search-bar.styles.js';
 
-/**
- * Material Design 3 Search Bar Component
- * 
- * A search bar component following Material Design 3 specifications with
- * support for leading and trailing content projection slots.
- * 
- * @fires search-input - Fired when the input value changes
- * @fires search-submit - Fired when the search is submitted (Enter key)
- * @fires search-clear - Fired when the clear button is clicked
- * 
- * @slot leading - Content to display before the input (e.g., search icon, menu button)
- * @slot trailing - Content to display after the input (e.g., clear button, avatar)
- * 
- * @cssprop --md-comp-search-bar-container-height - Height of the container
- * @cssprop --md-comp-search-bar-container-padding - Padding of the container
- * @cssprop --md-comp-search-bar-height - Height of the search bar
- * @cssprop --md-comp-search-bar-shape - Border radius of the search bar
- * @cssprop --md-comp-search-bar-padding-horizontal - Horizontal padding
- * @cssprop --md-comp-search-bar-padding-vertical - Vertical padding
- * @cssprop --md-comp-search-bar-input-font-size - Font size of input
- * @cssprop --md-comp-search-bar-input-line-height - Line height of input
- * @cssprop --md-comp-search-bar-icon-size - Size of icons in slots
- * @cssprop --md-sys-color-surface-container - Container background color
- * @cssprop --md-sys-color-surface-container-high - Search bar background color
- * @cssprop --md-sys-color-on-surface - Input text color
- * @cssprop --md-sys-color-on-surface-variant - Placeholder and icon color
- * @cssprop --md-sys-color-outline-variant - Border color
- * @cssprop --md-sys-color-primary - Focus border color
- */
+/** Material Design 3 search bar with native form participation. */
 @customElement('m3-search-bar')
-export class M3SearchBar extends LitElement {
+export class M3SearchBar extends FormAssociatedElement {
   static styles = m3SearchBarStyles;
+  static readonly formAssociated = true;
 
-  /**
-   * Placeholder text for the input field
-   */
-  @property({ type: String })
-  placeholder: string = 'Search';
+  @property({ type: String }) placeholder = 'Search';
+  @property({ type: String, reflect: true }) value = '';
+  @property({ type: Boolean, reflect: true }) disabled = false;
+  @property({ type: String, reflect: true }) name: string | null = null;
+  @property({ type: String, attribute: 'aria-label' }) ariaLabel: string | null = null;
+  @property({ type: String, attribute: 'aria-labelledby' }) ariaLabelledBy: string | null = null;
+  @property({ type: Number, attribute: 'maxlength' }) maxLength: number | null = null;
+  @property({ type: Number, attribute: 'minlength' }) minLength: number | null = null;
+  @property({ type: String }) pattern: string | null = null;
+  @property({ type: Boolean, reflect: true }) required = false;
+  @property({ type: String }) autocomplete: string | null = null;
 
-  /**
-   * Current value of the input field
-   */
-  @property({ type: String })
-  value: string = '';
-
-  /**
-   * Disables the search bar
-   */
-  @property({ type: Boolean, reflect: true })
-  disabled = false;
-
-  /**
-   * Name attribute for form submission
-   */
-  @property({ type: String })
-  name: string | null = null;
-
-  /**
-   * Form attribute to associate search bar with a form
-   */
-  @property({ type: String })
-  form: string | null = null;
-
-  /**
-   * ARIA label for accessibility
-   */
-  @property({ type: String, attribute: 'aria-label' })
-  ariaLabel: string | null = null;
-
-  /**
-   * ARIA labelled by for accessibility
-   */
-  @property({ type: String, attribute: 'aria-labelledby' })
-  ariaLabelledBy: string | null = null;
-
-  /**
-   * Maximum length of input
-   */
-  @property({ type: Number })
-  maxLength: number | null = null;
-
-  /**
-   * Minimum length of input
-   */
-  @property({ type: Number })
-  minLength: number | null = null;
-
-  /**
-   * Pattern for input validation
-   */
-  @property({ type: String })
-  pattern: string | null = null;
-
-  /**
-   * Whether the input is required
-   */
-  @property({ type: Boolean })
-  required = false;
-
-  /**
-   * Autocomplete attribute
-   */
-  @property({ type: String })
-  autocomplete: string | null = null;
-
-  /**
-   * Internal state for focused state
-   */
-  @state()
-  private _focused = false;
+  @state() private _focused = false;
+  @query('.input-field') private _input!: HTMLInputElement;
+  private _defaultValue = '';
 
   render() {
     return html`
       <div class="search-container">
         <div
           class="search-bar"
-          ?disabled=${this.disabled}
+          ?disabled=${this.isFormDisabled}
           @focusin=${this._handleFocusIn}
           @focusout=${this._handleFocusOut}
         >
-          <div class="leading-slot">
-            <slot name="leading"></slot>
-          </div>
+          <div class="leading-slot"><slot name="leading"></slot></div>
           <div class="input-wrapper">
             <input
-              type="text"
+              type="search"
               role="searchbox"
               class="input-field"
               .value=${this.value}
               placeholder=${this.placeholder}
-              ?disabled=${this.disabled}
+              ?disabled=${this.isFormDisabled}
               ?required=${this.required}
-              name=${this.name || ''}
-              form=${this.form || ''}
               aria-label=${this.ariaLabel || ''}
               aria-labelledby=${this.ariaLabelledBy || ''}
-              maxlength=${this.maxLength || ''}
-              minlength=${this.minLength || ''}
-              pattern=${this.pattern || ''}
-              autocomplete=${this.autocomplete || ''}
+              maxlength=${ifDefined(this.maxLength ?? undefined)}
+              minlength=${ifDefined(this.minLength ?? undefined)}
+              pattern=${ifDefined(this.pattern ?? undefined)}
+              autocomplete=${ifDefined(this.autocomplete ?? undefined)}
               @input=${this._handleInput}
               @keydown=${this._handleKeyDown}
               @change=${this._handleChange}
             />
           </div>
-          <div class="trailing-slot">
-            <slot name="trailing"></slot>
-          </div>
+          <div class="trailing-slot"><slot name="trailing"></slot></div>
         </div>
       </div>
     `;
   }
 
-  private _handleInput(e: Event) {
-    const input = e.target as HTMLInputElement;
-    this.value = input.value;
-
-    this.dispatchEvent(new CustomEvent('search-input', {
-      bubbles: true,
-      composed: true,
-      detail: {
-        value: this.value,
-        name: this.name
-      }
-    }));
+  firstUpdated(): void {
+    this._defaultValue = this.value;
+    this._syncFormState();
   }
 
-  private _handleKeyDown(e: KeyboardEvent) {
-    if (this.disabled) {
-      return;
-    }
+  updated(): void {
+    this._syncFormState();
+  }
 
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      this.dispatchEvent(new CustomEvent('search-submit', {
-        bubbles: true,
-        composed: true,
-        detail: {
-          value: this.value,
-          name: this.name
-        }
-      }));
-    }
+  private _handleInput(event: Event): void {
+    event.stopPropagation();
+    this.value = (event.target as HTMLInputElement).value;
+    this.emitInput();
+  }
 
-    if (e.key === 'Escape' && this.value) {
+  private _handleKeyDown(event: KeyboardEvent): void {
+    if (this.isFormDisabled) return;
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      this.form?.requestSubmit();
+    } else if (event.key === 'Escape' && this.value) {
       this._clear();
     }
   }
 
-  private _handleChange(e: Event) {
-    const input = e.target as HTMLInputElement;
-    this.value = input.value;
+  private _handleChange(event: Event): void {
+    event.stopPropagation();
+    this.value = (event.target as HTMLInputElement).value;
+    this.emitChange();
   }
 
-  private _handleFocusIn() {
+  private _handleFocusIn(): void {
     this._focused = true;
   }
 
-  private _handleFocusOut() {
+  private _handleFocusOut(): void {
     this._focused = false;
   }
 
-  private _clear() {
+  private _clear(): void {
+    if (this.value === '') return;
     this.value = '';
-    const input = this.shadowRoot?.querySelector('.input-field') as HTMLInputElement;
-    if (input) {
-      input.value = '';
-    }
-
-    this.dispatchEvent(new CustomEvent('search-clear', {
-      bubbles: true,
-      composed: true,
-      detail: {
-        name: this.name
-      }
-    }));
-
-    this.dispatchEvent(new CustomEvent('search-input', {
-      bubbles: true,
-      composed: true,
-      detail: {
-        value: this.value,
-        name: this.name
-      }
-    }));
+    this.emitInput();
+    this.emitChange();
   }
 
-  /**
-   * Focuses the search input
-   */
-  focus() {
-    (this.shadowRoot?.querySelector('.input-field') as HTMLInputElement)?.focus();
+  private _syncFormState(): void {
+    const flags = !this.isFormDisabled && this._input ? validityFlags(this._input.validity) : {};
+    if (this.value) delete flags.valueMissing;
+    else if (this.required && !this.isFormDisabled) flags.valueMissing = true;
+    const invalid = Object.keys(flags).length > 0;
+    this.setFormValue(this.isFormDisabled ? null : this.value, this.value);
+    this.setFormValidity(
+      flags,
+      invalid ? this._input.validationMessage : '',
+      this._input,
+    );
   }
 
-  /**
-   * Removes focus from the search input
-   */
-  blur() {
-    (this.shadowRoot?.querySelector('.input-field') as HTMLInputElement)?.blur();
+  protected resetFormControl(): void {
+    this.value = this._defaultValue;
   }
 
-  /**
-   * Clears the search input
-   */
-  clear() {
+  protected restoreFormControlState(state: string | File | FormData | null): void {
+    if (typeof state === 'string') this.value = state;
+  }
+
+  focus(): void {
+    this._input?.focus();
+  }
+
+  blur(): void {
+    this._input?.blur();
+  }
+
+  clear(): void {
     this._clear();
   }
 
-  /**
-   * Gets the current value
-   */
   getValue(): string {
     return this.value;
   }
 
-  /**
-   * Sets the value programmatically
-   */
-  setValue(value: string) {
+  setValue(value: string): void {
     this.value = value;
-    const input = this.shadowRoot?.querySelector('.input-field') as HTMLInputElement;
-    if (input) {
-      input.value = value;
-    }
   }
 }
 

--- a/packages/m3-slider/README.md
+++ b/packages/m3-slider/README.md
@@ -64,10 +64,10 @@ yarn add @banegasn/m3-slider
   </div>
 
   <script>
-    document.getElementById('volume').addEventListener('slider-change', (e) => {
+    document.getElementById('volume').addEventListener('change', (e) => {
       document.getElementById('vol-out').textContent = e.detail.value;
     });
-    document.getElementById('steps').addEventListener('slider-change', (e) => {
+    document.getElementById('steps').addEventListener('change', (e) => {
       document.getElementById('step-out').textContent = e.detail.value;
     });
   </script>
@@ -102,10 +102,12 @@ import '@banegasn/m3-slider';
 
 ### Events
 
-| Event | Detail | Description |
-|-------|--------|-------------|
-| `slider-change` | `{ value: number, name: string \| null }` | Fired when the value changes |
-| `slider-input` | `{ value: number, name: string \| null }` | Fired continuously while dragging |
+| Event | Description |
+|-------|-------------|
+| `input` | Native event fired continuously while the value changes. |
+| `change` | Native event fired after the value is committed. |
+
+See the [form-associated control migration guide](../../docs/FORM_ASSOCIATED_CONTROLS.md).
 
 ### CSS Custom Properties
 
@@ -122,18 +124,18 @@ import '@banegasn/m3-slider';
 import '@banegasn/m3-slider';
 ```
 ```html
-<m3-slider [value]="volume" min="0" max="100" (slider-change)="onVolumeChange($event)"></m3-slider>
+<m3-slider [value]="volume" min="0" max="100" (change)="onVolumeChange($event)"></m3-slider>
 ```
 
 ### React
 ```jsx
 import '@banegasn/m3-slider';
-// <m3-slider value={volume} min={0} max={100} onslider-change={handleChange} />
+// <m3-slider value={volume} min={0} max={100} onChange={handleChange} />
 ```
 
 ### Vue
 ```vue
-<m3-slider :value="volume" min="0" max="100" @slider-change="handleChange" />
+<m3-slider :value="volume" min="0" max="100" @change="handleChange" />
 ```
 
 ## Resources

--- a/packages/m3-slider/package.json
+++ b/packages/m3-slider/package.json
@@ -46,6 +46,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@banegasn/m3-form-associated": "workspace:^",
     "lit": "^3.3.3"
   },
   "devDependencies": {

--- a/packages/m3-slider/src/m3-slider.ts
+++ b/packages/m3-slider/src/m3-slider.ts
@@ -1,22 +1,24 @@
-import { LitElement, html } from 'lit';
+import { html } from 'lit';
 import { customElement, property, state, query } from 'lit/decorators.js';
+import { FormAssociatedElement } from '@banegasn/m3-form-associated';
 import { m3SliderStyles } from './m3-slider.styles.js';
 
 /**
  * Material Design 3 Slider Component
  * 
- * @fires slider-change - Fired when the slider value changes
+ * Emits native `input` while dragging and `change` on a committed value.
  */
 @customElement('m3-slider')
-export class M3Slider extends LitElement {
+export class M3Slider extends FormAssociatedElement {
   static styles = m3SliderStyles;
+  static readonly formAssociated = true;
 
   @property({ type: Number }) min = 0;
   @property({ type: Number }) max = 100;
   @property({ type: Number }) value = 50;
   @property({ type: Boolean, reflect: true }) disabled = false;
   @property({ type: Number }) step = 1;
-  @property({ type: String }) name: string | null = null;
+  @property({ type: String, reflect: true }) name: string | null = null;
   @property({ type: String, attribute: 'aria-label' }) ariaLabel: string | null = null;
   
   @query('.slider-input') inputEl!: HTMLInputElement;
@@ -24,6 +26,7 @@ export class M3Slider extends LitElement {
   @state() private _focused = false;
   @state() private _hovered = false;
   @state() private _active = false;
+  private _defaultValue = this.value;
 
   render() {
     const fraction = Math.max(0, Math.min(1, (this.value - this.min) / (this.max - this.min)));
@@ -52,9 +55,8 @@ export class M3Slider extends LitElement {
           max=${this.max}
           step=${this.step}
           .value=${String(this.value)}
-          ?disabled=${this.disabled}
+          ?disabled=${this.isFormDisabled}
           aria-label=${this.ariaLabel || ''}
-          name=${this.name || ''}
           @input=${this._handleInput}
           @change=${this._handleChange}
           @focus=${this._handleFocus}
@@ -68,8 +70,17 @@ export class M3Slider extends LitElement {
     `;
   }
 
+  firstUpdated(): void {
+    this._defaultValue = this.value;
+    this._syncFormState();
+  }
+
+  updated(): void {
+    this._syncFormState();
+  }
+
   private _handleMouseEnter() {
-    if (!this.disabled) this._hovered = true;
+    if (!this.isFormDisabled) this._hovered = true;
   }
 
   private _handleMouseLeave() {
@@ -77,7 +88,7 @@ export class M3Slider extends LitElement {
   }
 
   private _handleFocus() {
-    if (!this.disabled) this._focused = true;
+    if (!this.isFormDisabled) this._focused = true;
   }
 
   private _handleBlur() {
@@ -85,7 +96,7 @@ export class M3Slider extends LitElement {
   }
 
   private _handleMouseDown() {
-    if (!this.disabled) this._active = true;
+    if (!this.isFormDisabled) this._active = true;
   }
 
   private _handleMouseUp() {
@@ -93,25 +104,29 @@ export class M3Slider extends LitElement {
   }
 
   private _handleInput(e: Event) {
+    e.stopPropagation();
     const target = e.target as HTMLInputElement;
     this.value = Number(target.value);
-    
-    this.dispatchEvent(new CustomEvent('slider-input', {
-      bubbles: true,
-      composed: true,
-      detail: { value: this.value }
-    }));
+    this.emitInput();
   }
 
   private _handleChange(e: Event) {
+    e.stopPropagation();
     const target = e.target as HTMLInputElement;
     this.value = Number(target.value);
+    this.emitChange();
+  }
 
-    this.dispatchEvent(new CustomEvent('slider-change', {
-      bubbles: true,
-      composed: true,
-      detail: { value: this.value, name: this.name }
-    }));
+  private _syncFormState(): void {
+    this.setFormValue(this.isFormDisabled ? null : String(this.value), String(this.value));
+  }
+
+  protected resetFormControl(): void {
+    this.value = this._defaultValue;
+  }
+
+  protected restoreFormControlState(state: string | File | FormData | null): void {
+    if (typeof state === 'string' && state !== '') this.value = Number(state);
   }
 }
 

--- a/packages/m3-switch/README.md
+++ b/packages/m3-switch/README.md
@@ -59,7 +59,7 @@ yarn add @banegasn/m3-switch
   </div>
 
   <script>
-    document.getElementById('notifications').addEventListener('switch-change', (e) => {
+    document.getElementById('notifications').addEventListener('change', (e) => {
       console.log('Notifications:', e.detail.checked ? 'enabled' : 'disabled');
     });
   </script>
@@ -85,7 +85,7 @@ import '@banegasn/m3-switch';
 import '@banegasn/m3-switch';
 
 const switchElement = document.querySelector('m3-switch');
-switchElement.addEventListener('switch-change', (e) => {
+switchElement.addEventListener('change', (e) => {
   console.log('Switch is now:', e.detail.checked);
 });
 ```
@@ -116,7 +116,7 @@ import '@banegasn/m3-switch';
   template: `
     <m3-switch
       [checked]="isChecked"
-      (switch-change)="onSwitchChange($event)"
+      (change)="onSwitchChange($event)"
     ></m3-switch>
   `
 })
@@ -135,7 +135,7 @@ export class MyComponent {
 <template>
   <m3-switch
     :checked="isChecked"
-    @switch-change="onSwitchChange"
+    @change="onSwitchChange"
   />
 </template>
 
@@ -159,15 +159,18 @@ const onSwitchChange = (event) => {
 | `disabled` | `boolean` | `false` | Disables the switch |
 | `name` | `string` | `null` | Name attribute for form submission |
 | `value` | `string` | `null` | Value attribute for form submission |
-| `form` | `string` | `null` | Form attribute to associate switch with a form |
+| `form` | `HTMLFormElement \| null` | `null` | Current owner form; set the native `form` attribute to associate by ID |
 | `aria-label` | `string` | `null` | ARIA label for accessibility |
 | `aria-labelledby` | `string` | `null` | ARIA labelled by for accessibility |
 
 ## Events
 
-| Event | Detail | Description |
-|-------|--------|-------------|
-| `switch-change` | `{ checked: boolean, name: string \| null, value: string \| null }` | Fired when the switch state changes |
+| Event | Description |
+|-------|-------------|
+| `input` | Native event fired when the checked state changes. |
+| `change` | Native event fired after the checked state is committed. |
+
+See the [form-associated control migration guide](../../docs/FORM_ASSOCIATED_CONTROLS.md).
 
 ## Methods
 

--- a/packages/m3-switch/package.json
+++ b/packages/m3-switch/package.json
@@ -47,6 +47,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@banegasn/m3-form-associated": "workspace:^",
     "lit": "^3.3.3"
   },
   "devDependencies": {

--- a/packages/m3-switch/src/m3-switch.ts
+++ b/packages/m3-switch/src/m3-switch.ts
@@ -1,5 +1,6 @@
-import { LitElement, html } from 'lit';
+import { html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
+import { FormAssociatedElement } from '@banegasn/m3-form-associated';
 import { m3SwitchStyles } from './m3-switch.styles.js';
 
 /**
@@ -8,7 +9,7 @@ import { m3SwitchStyles } from './m3-switch.styles.js';
  * A switch component following Material Design 3 specifications that allows
  * users to toggle between on and off states.
  * 
- * @fires switch-change - Fired when the switch state changes
+ * Emits native `input` and `change` events when the checked state changes.
  * 
  * @cssprop --md-comp-switch-track-width - Width of the switch track (default: 52px)
  * @cssprop --md-comp-switch-track-height - Height of the switch track (default: 32px)
@@ -19,8 +20,9 @@ import { m3SwitchStyles } from './m3-switch.styles.js';
  * @cssprop --md-sys-color-surface-container-highest - Surface color for disabled state
  */
 @customElement('m3-switch')
-export class M3Switch extends LitElement {
+export class M3Switch extends FormAssociatedElement {
   static styles = m3SwitchStyles;
+  static readonly formAssociated = true;
 
   /**
    * Whether the switch is checked (on)
@@ -37,20 +39,17 @@ export class M3Switch extends LitElement {
   /**
    * Name attribute for form submission
    */
-  @property({ type: String })
+  @property({ type: String, reflect: true })
   name: string | null = null;
 
   /**
    * Value attribute for form submission
    */
-  @property({ type: String })
+  @property({ type: String, reflect: true })
   value: string | null = null;
 
-  /**
-   * Form attribute to associate switch with a form
-   */
-  @property({ type: String })
-  form: string | null = null;
+  @property({ type: Boolean, reflect: true })
+  required = false;
 
   /**
    * ARIA label for accessibility
@@ -75,6 +74,7 @@ export class M3Switch extends LitElement {
    */
   @state()
   private _hovered = false;
+  private _defaultChecked = false;
 
   render() {
     return html`
@@ -82,10 +82,10 @@ export class M3Switch extends LitElement {
         class="switch-container"
         role="switch"
         aria-checked=${this.checked}
-        aria-disabled=${this.disabled}
+        aria-disabled=${this.isFormDisabled}
         aria-label=${this.ariaLabel || ''}
         aria-labelledby=${this.ariaLabelledBy || ''}
-        tabindex=${this.disabled ? -1 : 0}
+        tabindex=${this.isFormDisabled ? -1 : 0}
         @click=${this._handleClick}
         @keydown=${this._handleKeyDown}
         @keyup=${this._handleKeyUp}
@@ -94,8 +94,8 @@ export class M3Switch extends LitElement {
         @mousedown=${this._handleMouseDown}
         @mouseup=${this._handleMouseUp}
       >
-        <div class="track" ?checked=${this.checked} ?disabled=${this.disabled}>
-          <div class="thumb" ?checked=${this.checked} ?disabled=${this.disabled} ?pressed=${this._pressed}>
+        <div class="track" ?checked=${this.checked} ?disabled=${this.isFormDisabled}>
+          <div class="thumb" ?checked=${this.checked} ?disabled=${this.isFormDisabled} ?pressed=${this._pressed}>
             ${this.checked ? html`
               <svg class="checkmark" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z" fill="currentColor"/>
@@ -104,22 +104,20 @@ export class M3Switch extends LitElement {
           </div>
         </div>
       </div>
-      <input
-        type="checkbox"
-        ?checked=${this.checked}
-        ?disabled=${this.disabled}
-        name=${this.name || ''}
-        value=${this.value || ''}
-        form=${this.form || ''}
-        aria-hidden="true"
-        tabindex="-1"
-        @change=${this._handleInputChange}
-      />
     `;
   }
 
+  firstUpdated(): void {
+    this._defaultChecked = this.checked;
+    this._syncFormState();
+  }
+
+  updated(): void {
+    this._syncFormState();
+  }
+
   private _handleClick(e: MouseEvent) {
-    if (this.disabled) {
+    if (this.isFormDisabled) {
       e.preventDefault();
       e.stopPropagation();
       return;
@@ -129,7 +127,7 @@ export class M3Switch extends LitElement {
   }
 
   private _handleKeyDown(e: KeyboardEvent) {
-    if (this.disabled) {
+    if (this.isFormDisabled) {
       return;
     }
 
@@ -140,7 +138,7 @@ export class M3Switch extends LitElement {
   }
 
   private _handleKeyUp(e: KeyboardEvent) {
-    if (this.disabled) {
+    if (this.isFormDisabled) {
       return;
     }
 
@@ -152,7 +150,7 @@ export class M3Switch extends LitElement {
   }
 
   private _handleMouseEnter() {
-    if (!this.disabled) {
+    if (!this.isFormDisabled) {
       this._hovered = true;
     }
   }
@@ -163,7 +161,7 @@ export class M3Switch extends LitElement {
   }
 
   private _handleMouseDown() {
-    if (!this.disabled) {
+    if (!this.isFormDisabled) {
       this._pressed = true;
     }
   }
@@ -172,32 +170,30 @@ export class M3Switch extends LitElement {
     this._pressed = false;
   }
 
-  private _handleInputChange(e: Event) {
-    // Sync with internal checkbox for form submission
-    const input = e.target as HTMLInputElement;
-    if (input.checked !== this.checked) {
-      this.checked = input.checked;
-    }
-  }
-
   private _toggle() {
     this.checked = !this.checked;
-    
-    // Update the hidden input for form submission
-    const input = this.shadowRoot?.querySelector('input[type="checkbox"]') as HTMLInputElement;
-    if (input) {
-      input.checked = this.checked;
-    }
+    this.emitInput();
+    this.emitChange();
+  }
 
-    this.dispatchEvent(new CustomEvent('switch-change', {
-      bubbles: true,
-      composed: true,
-      detail: {
-        checked: this.checked,
-        name: this.name,
-        value: this.value
-      }
-    }));
+  private _syncFormState(): void {
+    const disabled = this.isFormDisabled;
+    this.setFormValue(!disabled && this.checked ? this.value ?? 'on' : null, this.checked ? 'checked' : 'unchecked');
+    this.setFormValidity(
+      !disabled && this.required && !this.checked ? { valueMissing: true } : {},
+      !disabled && this.required && !this.checked ? 'Please turn this switch on.' : '',
+      this.shadowRoot?.querySelector<HTMLElement>('.switch-container') ?? undefined,
+    );
+  }
+
+  protected resetFormControl(): void {
+    this.checked = this._defaultChecked;
+  }
+
+  protected restoreFormControlState(state: string | File | FormData | null): void {
+    if (typeof state === 'string') {
+      this.checked = state === 'checked';
+    }
   }
 
   /**

--- a/packages/m3-text-field/README.md
+++ b/packages/m3-text-field/README.md
@@ -117,10 +117,12 @@ import '@banegasn/m3-text-field';
 
 ### Events
 
-| Event | Detail | Description |
-|-------|--------|-------------|
-| `text-field-input` | `{ value: string, name: string \| null }` | Fired on every keystroke |
-| `text-field-change` | `{ value: string, name: string \| null }` | Fired when value is committed |
+| Event | Description |
+|-------|-------------|
+| `input` | Native event fired on every user edit. |
+| `change` | Native event fired when the value is committed. |
+
+See the [form-associated control migration guide](../../docs/FORM_ASSOCIATED_CONTROLS.md).
 
 ### Slots
 

--- a/packages/m3-text-field/package.json
+++ b/packages/m3-text-field/package.json
@@ -45,6 +45,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@banegasn/m3-form-associated": "workspace:^",
     "lit": "^3.3.3"
   },
   "devDependencies": {

--- a/packages/m3-text-field/src/m3-text-field.ts
+++ b/packages/m3-text-field/src/m3-text-field.ts
@@ -1,20 +1,28 @@
-import { LitElement, html } from 'lit';
+import { html } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { customElement, property, state, query } from 'lit/decorators.js';
+import { FormAssociatedElement, validityFlags } from '@banegasn/m3-form-associated';
 import { m3TextFieldStyles } from './m3-text-field.styles.js';
 
 @customElement('m3-text-field')
-export class M3TextField extends LitElement {
+export class M3TextField extends FormAssociatedElement {
   static styles = m3TextFieldStyles;
+  static readonly formAssociated = true;
 
   @property({ type: String }) type = 'text';
   @property({ type: String }) label = '';
-  @property({ type: String }) value = '';
+  @property({ type: String, reflect: true }) value = '';
   @property({ type: String }) placeholder = '';
   @property({ type: Boolean, reflect: true }) disabled = false;
-  @property({ type: String }) name: string | null = null;
+  @property({ type: String, reflect: true }) name: string | null = null;
+  @property({ type: Boolean, reflect: true }) required = false;
+  @property({ type: Number, attribute: 'maxlength' }) maxLength: number | null = null;
+  @property({ type: Number, attribute: 'minlength' }) minLength: number | null = null;
+  @property({ type: String }) pattern: string | null = null;
   
   @state() private _focused = false;
   @query('input') inputEl!: HTMLInputElement;
+  private _defaultValue = '';
 
   render() {
     return html`
@@ -27,9 +35,12 @@ export class M3TextField extends LitElement {
           class="input"
           type=${this.type}
           .value=${this.value}
-          ?disabled=${this.disabled}
+          ?disabled=${this.isFormDisabled}
+          ?required=${this.required}
           placeholder=${this.placeholder}
-          name=${this.name || ''}
+          maxlength=${ifDefined(this.maxLength ?? undefined)}
+          minlength=${ifDefined(this.minLength ?? undefined)}
+          pattern=${ifDefined(this.pattern ?? undefined)}
           @focus=${this._handleFocus}
           @blur=${this._handleBlur}
           @input=${this._handleInput}
@@ -38,6 +49,15 @@ export class M3TextField extends LitElement {
         <div class="indicator"></div>
       </div>
     `;
+  }
+
+  firstUpdated(): void {
+    this._defaultValue = this.value;
+    this._syncFormState();
+  }
+
+  updated(): void {
+    this._syncFormState();
   }
 
   private _handleFocus() {
@@ -49,31 +69,46 @@ export class M3TextField extends LitElement {
   }
 
   private _handleInput(e: Event) {
+    e.stopPropagation();
     const target = e.target as HTMLInputElement;
     this.value = target.value;
-    
-    this.dispatchEvent(new CustomEvent('textfield-input', {
-      bubbles: true,
-      composed: true,
-      detail: { value: this.value }
-    }));
+    this.emitInput();
   }
 
   private _handleChange(e: Event) {
+    e.stopPropagation();
     const target = e.target as HTMLInputElement;
     this.value = target.value;
-    
-    this.dispatchEvent(new CustomEvent('textfield-change', {
-      bubbles: true,
-      composed: true,
-      detail: { value: this.value, name: this.name }
-    }));
+    this.emitChange();
+  }
+
+  private _syncFormState(): void {
+    const input = this.inputEl;
+    const flags = !this.isFormDisabled && input ? validityFlags(input.validity) : {};
+    if (this.value) delete flags.valueMissing;
+    else if (this.required && !this.isFormDisabled) flags.valueMissing = true;
+    const invalid = Object.keys(flags).length > 0;
+    this.setFormValue(this.isFormDisabled ? null : this.value, this.value);
+    this.setFormValidity(
+      flags,
+      invalid ? input.validationMessage : '',
+      input,
+    );
+  }
+
+  protected resetFormControl(): void {
+    this.value = this._defaultValue;
+  }
+
+  protected restoreFormControlState(state: string | File | FormData | null): void {
+    if (typeof state === 'string') this.value = state;
   }
 
   focus() {
     this.inputEl?.focus();
   }
 }
+
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,6 +202,9 @@ importers:
 
   packages/m3-button:
     dependencies:
+      '@banegasn/m3-form-associated':
+        specifier: workspace:^
+        version: link:../m3-form-associated
       lit:
         specifier: ^3.3.3
         version: 3.3.3
@@ -222,10 +225,31 @@ importers:
 
   packages/m3-checkbox:
     dependencies:
+      '@banegasn/m3-form-associated':
+        specifier: workspace:^
+        version: link:../m3-form-associated
       lit:
         specifier: ^3.3.3
         version: 3.3.3
     devDependencies:
+      '@banegasn/m3-button':
+        specifier: workspace:^
+        version: link:../m3-button
+      '@banegasn/m3-radio-button':
+        specifier: workspace:^
+        version: link:../m3-radio-button
+      '@banegasn/m3-search-bar':
+        specifier: workspace:^
+        version: link:../m3-search-bar
+      '@banegasn/m3-slider':
+        specifier: workspace:^
+        version: link:../m3-slider
+      '@banegasn/m3-switch':
+        specifier: workspace:^
+        version: link:../m3-switch
+      '@banegasn/m3-text-field':
+        specifier: workspace:^
+        version: link:../m3-text-field
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -261,6 +285,16 @@ importers:
         version: 5.9.3
 
   packages/m3-fab-menu:
+    dependencies:
+      lit:
+        specifier: ^3.3.3
+        version: 3.3.3
+    devDependencies:
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+  packages/m3-form-associated:
     dependencies:
       lit:
         specifier: ^3.3.3
@@ -342,6 +376,9 @@ importers:
 
   packages/m3-radio-button:
     dependencies:
+      '@banegasn/m3-form-associated':
+        specifier: workspace:^
+        version: link:../m3-form-associated
       lit:
         specifier: ^3.3.3
         version: 3.3.3
@@ -352,6 +389,9 @@ importers:
 
   packages/m3-search-bar:
     dependencies:
+      '@banegasn/m3-form-associated':
+        specifier: workspace:^
+        version: link:../m3-form-associated
       lit:
         specifier: ^3.3.3
         version: 3.3.3
@@ -362,6 +402,9 @@ importers:
 
   packages/m3-slider:
     dependencies:
+      '@banegasn/m3-form-associated':
+        specifier: workspace:^
+        version: link:../m3-form-associated
       lit:
         specifier: ^3.3.3
         version: 3.3.3
@@ -392,6 +435,9 @@ importers:
 
   packages/m3-switch:
     dependencies:
+      '@banegasn/m3-form-associated':
+        specifier: workspace:^
+        version: link:../m3-form-associated
       lit:
         specifier: ^3.3.3
         version: 3.3.3
@@ -412,6 +458,9 @@ importers:
 
   packages/m3-text-field:
     dependencies:
+      '@banegasn/m3-form-associated':
+        specifier: workspace:^
+        version: link:../m3-form-associated
       lit:
         specifier: ^3.3.3
         version: 3.3.3

--- a/scripts/install-test-browser.mjs
+++ b/scripts/install-test-browser.mjs
@@ -1,6 +1,6 @@
 import { spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
-import { chromium } from 'playwright';
+import { chromium, firefox, webkit } from 'playwright';
 
 if (process.env.VITEST_BROWSER_CHANNEL) {
   console.log(
@@ -9,16 +9,22 @@ if (process.env.VITEST_BROWSER_CHANNEL) {
   process.exit(0);
 }
 
-const executablePath = chromium.executablePath();
+const browserEngines = [
+  ['Chromium', chromium],
+  ['Firefox', firefox],
+  ['WebKit', webkit],
+];
 
-if (existsSync(executablePath)) {
-  console.log(`[test] Using installed Playwright Chromium: ${executablePath}`);
+const missingBrowsers = browserEngines.filter(([, browser]) => !existsSync(browser.executablePath()));
+
+if (missingBrowsers.length === 0) {
+  console.log(`[test] Using installed Playwright browsers: ${browserEngines.map(([name]) => name).join(', ')}`);
   process.exit(0);
 }
 
 const result = spawnSync(
   'pnpm',
-  ['exec', 'playwright', 'install', 'chromium'],
+  ['exec', 'playwright', 'install', ...missingBrowsers.map(([name]) => name.toLowerCase())],
   {
     stdio: 'inherit',
     shell: process.platform === 'win32',
@@ -29,7 +35,7 @@ const result = spawnSync(
 
 if (result.error?.code === 'ETIMEDOUT') {
   console.error(
-    '[test] Timed out installing Chromium after two minutes. Retry once the Playwright browser cache is available.',
+    '[test] Timed out installing Playwright browsers after two minutes. Retry once the browser cache is available.',
   );
 }
 

--- a/scripts/smoke-packages.mjs
+++ b/scripts/smoke-packages.mjs
@@ -118,18 +118,18 @@ async function validateInstalledPackage(fixture, expectedManifest) {
 
 async function packPackage(packageInfo, archiveDirectory) {
   const { stdout } = await run(
-    'npm',
-    ['pack', packageInfo.directory, '--json', '--pack-destination', archiveDirectory],
-    { cwd: repositoryRoot, maxBuffer: 10 * 1024 * 1024 },
+    'pnpm',
+    ['pack', '--json', '--pack-destination', archiveDirectory],
+    { cwd: packageInfo.directory, maxBuffer: 10 * 1024 * 1024 },
   );
-  const result = JSON.parse(stdout);
-  const filename = result[0]?.filename;
+  const result = JSON.parse(stdout.slice(stdout.indexOf('{')));
+  const filename = result.filename;
 
   if (!filename) {
     throw new Error(`npm pack did not return an archive for ${packageInfo.manifest.name}`);
   }
 
-  return join(archiveDirectory, filename);
+  return filename;
 }
 
 async function importPackagesFromFixture(fixture, packageNames) {

--- a/vitest.browser.config.ts
+++ b/vitest.browser.config.ts
@@ -20,6 +20,7 @@ const browserPorts: Record<string, number> = {
   'm3-snackbar': 63_323,
   'm3-top-app-bar': 63_324,
   'm3-progress': 63_326,
+  'm3-checkbox': 63_327,
 };
 
 const port = browserPorts[workspaceName];

--- a/vitest.browser.config.ts
+++ b/vitest.browser.config.ts
@@ -25,6 +25,14 @@ const browserPorts: Record<string, number> = {
 
 const port = browserPorts[workspaceName];
 
+const browserInstances = browserChannel
+  ? [{ browser: 'chromium' as const }]
+  : [
+      { browser: 'chromium' as const },
+      { browser: 'firefox' as const },
+      { browser: 'webkit' as const },
+    ];
+
 if (port === undefined) {
   throw new Error(`No Vitest browser port is assigned to ${workspaceName}.`);
 }
@@ -46,11 +54,10 @@ export default defineConfig({
       provider: playwright({
         launchOptions: browserChannel ? { channel: browserChannel } : undefined,
       }),
-      instances: [
-        {
-          browser: 'chromium',
-        },
-      ],
+      // This is the supported-browser matrix for browser tests. A channel is
+      // intentionally Chromium-only because Playwright channels are Chromium
+      // distributions rather than cross-browser engines.
+      instances: browserInstances,
     },
   },
   resolve: {


### PR DESCRIPTION
Closes #7

## What changed
- Adds a shared ElementInternals form-associated contract package.
- Migrates m3-button, checkbox, radio button, switch, slider, text field, and search bar away from shadow hidden-input mirrors.
- Uses native owner-form, FormData, disabled-fieldset, validation, reset, and state-restoration semantics.
- Removes component-specific interaction events in favour of native click/input/change events; the migration and browser-support contract is documented.
- Uses standards-consistent custom-button submission: submit invokes requestSubmit once, with a null native submitter and no synthetic button FormData entry.
- Runs the form integration suite on Playwright Chromium, Firefox, and WebKit; CI installs all three engines.
- Updates packed-package smoke coverage so workspace protocol dependencies are verified as publishable archives.

## Acceptance mapping
- FormData and external owner forms: real browser integration test.
- Native button submitter semantics plus submit/reset once: real browser integration test.
- Disabled fieldset and required/invalid validity: real browser integration test.
- Reset/restoration and radio owner-form grouping: real browser integration test.
- Chromium, Firefox, and WebKit: 24 passing browser executions.
- Browser support/fallback and clean-break migration: docs/FORM_ASSOCIATED_CONTROLS.md.

## Verification
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm tokens:check
- pnpm exec turbo run build
- pnpm audit:prod
- pnpm smoke:packages
- pnpm smoke:svelte-vite
- pnpm verify:package-licenses