### PR TITLE
fix: repair temporary menu interaction contracts

### DIFF
--- a/apps/angular-app/src/pages/fab-menu/fab-menu.component.html
+++ b/apps/angular-app/src/pages/fab-menu/fab-menu.component.html
@@ -1,48 +1,32 @@
 <div class="page-container docs-page">
-    <header class="page-header">
-        <h1>FAB Menu</h1>
-        <p class="subtitle">
-            A Floating Action Button that expands into a menu of related actions.
-            Replaces the traditional speed dial with more expressive motion.
-        </p>
-    </header>
+  <header class="page-header">
+    <h1>FAB Menu</h1>
+    <p class="subtitle">A Floating Action Button that opens a related accessible menu.</p>
+  </header>
 
-    <section class="demo-section">
-        <h2>Interactive Demo</h2>
-        <p>Click the FAB to toggle the menu. Notice the shape morphing and rotation animation.</p>
+  <section class="demo-section">
+    <h2>Interactive Demo</h2>
+    <div class="variant-card"
+      style="height: 400px; position: relative; background-color: var(--md-sys-color-surface-container-low, #f7f2fa); overflow: hidden; border-radius: 16px;">
+      <div style="position: absolute; bottom: 24px; right: 24px;">
+        <m3-fab-menu label="Create item">
+          <m3-menu slot="menu" placement="top-end">
+            <m3-menu-item value="edit">Edit</m3-menu-item>
+            <m3-menu-item value="delete">Delete</m3-menu-item>
+            <m3-menu-item value="link">Link</m3-menu-item>
+          </m3-menu>
+        </m3-fab-menu>
+      </div>
+    </div>
+    <app-code-block language="html" variant="sample" [code]="basicExample"></app-code-block>
+  </section>
 
-        <div class="variant-card"
-            style="height: 400px; position: relative; background-color: var(--md-sys-color-surface-container-low, #f7f2fa); overflow: hidden; border-radius: 16px;">
-            <div style="position: absolute; bottom: 24px; right: 24px;">
-                <m3-fab-menu>
-                    <m3-button variant="elevated" icon-only aria-label="Edit">
-                        <span slot="icon" class="material-symbols-outlined">edit</span>
-                    </m3-button>
-                    <m3-button variant="elevated" icon-only aria-label="Delete">
-                        <span slot="icon" class="material-symbols-outlined">delete</span>
-                    </m3-button>
-                    <m3-button variant="elevated" icon-only aria-label="Link">
-                        <span slot="icon" class="material-symbols-outlined">link</span>
-                    </m3-button>
-                </m3-fab-menu>
-            </div>
-            <p
-                style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); color: var(--md-sys-color-outline);">
-                Content Area
-            </p>
-        </div>
-
-        <app-code-block language="html" variant="sample" [code]="basicExample"></app-code-block>
-    </section>
-
-    <section class="demo-section accessibility">
-        <h2>♿ Accessibility</h2>
-        <ul class="feature-list">
-            <li><strong>Keyboard Support:</strong> The FAB is a button that can be activated with Enter/Space.</li>
-            <li><strong>Focus Management:</strong> When opened, focus should be managed to the menu items
-                (implementation
-                dependent).</li>
-            <li><strong>ARIA:</strong> The FAB has <code>aria-label="Menu"</code> by default.</li>
-        </ul>
-    </section>
+  <section class="demo-section accessibility">
+    <h2>♿ Accessibility</h2>
+    <ul class="feature-list">
+      <li><strong>Keyboard:</strong> Arrow keys, Home, and End enter the menu.</li>
+      <li><strong>Focus:</strong> Escape and outside click return to the FAB.</li>
+      <li><strong>ARIA:</strong> The configured label, expanded state, and controls relationship are exposed.</li>
+    </ul>
+  </section>
 </div>

--- a/apps/angular-app/src/pages/fab-menu/fab-menu.component.ts
+++ b/apps/angular-app/src/pages/fab-menu/fab-menu.component.ts
@@ -5,7 +5,7 @@ import {
 } from '@angular/core';
 import { CodeBlockComponent } from '../../app/components/code-block/code-block.component';
 import '@banegasn/m3-fab-menu';
-import '@banegasn/m3-button';
+import '@banegasn/m3-menu';
 
 @Component({
   selector: 'app-fab-menu',
@@ -17,8 +17,10 @@ import '@banegasn/m3-button';
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
 export class FabMenuComponent {
-  readonly basicExample = `<m3-fab-menu>
-    <m3-button variant="elevated" icon-only>...</m3-button>
-    <m3-button variant="elevated" icon-only>...</m3-button>
+  readonly basicExample = `<m3-fab-menu label="Create item">
+  <m3-menu slot="menu" placement="top-end">
+    <m3-menu-item value="edit">Edit</m3-menu-item>
+    <m3-menu-item value="delete">Delete</m3-menu-item>
+  </m3-menu>
 </m3-fab-menu>`;
 }

--- a/apps/angular-app/src/pages/split-button/split-button.component.html
+++ b/apps/angular-app/src/pages/split-button/split-button.component.html
@@ -1,108 +1,33 @@
 <div class="page-container docs-page">
-    <header class="page-header">
-        <h1>Split Button</h1>
-        <p class="subtitle">
-            A split button groups a primary action with a related menu of options.
-            Material 3 Expressive adds shape morphing and rotation animations.
-        </p>
-    </header>
+  <header class="page-header">
+    <h1>Split Button</h1>
+    <p class="subtitle">A primary action paired with a keyboard-complete menu trigger.</p>
+  </header>
 
-    <section class="demo-section">
-        <h2>Variants</h2>
-        <p>Split buttons come in the same variants as standard buttons: filled, tonal, elevated, and outlined.</p>
+  <section class="demo-section">
+    <h2>Interactive Demo</h2>
+    <div class="variant-card">
+      <m3-split-button [open]="menuOpen" menu-label="More send options"
+        (split-button-click)="handlePrimaryAction()"
+        (split-button-open-change)="handleMenuChange($event)">
+        Send
+        <m3-menu slot="menu" placement="bottom-end" (menu-item-select)="handleMenuItemSelect($event)">
+          <m3-menu-item value="schedule-send">Schedule send</m3-menu-item>
+          <m3-menu-item value="save-draft">Save draft</m3-menu-item>
+          <m3-menu-item value="send-test">Send test</m3-menu-item>
+        </m3-menu>
+      </m3-split-button>
+      <p style="margin: 12px 0 0;">Last interaction: <code>{{ lastInteraction }}</code></p>
+      <app-code-block language="html" variant="sample" [code]="basicExample"></app-code-block>
+    </div>
+  </section>
 
-        <div class="variant-card">
-            <div class="variant-header">
-                <h3>Interactive Demo</h3>
-                <span class="emphasis-badge high">Try clicking both sides</span>
-            </div>
-            <div class="demo-row split-button-row" style="gap: 24px; flex-wrap: wrap;">
-                <div class="split-button-demo">
-                    <m3-split-button menu-id="split-button-send-menu" [attr.menu-open]="menuState['send'] ? '' : null"
-                        (split-button-click)="handleMenuToggle('send', $event)">
-                        Send
-                    </m3-split-button>
-                    <m3-menu id="split-button-send-menu" placement="bottom-end" [attr.open]="menuState['send'] ? '' : null"
-                        (menu-dismiss)="handleMenuDismiss('send')"
-                        (menu-item-select)="handleMenuItemSelect('send', $event)">
-                        <m3-menu-item value="schedule-send">Schedule send</m3-menu-item>
-                        <m3-menu-item value="save-draft">Save draft</m3-menu-item>
-                        <m3-menu-item value="send-test">Send test</m3-menu-item>
-                    </m3-menu>
-                </div>
-
-                <div class="split-button-demo">
-                    <m3-split-button variant="outlined" menu-id="split-button-save-menu"
-                        [attr.menu-open]="menuState['save'] ? '' : null"
-                        (split-button-click)="handleMenuToggle('save', $event)">
-                        Save
-                    </m3-split-button>
-                    <m3-menu id="split-button-save-menu" placement="bottom-end" [attr.open]="menuState['save'] ? '' : null"
-                        (menu-dismiss)="handleMenuDismiss('save')"
-                        (menu-item-select)="handleMenuItemSelect('save', $event)">
-                        <m3-menu-item value="save-as">Save as</m3-menu-item>
-                        <m3-menu-item value="export-pdf">Export PDF</m3-menu-item>
-                    </m3-menu>
-                </div>
-
-                <div class="split-button-demo">
-                    <m3-split-button variant="tonal" menu-id="split-button-edit-menu"
-                        [attr.menu-open]="menuState['edit'] ? '' : null"
-                        (split-button-click)="handleMenuToggle('edit', $event)">
-                        Edit
-                    </m3-split-button>
-                    <m3-menu id="split-button-edit-menu" placement="bottom-end" [attr.open]="menuState['edit'] ? '' : null"
-                        (menu-dismiss)="handleMenuDismiss('edit')"
-                        (menu-item-select)="handleMenuItemSelect('edit', $event)">
-                        <m3-menu-item value="rename">Rename</m3-menu-item>
-                        <m3-menu-item value="duplicate">Duplicate</m3-menu-item>
-                    </m3-menu>
-                </div>
-
-                <div class="split-button-demo">
-                    <m3-split-button variant="elevated" menu-id="split-button-create-menu"
-                        [attr.menu-open]="menuState['create'] ? '' : null"
-                        (split-button-click)="handleMenuToggle('create', $event)">
-                        Create
-                    </m3-split-button>
-                    <m3-menu id="split-button-create-menu" placement="bottom-end"
-                        [attr.open]="menuState['create'] ? '' : null"
-                        (menu-dismiss)="handleMenuDismiss('create')"
-                        (menu-item-select)="handleMenuItemSelect('create', $event)">
-                        <m3-menu-item value="new-doc">New document</m3-menu-item>
-                        <m3-menu-item value="new-folder">New folder</m3-menu-item>
-                    </m3-menu>
-                </div>
-            </div>
-            <p style="margin: 12px 0 0;">Last interaction: <code>{{ lastInteraction }}</code></p>
-            <app-code-block language="html" variant="sample" [code]="basicExample"></app-code-block>
-        </div>
-    </section>
-
-    <section class="demo-section">
-        <h2>Usage</h2>
-        <p>Use split buttons when you have a primary action and related secondary actions. The left side triggers the
-            primary action, while the right side (arrow) opens a menu.</p>
-
-        <div class="pattern-card">
-            <h4>Common Use Cases</h4>
-            <ul class="feature-list">
-                <li><strong>Send / Schedule Send:</strong> Primary action sends immediately, menu offers scheduling.
-                </li>
-                <li><strong>Save / Save As:</strong> Primary action saves, menu offers formats.</li>
-                <li><strong>Merge / Squash & Merge:</strong> GitHub-style pull request actions.</li>
-            </ul>
-        </div>
-    </section>
-
-    <section class="demo-section accessibility">
-        <h2>♿ Accessibility</h2>
-        <ul class="feature-list">
-            <li><strong>Keyboard Navigation:</strong> Tab to focus, Enter/Space to activate.</li>
-            <li><strong>Screen Readers:</strong> The two parts are semantically separate buttons.</li>
-            <li><strong>ARIA:</strong> The menu trigger has <code>aria-haspopup="menu"</code> and
-                <code>aria-expanded</code> states.
-            </li>
-        </ul>
-    </section>
+  <section class="demo-section accessibility">
+    <h2>♿ Accessibility</h2>
+    <ul class="feature-list">
+      <li><strong>Keyboard:</strong> Arrow keys, Home, and End open and enter the menu.</li>
+      <li><strong>Focus:</strong> Escape and outside click return focus to the menu trigger.</li>
+      <li><strong>ARIA:</strong> The trigger exposes a real <code>aria-controls</code> relationship.</li>
+    </ul>
+  </section>
 </div>

--- a/apps/angular-app/src/pages/split-button/split-button.component.ts
+++ b/apps/angular-app/src/pages/split-button/split-button.component.ts
@@ -18,43 +18,32 @@ import '@banegasn/m3-split-button';
 })
 export class SplitButtonComponent {
   lastInteraction = 'None';
-  menuState: Record<string, boolean> = {
-    send: false,
-    save: false,
-    edit: false,
-    create: false,
-  };
+  menuOpen = false;
 
   readonly basicExample = `<div class="split-button-demo">
-  <m3-split-button menu-id="send-menu" menu-open>Send</m3-split-button>
-  <m3-menu id="send-menu" open placement="bottom-end">
+  <m3-split-button open>
+    Send
+    <m3-menu slot="menu" placement="bottom-end">
     <m3-menu-item value="schedule-send">Schedule send</m3-menu-item>
     <m3-menu-item value="save-draft">Save draft</m3-menu-item>
-  </m3-menu>
+    </m3-menu>
+  </m3-split-button>
 </div>`;
 
-  handleMenuToggle(key: string, event: any) {
-    const { action, open } = event.detail ?? {};
-
-    if (action === 'menu') {
-      this.menuState[key] = Boolean(open);
-      this.lastInteraction = `${action}: ${key}`;
-      return;
-    }
-
-    if (action === 'main') {
-      this.menuState[key] = false;
-      this.lastInteraction = `${action}: ${key}`;
-    }
+  handlePrimaryAction() {
+    this.menuOpen = false;
+    this.lastInteraction = 'main: send';
   }
 
-  handleMenuDismiss(key: string) {
-    this.menuState[key] = false;
+  handleMenuChange(event: Event) {
+    const detail = (event as CustomEvent<{ open: boolean; reason: string }>).detail;
+    this.menuOpen = detail.open;
+    this.lastInteraction = `menu: ${detail.reason}`;
   }
 
-  handleMenuItemSelect(key: string, event: Event) {
+  handleMenuItemSelect(event: Event) {
     const menuEvent = event as CustomEvent<{ text: string }>;
-    this.menuState[key] = false;
-    this.lastInteraction = `menu-item: ${key} -> ${menuEvent.detail.text}`;
+    this.menuOpen = false;
+    this.lastInteraction = `menu-item: ${menuEvent.detail.text}`;
   }
 }

--- a/packages/m3-fab-menu/README.md
+++ b/packages/m3-fab-menu/README.md
@@ -1,161 +1,44 @@
 # @banegasn/m3-fab-menu
 
-![Preview](images/preview.png)
+An accessible floating-action-button trigger for an `m3-menu`.
 
-
-> Material Design 3 FAB Menu web component — framework-agnostic, built with Lit.
-
-[![npm version](https://img.shields.io/npm/v/@banegasn/m3-fab-menu.svg)](https://www.npmjs.com/package/@banegasn/m3-fab-menu)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](../../LICENSE)
-
-An expressive **M3 FAB Menu** (Floating Action Button Menu) web component — a modern replacement for the speed dial pattern. Features smooth open/close animations and a slotted menu item system. Works in Angular, React, Vue, Svelte, or plain HTML — no build step required.
-
-## Features
-
-- Expressive open/close animations
-- Slotted FAB trigger and menu items
-- Keyboard accessible (Escape to close)
-- Click-outside to dismiss
-- Framework-agnostic custom element
-
-## Installation
-
-```bash
-npm install @banegasn/m3-fab-menu
-# or
-pnpm add @banegasn/m3-fab-menu
-# or
-yarn add @banegasn/m3-fab-menu
-```
-
-## CDN Usage (no build step)
-
-```html
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <title>M3 FAB Menu Demo</title>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@banegasn/m3-fab-menu/+esm"></script>
-  <style>
-    body { font-family: Roboto, sans-serif; background: #fef7ff;  }
-    .fab-container { position: fixed; bottom: 24px; right: 24px; }
-  </style>
-</head>
-<body>
-  <div class="fab-container">
-    <m3-fab-menu>
-      <m3-fab-menu-item label="New document">
-        <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
-          <path fill="currentColor" d="M14 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"/>
-        </svg>
-      </m3-fab-menu-item>
-      <m3-fab-menu-item label="Upload file">
-        <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
-          <path fill="currentColor" d="M9 16h6v-6h4l-7-7-7 7h4zm-4 2h14v2H5z"/>
-        </svg>
-      </m3-fab-menu-item>
-      <m3-fab-menu-item label="New folder">
-        <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
-          <path fill="currentColor" d="M20 6h-8l-2-2H4c-1.11 0-2 .89-2 2v12c0 1.11.89 2 2 2h16c1.11 0 2-.89 2-2V8c0-1.11-.89-2-2-2zm-1 8h-3v3h-2v-3h-3v-2h3V9h2v3h3v2z"/>
-        </svg>
-      </m3-fab-menu-item>
-    </m3-fab-menu>
-  </div>
-
-  <script>
-    document.querySelector('m3-fab-menu').addEventListener('fab-menu-item-click', (e) => {
-      console.log('Selected:', e.detail.label);
-    });
-  </script>
-</body>
-</html>
-```
-
-## npm Usage
-
-```js
-import '@banegasn/m3-fab-menu';
+```sh
+pnpm add @banegasn/m3-fab-menu @banegasn/m3-menu
 ```
 
 ```html
-<m3-fab-menu>
-  <m3-fab-menu-item label="New document">
-    <!-- icon slot -->
-  </m3-fab-menu-item>
-  <m3-fab-menu-item label="Upload">
-    <!-- icon slot -->
-  </m3-fab-menu-item>
+<m3-fab-menu label="Create">
+  <m3-menu slot="menu" placement="top-end">
+    <m3-menu-item value="document">New document</m3-menu-item>
+    <m3-menu-item value="upload">Upload file</m3-menu-item>
+  </m3-menu>
 </m3-fab-menu>
 ```
 
-## API
+The `menu` slot must contain one `m3-menu`. Its ID becomes `aria-controls` on the FAB trigger; an
+ID is generated only when the supplied menu has none, so the component never emits an empty ARIA
+relationship.
 
-### `m3-fab-menu` Properties
+## State and events
+
+`open` is both the direct-use state and controlled input. User interaction updates it and mirrors
+it to the slotted menu. Framework consumers bind `open` and write the value from
+`fab-menu-open-change` to their own state.
 
 | Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `open` | `boolean` | `false` | Whether the menu is open |
+|---|---|---|---|
+| `open` | `boolean` | `false` | Rendered menu visibility |
+| `disabled` | `boolean` | `false` | Makes the trigger inert |
+| `label` | `string` | `'Menu'` | Accessible trigger label |
 
-### `m3-fab-menu` Events
+| Event | Detail |
+|---|---|
+| `fab-menu-open-change` | `{ open: boolean; reason: string }` |
+| `fab-menu-dismiss` | `{ reason: 'escape' \| 'outside' \| 'selection' \| 'tab' }` |
 
-| Event | Detail | Description |
-|-------|--------|-------------|
-| `fab-menu-open` | `{}` | Fired when the menu opens |
-| `fab-menu-close` | `{}` | Fired when the menu closes |
-| `fab-menu-item-click` | `{ label: string }` | Fired when a menu item is clicked |
-
-### `m3-fab-menu-item` Properties
-
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `label` | `string` | `''` | Item label text |
-| `disabled` | `boolean` | `false` | Disables the item |
-
-### Slots
-
-| Slot | Description |
-|------|-------------|
-| (default) | `m3-fab-menu-item` elements |
-| `icon` (on item) | Icon for each menu item |
-
-### CSS Custom Properties
-
-| Property | Default | Description |
-|----------|---------|-------------|
-| `--md-sys-color-primary-container` | `#eaddff` | FAB background color |
-| `--md-sys-color-on-primary-container` | `#21005d` | FAB icon color |
-| `--md-sys-color-surface-container-high` | `#ece6f0` | Menu item background |
-
-## Framework Usage
-
-### Angular
-```typescript
-import '@banegasn/m3-fab-menu';
-```
-```html
-<m3-fab-menu (fab-menu-item-click)="onItemClick($event)">
-  <m3-fab-menu-item label="New"></m3-fab-menu-item>
-</m3-fab-menu>
-```
-
-### React
-```jsx
-import '@banegasn/m3-fab-menu';
-// <m3-fab-menu onfab-menu-item-click={handleClick}>...</m3-fab-menu>
-```
-
-### Vue
-```vue
-<m3-fab-menu @fab-menu-item-click="handleClick">
-  <m3-fab-menu-item label="New" />
-</m3-fab-menu>
-```
-
-## Resources
-
-- [Material Design 3 FAB](https://m3.material.io/components/floating-action-button/overview)
-- [GitHub Repository](https://github.com/banegasn/components)
+The trigger uses `aria-haspopup="menu"`, accurate `aria-expanded`, and keyboard opening with
+ArrowDown/ArrowUp/Home/End. Escape, outside press, item selection, and Tab delegate to the slotted
+menu’s focus and dismissal behavior.
 
 ## License
 

--- a/packages/m3-fab-menu/package.json
+++ b/packages/m3-fab-menu/package.json
@@ -23,8 +23,8 @@
     "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist",
     "lint": "eslint src --max-warnings 0",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node ../../scripts/no-tests.mjs"
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json",
+    "test": "vitest run --config ../../vitest.browser.config.ts"
   },
   "repository": {
     "type": "git",

--- a/packages/m3-fab-menu/src/m3-fab-menu.styles.ts
+++ b/packages/m3-fab-menu/src/m3-fab-menu.styles.ts
@@ -30,6 +30,13 @@ export const m3FabMenuStyles = css`
     box-shadow: 0px 6px 10px 4px rgba(0,0,0,0.15);
   }
 
+  .fab:disabled {
+    cursor: default;
+    opacity: 0.38;
+    filter: none;
+    box-shadow: none;
+  }
+
   .fab.active {
     transform: rotate(135deg);
     border-radius: 28px; /* Circle */

--- a/packages/m3-fab-menu/src/m3-fab-menu.test.ts
+++ b/packages/m3-fab-menu/src/m3-fab-menu.test.ts
@@ -1,0 +1,38 @@
+import { fixture, html, expect } from '@open-wc/testing';
+import { describe, it } from 'vitest';
+import '../../m3-menu/src/m3-menu.js';
+import './m3-fab-menu.js';
+import type { M3FabMenu } from './m3-fab-menu.js';
+
+describe('M3FabMenu public interaction contract', () => {
+  it('uses the supplied label and coordinates its slotted menu', async () => {
+    const el = await fixture<M3FabMenu>(html`
+      <m3-fab-menu label="Create item">
+        <m3-menu slot="menu"><m3-menu-item>New file</m3-menu-item></m3-menu>
+      </m3-fab-menu>
+    `);
+    await el.updateComplete;
+    const trigger = el.shadowRoot!.querySelector<HTMLButtonElement>('.fab')!;
+    const menu = el.querySelector('m3-menu')!;
+    expect(trigger.getAttribute('aria-label')).to.equal('Create item');
+    expect(trigger.getAttribute('aria-controls')).to.equal(menu.id);
+
+    trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, composed: true }));
+    await el.updateComplete;
+    await (menu as unknown as { updateComplete: Promise<unknown> }).updateComplete;
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+    expect(el.open).to.be.true;
+    expect(trigger.getAttribute('aria-expanded')).to.equal('true');
+    expect((menu.querySelector('m3-menu-item') as HTMLElement).shadowRoot!.activeElement).to.exist;
+  });
+
+  it('reports dismissal and keeps a disabled trigger inert', async () => {
+    const el = await fixture<M3FabMenu>(html`
+      <m3-fab-menu disabled><m3-menu slot="menu"><m3-menu-item>New</m3-menu-item></m3-menu></m3-fab-menu>
+    `);
+    const trigger = el.shadowRoot!.querySelector<HTMLButtonElement>('.fab')!;
+    trigger.click();
+    await el.updateComplete;
+    expect(el.open).to.be.false;
+  });
+});

--- a/packages/m3-fab-menu/src/m3-fab-menu.ts
+++ b/packages/m3-fab-menu/src/m3-fab-menu.ts
@@ -1,34 +1,179 @@
 import { LitElement, html } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
+import { customElement, property, queryAssignedElements } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { m3FabMenuStyles } from './m3-fab-menu.styles.js';
 
+type MenuOpenReason = 'trigger' | 'programmatic' | 'escape' | 'outside' | 'selection' | 'tab';
+
+interface MenuElement extends HTMLElement {
+    open: boolean;
+    show(reason?: 'trigger' | 'programmatic'): void;
+    dismiss(reason?: MenuOpenReason): void;
+    focusFirstItem(): void;
+    focusLastItem(): void;
+}
+
+let menuId = 0;
+
 /**
- * Material Design 3 FAB Menu
- * 
- * Replaces speed dial with a more expressive menu interaction.
+ * A FAB trigger for an `m3-menu` supplied through the `menu` slot.
+ * `open` is the public source of truth: user interaction updates it, while
+ * framework consumers can set it directly and observe `fab-menu-open-change`.
  */
 @customElement('m3-fab-menu')
 export class M3FabMenu extends LitElement {
     static styles = m3FabMenuStyles;
 
-    @state()
-    private _open = false;
+    @property({ type: Boolean, reflect: true })
+    open = false;
 
-    private _toggle() {
-        this._open = !this._open;
+    @property({ type: Boolean, reflect: true })
+    disabled = false;
+
+    @property({ type: String, attribute: 'label' })
+    label = 'Menu';
+
+    @queryAssignedElements({ slot: 'menu', flatten: true })
+    private _menus!: HTMLElement[];
+
+    private _pendingReason: MenuOpenReason | undefined;
+
+    connectedCallback() {
+        super.connectedCallback();
+        this.addEventListener('menu-open-change', this._handleMenuOpenChange);
+        this.addEventListener('menu-dismiss', this._handleMenuDismiss);
+    }
+
+    disconnectedCallback() {
+        this.removeEventListener('menu-open-change', this._handleMenuOpenChange);
+        this.removeEventListener('menu-dismiss', this._handleMenuDismiss);
+        super.disconnectedCallback();
+    }
+
+    updated(changedProperties: Map<string, unknown>) {
+        if (!changedProperties.has('open')) {
+            return;
+        }
+
+        const reason = this._pendingReason ?? 'programmatic';
+        this._pendingReason = undefined;
+        const menu = this._menu();
+        if (menu && menu.open !== this.open) {
+            if (this.open) {
+                menu.show(reason === 'programmatic' ? 'programmatic' : 'trigger');
+            } else {
+                menu.dismiss(reason);
+            }
+        }
+        this.dispatchEvent(new CustomEvent('fab-menu-open-change', {
+            bubbles: true,
+            composed: true,
+            detail: { open: this.open, reason }
+        }));
     }
 
     render() {
+        const menu = this._menu();
+        const controls = menu?.id || undefined;
         return html`
-      <div class="menu ${this._open ? 'open' : ''}">
-        <slot></slot>
-      </div>
-      <button class="fab ${this._open ? 'active' : ''}" @click=${this._toggle} aria-label="Menu">
-        <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 -960 960 960" width="24" fill="currentColor">
+      <slot name="menu" @slotchange=${this._handleMenuSlotChange}></slot>
+      <button
+        class="fab ${this.open ? 'active' : ''}"
+        type="button"
+        ?disabled=${this.disabled}
+        aria-label=${this.label}
+        aria-haspopup="menu"
+        aria-expanded=${String(this.open)}
+        aria-controls=${ifDefined(controls || undefined)}
+        @click=${this._toggle}
+        @keydown=${this._handleKeydown}
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 -960 960 960" width="24" fill="currentColor" aria-hidden="true">
           <path d="M440-440H200v-80h240v-240h80v240h240v80H520v240h-80v-240Z"/>
         </svg>
       </button>
     `;
+    }
+
+    private _handleMenuSlotChange = () => {
+        const menu = this._menu();
+        if (!menu) {
+            return;
+        }
+        if (!menu.id) {
+            menu.id = `m3-fab-menu-menu-${++menuId}`;
+        }
+        if (menu.open !== this.open) {
+            menu.open = this.open;
+        }
+        this.requestUpdate();
+    };
+
+    private _handleMenuOpenChange = (event: Event) => {
+        if (event.target === this) {
+            return;
+        }
+        const detail = (event as CustomEvent<{ open: boolean; reason: MenuOpenReason }>).detail;
+        this._pendingReason = detail.reason;
+        this.open = detail.open;
+    };
+
+    private _handleMenuDismiss = (event: Event) => {
+        if (event.target === this) {
+            return;
+        }
+        const detail = (event as CustomEvent<{ reason: MenuOpenReason }>).detail;
+        if (detail.reason !== 'tab') {
+            this.shadowRoot?.querySelector<HTMLButtonElement>('.fab')?.focus();
+        }
+        this.dispatchEvent(new CustomEvent('fab-menu-dismiss', {
+            bubbles: true,
+            composed: true,
+            detail
+        }));
+    };
+
+    private _toggle = (event: MouseEvent) => {
+        if (this.disabled) {
+            return;
+        }
+        (event.currentTarget as HTMLButtonElement).focus();
+        this._requestOpen(!this.open, 'trigger');
+    };
+
+    private _handleKeydown = (event: KeyboardEvent) => {
+        if (this.disabled) {
+            return;
+        }
+        if (event.key === 'Escape' && this.open) {
+            event.preventDefault();
+            this._requestOpen(false, 'escape');
+            return;
+        }
+        if (!this.open && ['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(event.key)) {
+            event.preventDefault();
+            this._requestOpen(true, 'trigger');
+            queueMicrotask(() => {
+                const menu = this._menu();
+                if (event.key === 'ArrowUp' || event.key === 'End') {
+                    menu?.focusLastItem();
+                } else {
+                    menu?.focusFirstItem();
+                }
+            });
+        }
+    };
+
+    private _requestOpen(open: boolean, reason: MenuOpenReason) {
+        if (this.open === open) {
+            return;
+        }
+        this._pendingReason = reason;
+        this.open = open;
+    }
+
+    private _menu(): MenuElement | null {
+        return (this._menus?.find((element) => element.tagName === 'M3-MENU') as MenuElement | undefined) ?? null;
     }
 }
 

--- a/packages/m3-fab-menu/src/m3-fab-menu.ts
+++ b/packages/m3-fab-menu/src/m3-fab-menu.ts
@@ -7,7 +7,7 @@ type MenuOpenReason = 'trigger' | 'programmatic' | 'escape' | 'outside' | 'selec
 
 interface MenuElement extends HTMLElement {
     open: boolean;
-    show(reason?: 'trigger' | 'programmatic'): void;
+    show(reason?: 'trigger' | 'programmatic', opener?: HTMLElement | null): void;
     dismiss(reason?: MenuOpenReason): void;
     focusFirstItem(): void;
     focusLastItem(): void;
@@ -60,7 +60,7 @@ export class M3FabMenu extends LitElement {
         const menu = this._menu();
         if (menu && menu.open !== this.open) {
             if (this.open) {
-                menu.show(reason === 'programmatic' ? 'programmatic' : 'trigger');
+                menu.show(reason === 'programmatic' ? 'programmatic' : 'trigger', this._menuTrigger());
             } else {
                 menu.dismiss(reason);
             }
@@ -174,6 +174,10 @@ export class M3FabMenu extends LitElement {
 
     private _menu(): MenuElement | null {
         return (this._menus?.find((element) => element.tagName === 'M3-MENU') as MenuElement | undefined) ?? null;
+    }
+
+    private _menuTrigger(): HTMLButtonElement | null {
+        return this.shadowRoot?.querySelector<HTMLButtonElement>('.fab') ?? null;
     }
 }
 

--- a/packages/m3-fab-menu/tsconfig.test.json
+++ b/packages/m3-fab-menu/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.test.json",
+  "compilerOptions": {
+    "rootDir": "../.."
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/m3-menu/README.md
+++ b/packages/m3-menu/README.md
@@ -1,161 +1,46 @@
 # @banegasn/m3-menu
 
-![Preview](images/preview.png)
+An accessible Material 3 menu with a public, observable visibility contract.
 
-
-> Material Design 3 Menu web component — framework-agnostic, built with Lit.
-
-[![npm version](https://img.shields.io/npm/v/@banegasn/m3-menu.svg)](https://www.npmjs.com/package/@banegasn/m3-menu)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](../../LICENSE)
-
-An accessible **M3 Menu** web component following the [Material Design 3 menu specifications](https://m3.material.io/components/menus/overview). Includes `m3-menu` and `m3-menu-item` with smart positioning, keyboard navigation, and expressive animations. Works in Angular, React, Vue, Svelte, or plain HTML — no build step required.
-
-## Features
-
-- Smart auto-positioning (top, bottom, start, end)
-- Keyboard navigation (arrow keys, Enter, Escape)
-- Disabled menu items
-- Accessible with ARIA `menu` and `menuitem` roles
-- Pairs naturally with `@banegasn/m3-split-button`
-- Framework-agnostic custom elements
-
-## Installation
-
-```bash
-npm install @banegasn/m3-menu
-# or
+```sh
 pnpm add @banegasn/m3-menu
-# or
-yarn add @banegasn/m3-menu
-```
-
-## CDN Usage (no build step)
-
-```html
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <title>M3 Menu Demo</title>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@banegasn/m3-menu/+esm"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@banegasn/m3-button/+esm"></script>
-  <style>
-    body { font-family: Roboto, sans-serif; padding: 64px; background: #fef7ff; min-width: 400px }
-    .anchor { position: relative; display: flex; justify-content: flex-end; }
-  </style>
-</head>
-<body>
-  <div class="anchor">
-    <m3-button id="menu-trigger" variant="outlined">
-      Options
-      <svg slot="icon" viewBox="0 0 24 24" width="18" height="18">
-        <path fill="currentColor" d="M7 10l5 5 5-5z"/>
-      </svg>
-    </m3-button>
-
-    <m3-menu id="options-menu" open placement="bottom-end">
-      <m3-menu-item value="edit">Edit</m3-menu-item>
-      <m3-menu-item value="duplicate">Duplicate</m3-menu-item>
-      <m3-menu-item value="share">Share</m3-menu-item>
-      <m3-menu-item value="delete" disabled>Delete</m3-menu-item>
-    </m3-menu>
-  </div>
-
-  <script>
-    const menu = document.getElementById('options-menu');
-    document.getElementById('menu-trigger').addEventListener('button-click', () => {
-      menu.open = !menu.open;
-    });
-    menu.addEventListener('menu-item-click', (e) => {
-      console.log('Selected:', e.detail.value);
-      menu.open = false;
-    });
-  </script>
-</body>
-</html>
-```
-
-## npm Usage
-
-```js
-import '@banegasn/m3-menu';
 ```
 
 ```html
-<m3-menu open placement="bottom-end">
+<button id="options">Options</button>
+<m3-menu id="options-menu" placement="bottom-end">
   <m3-menu-item value="edit">Edit</m3-menu-item>
-  <m3-menu-item value="duplicate">Duplicate</m3-menu-item>
   <m3-menu-item value="delete" disabled>Delete</m3-menu-item>
 </m3-menu>
+<script>
+  const trigger = document.querySelector('#options');
+  const menu = document.querySelector('#options-menu');
+  trigger.addEventListener('click', () => menu.show('trigger'));
+  menu.addEventListener('menu-open-change', (event) => console.log(event.detail));
+</script>
 ```
 
-## API
+## State and events
 
-### `m3-menu` Properties
+`open` is the source of truth for rendered visibility. A menu is self-managing when opened with
+`show()` and closed with `dismiss()`, and can be framework-controlled by binding `open` and writing
+the value reported by `menu-open-change` back to application state.
 
 | Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `open` | `boolean` | `false` | Whether the menu is open |
-| `placement` | `'bottom-start' \| 'bottom-end' \| 'top-start' \| 'top-end'` | `'bottom-end'` | Menu placement relative to anchor |
-| `offset` | `number` | `8` | Distance from anchor in pixels |
+|---|---|---|---|
+| `open` | `boolean` | `false` | Rendered visibility |
+| `placement` | `M3MenuPlacement` | `'bottom-end'` | Position relative to its containing anchor |
+| `offset` | `number` | `8` | Anchor separation in pixels |
 
-### `m3-menu` Events
+| Event | Detail |
+|---|---|
+| `menu-item-select` | `{ value: string; text: string }` |
+| `menu-open-change` | `{ open: boolean; reason: 'trigger' \| 'programmatic' \| 'escape' \| 'outside' \| 'selection' \| 'tab' }` |
+| `menu-dismiss` | `{ reason: 'escape' \| 'outside' \| 'selection' \| 'tab' }` |
 
-| Event | Detail | Description |
-|-------|--------|-------------|
-| `menu-item-click` | `{ value: string }` | Fired when a menu item is selected |
-| `menu-close` | `{}` | Fired when the menu closes |
-
-### `m3-menu-item` Properties
-
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `value` | `string` | `''` | Item value returned in events |
-| `disabled` | `boolean` | `false` | Disables the item |
-
-### CSS Custom Properties
-
-| Property | Default | Description |
-|----------|---------|-------------|
-| `--md-sys-color-surface-container` | `#f7f2fa` | Menu background |
-| `--md-sys-color-on-surface` | `#1d1b20` | Menu item text color |
-| `--md-sys-color-secondary-container` | `#e8def8` | Hover state background |
-| `--md-comp-menu-container-shape` | `16px` | Menu border radius |
-
-## Framework Usage
-
-### Angular
-```typescript
-import '@banegasn/m3-menu';
-```
-```html
-<m3-menu [open]="menuOpen" (menu-item-click)="onMenuItemClick($event)" (menu-close)="menuOpen = false">
-  <m3-menu-item value="edit">Edit</m3-menu-item>
-  <m3-menu-item value="delete">Delete</m3-menu-item>
-</m3-menu>
-```
-
-### React
-```jsx
-import '@banegasn/m3-menu';
-// <m3-menu open={menuOpen} onmenu-item-click={handleClick} onmenu-close={() => setMenuOpen(false)}>...</m3-menu>
-```
-
-### Vue
-```vue
-<m3-menu :open="menuOpen" @menu-item-click="handleClick" @menu-close="menuOpen = false">
-  <m3-menu-item value="edit">Edit</m3-menu-item>
-</m3-menu>
-```
-
-## Related Packages
-
-- [@banegasn/m3-split-button](https://www.npmjs.com/package/@banegasn/m3-split-button) — pairs naturally with m3-menu
-
-## Resources
-
-- [Material Design 3 Menus](https://m3.material.io/components/menus/overview)
-- [GitHub Repository](https://github.com/banegasn/components)
+When opened, focus enters the first enabled item. Arrow keys, Home, and End navigate enabled items;
+Escape, outside press, selection, and Tab close the menu. Escape/outside return focus to the opener;
+Tab retains its normal forward focus movement.
 
 ## License
 

--- a/packages/m3-menu/package.json
+++ b/packages/m3-menu/package.json
@@ -23,8 +23,8 @@
     "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist",
     "lint": "eslint src --max-warnings 0",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node ../../scripts/no-tests.mjs"
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json",
+    "test": "vitest run --config ../../vitest.browser.config.ts"
   },
   "repository": {
     "type": "git",

--- a/packages/m3-menu/src/m3-menu.test.ts
+++ b/packages/m3-menu/src/m3-menu.test.ts
@@ -1,0 +1,73 @@
+import { fixture, html, expect } from '@open-wc/testing';
+import { describe, it } from 'vitest';
+import './m3-menu.js';
+import type { M3Menu } from './m3-menu.js';
+
+const keydown = (element: Element, key: string) =>
+  element.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, composed: true }));
+
+describe('M3Menu public interaction contract', () => {
+  it('keeps public open state and rendered visibility in sync while reporting changes', async () => {
+    const el = await fixture<M3Menu>(html`<m3-menu><m3-menu-item>One</m3-menu-item></m3-menu>`);
+    const changes: Array<{ open: boolean; reason: string }> = [];
+    el.addEventListener('menu-open-change', (event) => changes.push((event as CustomEvent).detail));
+
+    el.show('trigger');
+    await el.updateComplete;
+    expect(el.open).to.be.true;
+    expect(el.shadowRoot!.querySelector<HTMLElement>('.surface')!.hidden).to.be.false;
+    expect(changes).to.deep.equal([{ open: true, reason: 'trigger' }]);
+
+    el.dismiss('escape');
+    await el.updateComplete;
+    expect(el.open).to.be.false;
+    expect(el.shadowRoot!.querySelector<HTMLElement>('.surface')!.hidden).to.be.true;
+    expect(changes[1]).to.deep.equal({ open: false, reason: 'escape' });
+  });
+
+  it('handles keyboard navigation, Escape focus return, and Tab dismissal', async () => {
+    const trigger = await fixture<HTMLButtonElement>(html`<button>Open</button>`);
+    const el = await fixture<M3Menu>(html`
+      <m3-menu>
+        <m3-menu-item>First</m3-menu-item>
+        <m3-menu-item disabled>Disabled</m3-menu-item>
+        <m3-menu-item>Last</m3-menu-item>
+      </m3-menu>
+    `);
+    trigger.focus();
+    el.show('trigger');
+    await el.updateComplete;
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+    const surface = el.shadowRoot!.querySelector<HTMLElement>('.surface')!;
+    keydown(surface, 'End');
+    expect((el.querySelectorAll('m3-menu-item')[2] as HTMLElement).shadowRoot!.activeElement).to.exist;
+
+    keydown(surface, 'Escape');
+    await el.updateComplete;
+    expect(document.activeElement).to.equal(trigger);
+
+    el.show('trigger');
+    await el.updateComplete;
+    keydown(surface, 'Tab');
+    await el.updateComplete;
+    expect(el.open).to.be.false;
+  });
+
+  it('dismisses on outside press, preserves nested menu targets, and supports multiple menus', async () => {
+    const first = await fixture<M3Menu>(html`<m3-menu open><m3-menu-item><span>Nested</span></m3-menu-item></m3-menu>`);
+    const second = await fixture<M3Menu>(html`<m3-menu open><m3-menu-item>Second</m3-menu-item></m3-menu>`);
+    await first.updateComplete;
+    await second.updateComplete;
+
+    const nested = first.querySelector('span')!;
+    nested.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, composed: true }));
+    await first.updateComplete;
+    expect(first.open).to.be.true;
+
+    document.body.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, composed: true }));
+    await first.updateComplete;
+    await second.updateComplete;
+    expect(first.open).to.be.false;
+    expect(second.open).to.be.false;
+  });
+});

--- a/packages/m3-menu/src/m3-menu.test.ts
+++ b/packages/m3-menu/src/m3-menu.test.ts
@@ -1,4 +1,5 @@
 import { fixture, html, expect } from '@open-wc/testing';
+import { userEvent } from 'vitest/browser';
 import { describe, it } from 'vitest';
 import './m3-menu.js';
 import type { M3Menu } from './m3-menu.js';
@@ -25,7 +26,7 @@ describe('M3Menu public interaction contract', () => {
     expect(changes[1]).to.deep.equal({ open: false, reason: 'escape' });
   });
 
-  it('handles keyboard navigation, Escape focus return, and Tab dismissal', async () => {
+  it('handles keyboard navigation and Escape focus return', async () => {
     const trigger = await fixture<HTMLButtonElement>(html`<button>Open</button>`);
     const el = await fixture<M3Menu>(html`
       <m3-menu>
@@ -46,11 +47,29 @@ describe('M3Menu public interaction contract', () => {
     await el.updateComplete;
     expect(document.activeElement).to.equal(trigger);
 
-    el.show('trigger');
+  });
+
+  it('synchronously hides and escapes the menu when a real Tab key moves focus', async () => {
+    const container = await fixture<HTMLDivElement>(html`
+      <div>
+        <button id="trigger">Open</button>
+        <m3-menu><m3-menu-item>First</m3-menu-item></m3-menu>
+        <button id="after">After menu</button>
+      </div>
+    `);
+    const trigger = container.querySelector<HTMLButtonElement>('#trigger')!;
+    const after = container.querySelector<HTMLButtonElement>('#after')!;
+    const el = container.querySelector<M3Menu>('m3-menu')!;
+    el.show('trigger', trigger);
     await el.updateComplete;
-    keydown(surface, 'Tab');
-    await el.updateComplete;
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+    expect((el.querySelector('m3-menu-item') as HTMLElement).shadowRoot!.activeElement).to.exist;
+
+    await userEvent.keyboard('{Tab}');
+
     expect(el.open).to.be.false;
+    expect(el.shadowRoot!.querySelector<HTMLElement>('.surface')!.hidden).to.be.true;
+    expect(document.activeElement).to.equal(after);
   });
 
   it('dismisses on outside press, preserves nested menu targets, and supports multiple menus', async () => {
@@ -69,5 +88,40 @@ describe('M3Menu public interaction contract', () => {
     await second.updateComplete;
     expect(first.open).to.be.false;
     expect(second.open).to.be.false;
+  });
+
+  it('only exempts its defined opener, not siblings or a menu mounted on body', async () => {
+    const container = await fixture<HTMLDivElement>(html`
+      <div>
+        <button id="opener">Open</button>
+        <button id="sibling">Sibling control</button>
+        <m3-menu><m3-menu-item>Item</m3-menu-item></m3-menu>
+      </div>
+    `);
+    const opener = container.querySelector<HTMLButtonElement>('#opener')!;
+    const sibling = container.querySelector<HTMLButtonElement>('#sibling')!;
+    const el = container.querySelector<M3Menu>('m3-menu')!;
+    el.show('trigger', opener);
+    await el.updateComplete;
+
+    await userEvent.click(opener);
+    expect(el.open).to.be.true;
+
+    await userEvent.click(sibling);
+    await el.updateComplete;
+    expect(el.open).to.be.false;
+
+    const bodyMenu = document.createElement('m3-menu') as M3Menu;
+    bodyMenu.innerHTML = '<m3-menu-item>Body menu item</m3-menu-item>';
+    document.body.append(bodyMenu);
+    try {
+      bodyMenu.open = true;
+      await bodyMenu.updateComplete;
+      await userEvent.click(document.body);
+      await bodyMenu.updateComplete;
+      expect(bodyMenu.open).to.be.false;
+    } finally {
+      bodyMenu.remove();
+    }
   });
 });

--- a/packages/m3-menu/src/m3-menu.ts
+++ b/packages/m3-menu/src/m3-menu.ts
@@ -38,6 +38,7 @@ export class M3Menu extends LitElement {
 
     private _pendingOpenReason: M3MenuOpenReason | undefined;
     private _returnFocus: HTMLElement | null = null;
+    private _opener: HTMLElement | null = null;
 
     connectedCallback() {
         super.connectedCallback();
@@ -92,6 +93,7 @@ export class M3Menu extends LitElement {
                     this._returnFocus?.focus();
                 }
                 this._returnFocus = null;
+                this._opener = null;
             }
         }
     }
@@ -120,11 +122,17 @@ export class M3Menu extends LitElement {
     }
 
     /** Opens the menu and moves focus to its first enabled item. */
-    show(reason: Extract<M3MenuOpenReason, 'trigger' | 'programmatic'> = 'programmatic') {
+    show(
+        reason: Extract<M3MenuOpenReason, 'trigger' | 'programmatic'> = 'programmatic',
+        opener: HTMLElement | null = document.activeElement instanceof HTMLElement && document.activeElement !== document.body
+            ? document.activeElement
+            : null
+    ) {
         if (this.open) {
             return;
         }
-        this._returnFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+        this._returnFocus = opener;
+        this._opener = opener;
         this._setOpen(true, reason);
     }
 
@@ -143,11 +151,11 @@ export class M3Menu extends LitElement {
 
         const path = event.composedPath();
         const pathIncludesMenu = path.includes(this);
-        const pathIncludesAnchor = this.parentElement != null && path.includes(this.parentElement);
+        const pathIncludesOpener = this._opener != null && path.includes(this._opener);
         const pathIncludesSlottedContent = path.some(
             (node) => node instanceof Node && this.contains(node)
         );
-        if (pathIncludesMenu || pathIncludesAnchor || pathIncludesSlottedContent) {
+        if (pathIncludesMenu || pathIncludesOpener || pathIncludesSlottedContent) {
             return;
         }
 
@@ -159,35 +167,41 @@ export class M3Menu extends LitElement {
             return;
         }
 
-        const items = this._enabledItems();
-        if (items.length === 0) {
-            return;
-        }
-
-        const activeIndex = items.findIndex((item) => item.shadowRoot?.activeElement || item === document.activeElement);
-
         switch (event.key) {
             case 'ArrowDown':
+                if (this._enabledItems().length === 0) return;
                 event.preventDefault();
-                this._focusItem(activeIndex < 0 ? 0 : (activeIndex + 1) % items.length);
+                {
+                    const items = this._enabledItems();
+                    const activeIndex = items.findIndex((item) => item.shadowRoot?.activeElement || item === document.activeElement);
+                    this._focusItem(activeIndex < 0 ? 0 : (activeIndex + 1) % items.length);
+                }
                 break;
             case 'ArrowUp':
+                if (this._enabledItems().length === 0) return;
                 event.preventDefault();
-                this._focusItem(activeIndex < 0 ? items.length - 1 : (activeIndex - 1 + items.length) % items.length);
+                {
+                    const items = this._enabledItems();
+                    const activeIndex = items.findIndex((item) => item.shadowRoot?.activeElement || item === document.activeElement);
+                    this._focusItem(activeIndex < 0 ? items.length - 1 : (activeIndex - 1 + items.length) % items.length);
+                }
                 break;
             case 'Home':
+                if (this._enabledItems().length === 0) return;
                 event.preventDefault();
                 this._focusItem(0);
                 break;
             case 'End':
+                if (this._enabledItems().length === 0) return;
                 event.preventDefault();
-                this._focusItem(items.length - 1);
+                this._focusItem(this._enabledItems().length - 1);
                 break;
             case 'Escape':
                 event.preventDefault();
                 this.dismiss('escape');
                 break;
             case 'Tab':
+                this.shadowRoot?.querySelector<HTMLElement>('.surface')?.setAttribute('hidden', '');
                 this.dismiss('tab');
                 break;
             default:

--- a/packages/m3-menu/src/m3-menu.ts
+++ b/packages/m3-menu/src/m3-menu.ts
@@ -17,6 +17,9 @@ export type M3MenuPlacement =
     | 'left-center'
     | 'left-end';
 
+export type M3MenuDismissReason = 'escape' | 'outside' | 'selection' | 'tab';
+export type M3MenuOpenReason = 'trigger' | 'programmatic' | M3MenuDismissReason;
+
 @customElement('m3-menu')
 export class M3Menu extends LitElement {
     static styles = m3MenuStyles;
@@ -32,6 +35,9 @@ export class M3Menu extends LitElement {
 
     @queryAssignedElements({ flatten: true })
     private _assignedElements!: HTMLElement[];
+
+    private _pendingOpenReason: M3MenuOpenReason | undefined;
+    private _returnFocus: HTMLElement | null = null;
 
     connectedCallback() {
         super.connectedCallback();
@@ -52,7 +58,7 @@ export class M3Menu extends LitElement {
         const detail = ce.detail ?? {};
         event.stopPropagation();
         this.dispatchEvent(new CustomEvent('menu-item-select', { bubbles: true, composed: true, detail }));
-        queueMicrotask(() => this._requestDismiss('selection'));
+        queueMicrotask(() => this.dismiss('selection'));
     };
 
     updated(changedProperties: Map<string, unknown>) {
@@ -60,8 +66,33 @@ export class M3Menu extends LitElement {
             this._syncOffset();
         }
 
-        if (changedProperties.has('open') && this.open) {
-            queueMicrotask(() => this.focusFirstItem());
+        if (changedProperties.has('open')) {
+            const reason = this._pendingOpenReason ?? 'programmatic';
+            this._pendingOpenReason = undefined;
+            this.dispatchEvent(new CustomEvent('menu-open-change', {
+                bubbles: true,
+                composed: true,
+                detail: { open: this.open, reason }
+            }));
+
+            if (this.open) {
+                if (!this._returnFocus && document.activeElement instanceof HTMLElement) {
+                    this._returnFocus = document.activeElement;
+                }
+                queueMicrotask(() => this.focusFirstItem());
+            } else {
+                if (reason !== 'programmatic') {
+                    this.dispatchEvent(new CustomEvent('menu-dismiss', {
+                        bubbles: true,
+                        composed: true,
+                        detail: { reason }
+                    }));
+                }
+                if (reason !== 'tab') {
+                    this._returnFocus?.focus();
+                }
+                this._returnFocus = null;
+            }
         }
     }
 
@@ -88,13 +119,25 @@ export class M3Menu extends LitElement {
         this._focusItem(items.length - 1);
     }
 
-    private _handleDocumentPointerDown = (event: Event) => {
+    /** Opens the menu and moves focus to its first enabled item. */
+    show(reason: Extract<M3MenuOpenReason, 'trigger' | 'programmatic'> = 'programmatic') {
+        if (this.open) {
+            return;
+        }
+        this._returnFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+        this._setOpen(true, reason);
+    }
+
+    /** Closes the menu, reports the reason, and restores trigger focus except on Tab. */
+    dismiss(reason: M3MenuOpenReason = 'programmatic') {
         if (!this.open) {
             return;
         }
+        this._setOpen(false, reason);
+    }
 
-        // Ignore events if the menu is hidden (e.g., its parent is display: none due to responsive CSS)
-        if (this.getClientRects().length === 0) {
+    private _handleDocumentPointerDown = (event: Event) => {
+        if (!this.open) {
             return;
         }
 
@@ -108,7 +151,7 @@ export class M3Menu extends LitElement {
             return;
         }
 
-        this._requestDismiss('outside');
+        this.dismiss('outside');
     };
 
     private _handleKeydown = (event: KeyboardEvent) => {
@@ -142,10 +185,10 @@ export class M3Menu extends LitElement {
                 break;
             case 'Escape':
                 event.preventDefault();
-                this._requestDismiss('escape');
+                this.dismiss('escape');
                 break;
             case 'Tab':
-                this._requestDismiss('tab');
+                this.dismiss('tab');
                 break;
             default:
                 break;
@@ -153,7 +196,7 @@ export class M3Menu extends LitElement {
     };
 
     private _handleItemSelect = () => {
-        this._requestDismiss('selection');
+        this.dismiss('selection');
     };
 
     private _enabledItems() {
@@ -171,12 +214,9 @@ export class M3Menu extends LitElement {
         items[index].focus();
     }
 
-    private _requestDismiss(reason: 'escape' | 'outside' | 'selection' | 'tab') {
-        this.dispatchEvent(new CustomEvent('menu-dismiss', {
-            bubbles: true,
-            composed: true,
-            detail: { reason }
-        }));
+    private _setOpen(open: boolean, reason: M3MenuOpenReason) {
+        this._pendingOpenReason = reason;
+        this.open = open;
     }
 
     private _syncOffset() {

--- a/packages/m3-menu/tsconfig.test.json
+++ b/packages/m3-menu/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.test.json",
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/m3-split-button/README.md
+++ b/packages/m3-split-button/README.md
@@ -1,170 +1,46 @@
 # @banegasn/m3-split-button
 
-![Preview](images/preview.png)
+An accessible primary action paired with an `m3-menu` dropdown.
 
-
-> Material Design 3 Split Button web component — framework-agnostic, built with Lit.
-
-[![npm version](https://img.shields.io/npm/v/@banegasn/m3-split-button.svg)](https://www.npmjs.com/package/@banegasn/m3-split-button)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](../../LICENSE)
-
-An expressive **M3 Split Button** web component — a button with a primary action and a secondary dropdown trigger. Features shape morphing and rotation animations following Material Design 3 expressive motion. Works in Angular, React, Vue, Svelte, or plain HTML — no build step required.
-
-## Features
-
-- Primary action + dropdown trigger in one component
-- Shape morphing animation on menu open
-- Filled, outlined, tonal, and elevated variants
-- Pairs with `@banegasn/m3-menu` for the dropdown
-- Keyboard accessible
-- Framework-agnostic custom element
-
-## Installation
-
-```bash
-npm install @banegasn/m3-split-button
-# or
-pnpm add @banegasn/m3-split-button
-# or
-yarn add @banegasn/m3-split-button
-```
-
-## CDN Usage (no build step)
-
-```html
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <title>M3 Split Button Demo</title>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@banegasn/m3-split-button/+esm"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@banegasn/m3-menu/+esm"></script>
-  <style>
-    body { font-family: Roboto, sans-serif; padding: 32px; background: #fef7ff; }
-    .container { position: relative; display: inline-flex; }
-  </style>
-</head>
-<body>
-  <div class="container">
-    <m3-split-button id="split-btn" variant="filled" menu-id="action-menu">
-      Save
-    </m3-split-button>
-
-    <m3-menu id="action-menu" placement="bottom-end">
-      <m3-menu-item value="save-draft">Save as draft</m3-menu-item>
-      <m3-menu-item value="save-copy">Save a copy</m3-menu-item>
-      <m3-menu-item value="export">Export</m3-menu-item>
-    </m3-menu>
-  </div>
-
-  <script>
-    const btn = document.getElementById('split-btn');
-    const menu = document.getElementById('action-menu');
-
-    btn.addEventListener('split-button-click', () => {
-      console.log('Primary action: Save');
-    });
-
-    btn.addEventListener('split-button-dropdown-click', () => {
-      menu.open = !menu.open;
-      btn.menuOpen = menu.open;
-    });
-
-    menu.addEventListener('menu-item-click', (e) => {
-      console.log('Menu action:', e.detail.value);
-      menu.open = false;
-      btn.menuOpen = false;
-    });
-  </script>
-</body>
-</html>
-```
-
-## npm Usage
-
-```js
-import '@banegasn/m3-split-button';
-import '@banegasn/m3-menu';
+```sh
+pnpm add @banegasn/m3-split-button @banegasn/m3-menu
 ```
 
 ```html
-<m3-split-button variant="filled" menu-id="my-menu">
-  Save
+<m3-split-button variant="filled" menu-label="More send options">
+  Send
+  <m3-menu slot="menu" placement="bottom-end">
+    <m3-menu-item value="schedule">Schedule send</m3-menu-item>
+    <m3-menu-item value="draft">Save draft</m3-menu-item>
+  </m3-menu>
 </m3-split-button>
-
-<m3-menu id="my-menu" placement="bottom-end">
-  <m3-menu-item value="draft">Save as draft</m3-menu-item>
-  <m3-menu-item value="copy">Save a copy</m3-menu-item>
-</m3-menu>
 ```
 
-## API
+The default slot labels the primary action. The `menu` slot must contain one `m3-menu`; its ID is
+used by `aria-controls`, generated only when necessary. No empty ARIA relationship is emitted.
 
-### Properties
+## State and events
+
+`open` is the public source of truth and controls the slotted menu. It changes for direct use and
+is observable through `split-button-open-change`; controlled framework consumers bind `open` and
+write `event.detail.open` to their own state.
 
 | Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `variant` | `'filled' \| 'outlined' \| 'tonal' \| 'elevated'` | `'filled'` | Button style variant |
-| `menuOpen` | `boolean` | `false` | Reflects whether the associated menu is open (affects shape morphing) |
-| `menuId` | `string \| null` | `null` | ID of the controlled `m3-menu` element |
-| `disabled` | `boolean` | `false` | Disables both button sections |
+|---|---|---|---|
+| `variant` | `'filled' \| 'outlined' \| 'tonal' \| 'elevated'` | `'filled'` | Button style |
+| `open` | `boolean` | `false` | Rendered menu visibility |
+| `disabled` | `boolean` | `false` | Disables both actions |
+| `menuLabel` | `string` | `'More options'` | Accessible dropdown-trigger label |
 
-### Events
+| Event | Detail |
+|---|---|
+| `split-button-click` | `{ action: 'main' }` |
+| `split-button-open-change` | `{ open: boolean; reason: string }` |
+| `split-button-dismiss` | `{ reason: 'escape' \| 'outside' \| 'selection' \| 'tab' }` |
 
-| Event | Detail | Description |
-|-------|--------|-------------|
-| `split-button-click` | `{ variant: string }` | Fired when the primary action is clicked |
-| `split-button-dropdown-click` | `{ variant: string }` | Fired when the dropdown arrow is clicked |
-
-### Slots
-
-| Slot | Description |
-|------|-------------|
-| (default) | Primary button label |
-
-### CSS Custom Properties
-
-| Property | Default | Description |
-|----------|---------|-------------|
-| `--md-sys-color-primary` | `#6750a4` | Filled variant background |
-| `--md-sys-color-on-primary` | `#ffffff` | Filled variant text color |
-| `--md-sys-color-outline` | `#79747e` | Outlined variant border |
-
-## Framework Usage
-
-### Angular
-```typescript
-import '@banegasn/m3-split-button';
-import '@banegasn/m3-menu';
-```
-```html
-<m3-split-button variant="filled" [menuOpen]="menuOpen" (split-button-click)="save()" (split-button-dropdown-click)="menuOpen = !menuOpen">
-  Save
-</m3-split-button>
-```
-
-### React
-```jsx
-import '@banegasn/m3-split-button';
-// <m3-split-button variant="filled" menuOpen={menuOpen} onsplit-button-click={save}>Save</m3-split-button>
-```
-
-### Vue
-```vue
-<m3-split-button variant="filled" :menuOpen="menuOpen" @split-button-click="save" @split-button-dropdown-click="menuOpen = !menuOpen">
-  Save
-</m3-split-button>
-```
-
-## Related Packages
-
-- [@banegasn/m3-menu](https://www.npmjs.com/package/@banegasn/m3-menu) — pairs naturally with split button
-- [@banegasn/m3-button](https://www.npmjs.com/package/@banegasn/m3-button) — standard M3 button
-
-## Resources
-
-- [Material Design 3 Buttons](https://m3.material.io/components/buttons/overview)
-- [GitHub Repository](https://github.com/banegasn/components)
+The menu trigger has `aria-haspopup="menu"`, accurate `aria-expanded`, keyboard opening with
+ArrowDown/ArrowUp/Home/End, and an Escape close path. The slotted menu owns item navigation,
+outside-click handling, and predictable focus return.
 
 ## License
 

--- a/packages/m3-split-button/package.json
+++ b/packages/m3-split-button/package.json
@@ -23,8 +23,8 @@
     "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist",
     "lint": "eslint src --max-warnings 0",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node ../../scripts/no-tests.mjs"
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json",
+    "test": "vitest run --config ../../vitest.browser.config.ts"
   },
   "repository": {
     "type": "git",

--- a/packages/m3-split-button/src/m3-split-button.styles.ts
+++ b/packages/m3-split-button/src/m3-split-button.styles.ts
@@ -3,6 +3,7 @@ import { css } from 'lit';
 export const m3SplitButtonStyles = css`
   :host {
     display: inline-flex;
+    position: relative;
     align-items: center;
     gap: 1px;
     vertical-align: middle;
@@ -51,6 +52,12 @@ export const m3SplitButtonStyles = css`
 
   .button:active, .menu-button:active {
     filter: brightness(0.8);
+  }
+
+  .button:disabled, .menu-button:disabled {
+    cursor: default;
+    opacity: 0.38;
+    filter: none;
   }
   
   .menu-button.active {

--- a/packages/m3-split-button/src/m3-split-button.test.ts
+++ b/packages/m3-split-button/src/m3-split-button.test.ts
@@ -1,0 +1,48 @@
+import { fixture, html, expect } from '@open-wc/testing';
+import { describe, it } from 'vitest';
+import '../../m3-menu/src/m3-menu.js';
+import './m3-split-button.js';
+import type { M3SplitButton } from './m3-split-button.js';
+
+describe('M3SplitButton public interaction contract', () => {
+  it('coordinates a slotted menu, generated ARIA relationship, and focus return', async () => {
+    const el = await fixture<M3SplitButton>(html`
+      <m3-split-button>
+        Send
+        <m3-menu slot="menu"><m3-menu-item>Schedule</m3-menu-item></m3-menu>
+      </m3-split-button>
+    `);
+    await el.updateComplete;
+    const trigger = el.shadowRoot!.querySelector<HTMLButtonElement>('.menu-button')!;
+    const menu = el.querySelector('m3-menu')!;
+    expect(trigger.getAttribute('aria-haspopup')).to.equal('menu');
+    expect(trigger.getAttribute('aria-controls')).to.equal(menu.id);
+    expect(menu.id).not.to.equal('');
+
+    trigger.click();
+    await el.updateComplete;
+    await (menu as unknown as { updateComplete: Promise<unknown> }).updateComplete;
+    expect(el.open).to.be.true;
+    expect(trigger.getAttribute('aria-expanded')).to.equal('true');
+
+    menu.shadowRoot!.querySelector<HTMLElement>('.surface')!.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, composed: true }),
+    );
+    await el.updateComplete;
+    expect(el.open).to.be.false;
+    expect(el.shadowRoot!.activeElement).to.equal(trigger);
+  });
+
+  it('does not emit empty aria-controls or activate disabled actions', async () => {
+    const el = await fixture<M3SplitButton>(html`<m3-split-button disabled>Send</m3-split-button>`);
+    const [main, trigger] = Array.from(el.shadowRoot!.querySelectorAll<HTMLButtonElement>('button'));
+    let clicked = false;
+    el.addEventListener('split-button-click', () => { clicked = true; });
+    expect(trigger.hasAttribute('aria-controls')).to.be.false;
+    main.click();
+    trigger.click();
+    await el.updateComplete;
+    expect(clicked).to.be.false;
+    expect(el.open).to.be.false;
+  });
+});

--- a/packages/m3-split-button/src/m3-split-button.ts
+++ b/packages/m3-split-button/src/m3-split-button.ts
@@ -1,65 +1,189 @@
 import { LitElement, html } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, queryAssignedElements } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { m3SplitButtonStyles } from './m3-split-button.styles.js';
 
-/**
- * Material Design 3 Split Button Component
- * 
- * A split button with a main action and a dropdown menu action.
- * Features shape morphing and rotation animations.
- */
+type MenuOpenReason = 'trigger' | 'programmatic' | 'escape' | 'outside' | 'selection' | 'tab';
+
+interface MenuElement extends HTMLElement {
+    open: boolean;
+    show(reason?: 'trigger' | 'programmatic'): void;
+    dismiss(reason?: MenuOpenReason): void;
+    focusFirstItem(): void;
+    focusLastItem(): void;
+}
+
+let menuId = 0;
+
+/** A primary action paired with an `m3-menu` in the named `menu` slot. */
 @customElement('m3-split-button')
 export class M3SplitButton extends LitElement {
     static styles = m3SplitButtonStyles;
 
-    /**
-     * Button variant style
-     */
     @property({ type: String, reflect: true })
     variant: 'filled' | 'outlined' | 'tonal' | 'elevated' = 'filled';
 
-    @property({ type: Boolean, reflect: true, attribute: 'menu-open' })
-    menuOpen = false;
+    @property({ type: Boolean, reflect: true })
+    open = false;
 
-    @property({ type: String, attribute: 'menu-id' })
-    menuId: string | null = null;
+    @property({ type: Boolean, reflect: true })
+    disabled = false;
 
-    private _handleMainClick() {
+    @property({ type: String, attribute: 'menu-label' })
+    menuLabel = 'More options';
+
+    @queryAssignedElements({ slot: 'menu', flatten: true })
+    private _menus!: HTMLElement[];
+
+    private _pendingReason: MenuOpenReason | undefined;
+
+    connectedCallback() {
+        super.connectedCallback();
+        this.addEventListener('menu-open-change', this._handleMenuOpenChange);
+        this.addEventListener('menu-dismiss', this._handleMenuDismiss);
+    }
+
+    disconnectedCallback() {
+        this.removeEventListener('menu-open-change', this._handleMenuOpenChange);
+        this.removeEventListener('menu-dismiss', this._handleMenuDismiss);
+        super.disconnectedCallback();
+    }
+
+    updated(changedProperties: Map<string, unknown>) {
+        if (!changedProperties.has('open')) {
+            return;
+        }
+
+        const reason = this._pendingReason ?? 'programmatic';
+        this._pendingReason = undefined;
+        const menu = this._menu();
+        if (menu && menu.open !== this.open) {
+            if (this.open) {
+                menu.show(reason === 'programmatic' ? 'programmatic' : 'trigger');
+            } else {
+                menu.dismiss(reason);
+            }
+        }
+        this.dispatchEvent(new CustomEvent('split-button-open-change', {
+            bubbles: true,
+            composed: true,
+            detail: { open: this.open, reason }
+        }));
+    }
+
+    render() {
+        const controls = this._menu()?.id || undefined;
+        return html`
+      <button class="button" type="button" ?disabled=${this.disabled} @click=${this._handleMainClick}>
+        <slot></slot>
+      </button>
+      <button
+        class="menu-button ${this.open ? 'active' : ''}"
+        type="button"
+        ?disabled=${this.disabled}
+        aria-label=${this.menuLabel}
+        aria-haspopup="menu"
+        aria-expanded=${String(this.open)}
+        aria-controls=${ifDefined(controls || undefined)}
+        @click=${this._toggle}
+        @keydown=${this._handleKeydown}
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 -960 960 960" width="24" fill="currentColor" aria-hidden="true">
+          <path d="M480-360 280-560h400L480-360Z"/>
+        </svg>
+      </button>
+      <slot name="menu" @slotchange=${this._handleMenuSlotChange}></slot>
+    `;
+    }
+
+    private _handleMainClick = () => {
+        if (this.disabled) {
+            return;
+        }
         this.dispatchEvent(new CustomEvent('split-button-click', {
             bubbles: true,
             composed: true,
             detail: { action: 'main' }
         }));
-    }
+    };
 
-    private _handleMenuClick() {
-        this.menuOpen = !this.menuOpen;
-        this.dispatchEvent(new CustomEvent('split-button-click', {
+    private _handleMenuSlotChange = () => {
+        const menu = this._menu();
+        if (!menu) {
+            return;
+        }
+        if (!menu.id) {
+            menu.id = `m3-split-button-menu-${++menuId}`;
+        }
+        if (menu.open !== this.open) {
+            menu.open = this.open;
+        }
+        this.requestUpdate();
+    };
+
+    private _handleMenuOpenChange = (event: Event) => {
+        if (event.target === this) {
+            return;
+        }
+        const detail = (event as CustomEvent<{ open: boolean; reason: MenuOpenReason }>).detail;
+        this._pendingReason = detail.reason;
+        this.open = detail.open;
+    };
+
+    private _handleMenuDismiss = (event: Event) => {
+        if (event.target === this) {
+            return;
+        }
+        const detail = (event as CustomEvent<{ reason: MenuOpenReason }>).detail;
+        if (detail.reason !== 'tab') {
+            this.shadowRoot?.querySelector<HTMLButtonElement>('.menu-button')?.focus();
+        }
+        this.dispatchEvent(new CustomEvent('split-button-dismiss', {
             bubbles: true,
             composed: true,
-            detail: { action: 'menu', open: this.menuOpen }
+            detail
         }));
+    };
+
+    private _toggle = (event: MouseEvent) => {
+        if (!this.disabled) {
+            (event.currentTarget as HTMLButtonElement).focus();
+            this._requestOpen(!this.open, 'trigger');
+        }
+    };
+
+    private _handleKeydown = (event: KeyboardEvent) => {
+        if (this.disabled) {
+            return;
+        }
+        if (event.key === 'Escape' && this.open) {
+            event.preventDefault();
+            this._requestOpen(false, 'escape');
+            return;
+        }
+        if (!this.open && ['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(event.key)) {
+            event.preventDefault();
+            this._requestOpen(true, 'trigger');
+            queueMicrotask(() => {
+                const menu = this._menu();
+                if (event.key === 'ArrowUp' || event.key === 'End') {
+                    menu?.focusLastItem();
+                } else {
+                    menu?.focusFirstItem();
+                }
+            });
+        }
+    };
+
+    private _requestOpen(open: boolean, reason: MenuOpenReason) {
+        if (this.open !== open) {
+            this._pendingReason = reason;
+            this.open = open;
+        }
     }
 
-    render() {
-        return html`
-      <button class="button" type="button" @click=${this._handleMainClick}>
-        <slot></slot>
-      </button>
-      <button
-        class="menu-button ${this.menuOpen ? 'active' : ''}"
-        type="button"
-        @click=${this._handleMenuClick}
-        aria-label="More options"
-        aria-haspopup="menu"
-        aria-expanded=${String(this.menuOpen)}
-        aria-controls=${this.menuId ?? ''}
-      >
-        <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 -960 960 960" width="24" fill="currentColor">
-          <path d="M480-360 280-560h400L480-360Z"/>
-        </svg>
-      </button>
-    `;
+    private _menu(): MenuElement | null {
+        return (this._menus?.find((element) => element.tagName === 'M3-MENU') as MenuElement | undefined) ?? null;
     }
 }
 

--- a/packages/m3-split-button/src/m3-split-button.ts
+++ b/packages/m3-split-button/src/m3-split-button.ts
@@ -7,7 +7,7 @@ type MenuOpenReason = 'trigger' | 'programmatic' | 'escape' | 'outside' | 'selec
 
 interface MenuElement extends HTMLElement {
     open: boolean;
-    show(reason?: 'trigger' | 'programmatic'): void;
+    show(reason?: 'trigger' | 'programmatic', opener?: HTMLElement | null): void;
     dismiss(reason?: MenuOpenReason): void;
     focusFirstItem(): void;
     focusLastItem(): void;
@@ -59,7 +59,7 @@ export class M3SplitButton extends LitElement {
         const menu = this._menu();
         if (menu && menu.open !== this.open) {
             if (this.open) {
-                menu.show(reason === 'programmatic' ? 'programmatic' : 'trigger');
+                menu.show(reason === 'programmatic' ? 'programmatic' : 'trigger', this._menuTrigger());
             } else {
                 menu.dismiss(reason);
             }
@@ -184,6 +184,10 @@ export class M3SplitButton extends LitElement {
 
     private _menu(): MenuElement | null {
         return (this._menus?.find((element) => element.tagName === 'M3-MENU') as MenuElement | undefined) ?? null;
+    }
+
+    private _menuTrigger(): HTMLButtonElement | null {
+        return this.shadowRoot?.querySelector<HTMLButtonElement>('.menu-button') ?? null;
     }
 }
 

--- a/packages/m3-split-button/tsconfig.test.json
+++ b/packages/m3-split-button/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.test.json",
+  "compilerOptions": {
+    "rootDir": "../.."
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/vitest.browser.config.ts
+++ b/vitest.browser.config.ts
@@ -21,6 +21,9 @@ const browserPorts: Record<string, number> = {
   'm3-top-app-bar': 63_324,
   'm3-progress': 63_326,
   'm3-checkbox': 63_327,
+  'm3-menu': 63_328,
+  'm3-fab-menu': 63_329,
+  'm3-split-button': 63_330,
 };
 
 const port = browserPorts[workspaceName];


### PR DESCRIPTION
Fixes #9

## Public contract

- `m3-menu`, `m3-fab-menu`, and `m3-split-button` expose `open` as their single public visibility state. For direct/uncontrolled use, user interaction updates `open` (or consumers call `m3-menu.show()` / `dismiss()`). For controlled use, frameworks bind `open` and write `detail.open` from the corresponding `*-open-change` event to application state. Rendered visibility always follows that property.
- Every transition emits `menu-open-change`, `fab-menu-open-change`, or `split-button-open-change` with `{ open, reason }`. User dismissals additionally emit the matching `*-dismiss` event with `{ reason }`; reasons are `escape`, `outside`, `selection`, or `tab`.
- FAB and split button compose only with a single `<m3-menu slot="menu">`; their trigger sets an actual `aria-controls` relationship, generating an ID only when needed. No legacy property/event aliases are retained.

## Included

- Keyboard open/navigation, Escape, Tab, outside-press, focus-entry/return, labels, ARIA state, and disabled behavior.
- Chromium Vitest contract coverage for nested targets and multiple menus.
- Updated package docs and Angular demos.

## Verification

- Node `v24.18.0`, pnpm `11.12.0`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`