### PR TITLE
fix(radio): scope groups and labels

### DIFF
--- a/docs/FORM_ASSOCIATED_CONTROLS.md
+++ b/docs/FORM_ASSOCIATED_CONTROLS.md
@@ -27,6 +27,19 @@ contract. They participate in the owner form directly through
   button `name`/`value` are not added to `FormData`. The library does not fake
   submitter data with a `formdata` listener.
 
+## Radio group scope and labels
+
+`m3-radio-button` groups are local: controls must share a non-empty `name`,
+the same owner form, and the same document or shadow root. Matching names in
+different forms or shadow roots do not interact. The checked radio is the
+single tab stop; arrow keys move focus and selection through enabled peers.
+
+For an external label, use the platform `for`/`id` association and point the
+radio's `aria-labelledby` at that label (or supply `aria-label`). This is the
+supported label contract. It observes only labels explicitly associated through
+`for`/`id`, removes those listeners when the radio disconnects, and never
+mutates surrounding DOM.
+
 ## Clean-break migration
 
 The component-specific `button-click`, `checkbox-change`, `radio-change`,

--- a/packages/m3-radio-button/README.md
+++ b/packages/m3-radio-button/README.md
@@ -2,7 +2,6 @@
 
 ![Preview](images/preview.png)
 
-
 > Material Design 3 Radio Button web component — framework-agnostic, built with Lit.
 
 [![npm version](https://img.shields.io/npm/v/@banegasn/m3-radio-button.svg)](https://www.npmjs.com/package/@banegasn/m3-radio-button)
@@ -12,7 +11,7 @@ An accessible **M3 Radio Button** web component following the [Material Design 3
 
 ## Features
 
-- Single-selection from a group via `name` attribute
+- Single-selection from a scoped group via a non-empty `name` attribute
 - Checked and disabled states
 - Form integration (name, value, form attributes)
 - Accessible with ARIA `radio` role
@@ -34,41 +33,79 @@ yarn add @banegasn/m3-radio-button
 ```html
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <title>M3 Radio Button Demo</title>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@banegasn/m3-radio-button/+esm"></script>
-  <style>
-    body { font-family: Roboto, sans-serif; padding: 32px; background: #fef7ff; }
-    .row { display: flex; align-items: center; gap: 12px; margin-bottom: 12px; }
-    label { font-size: 16px; color: #1d1b20; }
-    #result { margin-top: 16px; font-size: 14px; color: #6750a4; }
-  </style>
-</head>
-<body>
-  <p style="font-weight:500;color:#1d1b20;">Choose a theme:</p>
-  <div class="row">
-    <m3-radio-button name="theme" value="light" checked></m3-radio-button>
-    <label>Light</label>
-  </div>
-  <div class="row">
-    <m3-radio-button name="theme" value="dark"></m3-radio-button>
-    <label>Dark</label>
-  </div>
-  <div class="row">
-    <m3-radio-button name="theme" value="auto"></m3-radio-button>
-    <label>System default</label>
-  </div>
-  <p id="result">Selected: light</p>
+  <head>
+    <meta charset="UTF-8" />
+    <title>M3 Radio Button Demo</title>
+    <script
+      type="module"
+      src="https://cdn.jsdelivr.net/npm/@banegasn/m3-radio-button/+esm"
+    ></script>
+    <style>
+      body {
+        font-family: Roboto, sans-serif;
+        padding: 32px;
+        background: #fef7ff;
+      }
+      .row {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        margin-bottom: 12px;
+      }
+      label {
+        font-size: 16px;
+        color: #1d1b20;
+      }
+      #result {
+        margin-top: 16px;
+        font-size: 14px;
+        color: #6750a4;
+      }
+    </style>
+  </head>
+  <body>
+    <p style="font-weight:500;color:#1d1b20;">Choose a theme:</p>
+    <div class="row">
+      <m3-radio-button
+        id="theme-light"
+        name="theme"
+        value="light"
+        checked
+        aria-labelledby="theme-light-label"
+      ></m3-radio-button>
+      <label id="theme-light-label" for="theme-light">Light</label>
+    </div>
+    <div class="row">
+      <m3-radio-button
+        id="theme-dark"
+        name="theme"
+        value="dark"
+        aria-labelledby="theme-dark-label"
+      ></m3-radio-button>
+      <label id="theme-dark-label" for="theme-dark">Dark</label>
+    </div>
+    <div class="row">
+      <m3-radio-button
+        id="theme-auto"
+        name="theme"
+        value="auto"
+        aria-labelledby="theme-auto-label"
+      ></m3-radio-button>
+      <label id="theme-auto-label" for="theme-auto">System default</label>
+    </div>
+    <p id="result">Selected: light</p>
 
-  <script>
-    document.querySelectorAll('m3-radio-button[name="theme"]').forEach(radio => {
-      radio.addEventListener('change', (e) => {
-        document.getElementById('result').textContent = 'Selected: ' + e.detail.value;
-      });
-    });
-  </script>
-</body>
+    <script>
+      document
+        .querySelectorAll('m3-radio-button[name="theme"]')
+        .forEach((radio) => {
+          radio.addEventListener('change', (e) => {
+            document.getElementById('result').textContent =
+              'Selected: ' + radio.value;
+          });
+        });
+    </script>
+  </body>
 </html>
 ```
 
@@ -86,7 +123,9 @@ import '@banegasn/m3-radio-button';
 
 ### Radio Group
 
-Radio buttons with the same `name` attribute form a group where only one can be selected:
+Radio buttons with the same non-empty `name`, in the same tree root and with
+the same owner form, form a group where only one can be selected. Radios in
+different forms or shadow roots stay independent even when their names match:
 
 ```html
 <m3-radio-button name="theme" value="light" checked>Light</m3-radio-button>
@@ -99,8 +138,10 @@ Radio buttons with the same `name` attribute form a group where only one can be 
 ```javascript
 import '@banegasn/m3-radio-button';
 
-const radioButtons = document.querySelectorAll('m3-radio-button[name="option"]');
-radioButtons.forEach(radio => {
+const radioButtons = document.querySelectorAll(
+  'm3-radio-button[name="option"]',
+);
+radioButtons.forEach((radio) => {
   radio.addEventListener('change', (e) => {
     console.log('Selected:', e.detail.value);
   });
@@ -147,7 +188,7 @@ import '@banegasn/m3-radio-button';
       [checked]="selected === 'option1'"
       (change)="onRadioChange($event)"
     ></m3-radio-button>
-  `
+  `,
 })
 export class MyComponent {
   selected = 'option1';
@@ -184,31 +225,31 @@ const onRadioChange = (event) => {
 
 ## Properties
 
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `checked` | `boolean` | `false` | Whether the radio button is checked |
-| `disabled` | `boolean` | `false` | Disables the radio button |
-| `name` | `string` | `null` | Name attribute for radio group (required for grouping) |
-| `value` | `string` | `null` | Value attribute for form submission |
-| `form` | `HTMLFormElement \| null` | `null` | Current owner form; set the native `form` attribute to associate by ID |
-| `aria-label` | `string` | `null` | ARIA label for accessibility |
-| `aria-labelledby` | `string` | `null` | ARIA labelled by for accessibility |
+| Property          | Type                      | Default | Description                                                            |
+| ----------------- | ------------------------- | ------- | ---------------------------------------------------------------------- |
+| `checked`         | `boolean`                 | `false` | Whether the radio button is checked                                    |
+| `disabled`        | `boolean`                 | `false` | Disables the radio button                                              |
+| `name`            | `string`                  | `null`  | Name attribute for radio group (required for grouping)                 |
+| `value`           | `string`                  | `null`  | Value attribute for form submission                                    |
+| `form`            | `HTMLFormElement \| null` | `null`  | Current owner form; set the native `form` attribute to associate by ID |
+| `aria-label`      | `string`                  | `null`  | ARIA label for accessibility                                           |
+| `aria-labelledby` | `string`                  | `null`  | ARIA labelled by for accessibility                                     |
 
 ## Events
 
-| Event | Description |
-|-------|-------------|
-| `input` | Native event fired on the newly selected radio. |
+| Event    | Description                                              |
+| -------- | -------------------------------------------------------- |
+| `input`  | Native event fired on the newly selected radio.          |
 | `change` | Native event fired after a radio selection is committed. |
 
 See the [form-associated control migration guide](../../docs/FORM_ASSOCIATED_CONTROLS.md).
 
 ## Methods
 
-| Method | Description |
-|--------|-------------|
-| `focus()` | Focuses the radio button |
-| `blur()` | Removes focus from the radio button |
+| Method    | Description                         |
+| --------- | ----------------------------------- |
+| `focus()` | Focuses the radio button            |
+| `blur()`  | Removes focus from the radio button |
 
 ## CSS Custom Properties
 
@@ -225,9 +266,31 @@ m3-radio-button {
 }
 ```
 
-## Radio Groups
+## Radio groups and external labels
 
-Radio buttons with the same `name` attribute automatically form a group. When one radio button in a group is selected, all others in the same group are automatically deselected.
+Radio buttons with the same non-empty `name`, owner form, and tree root form a
+local group. Selecting one clears checked peers in that local group only. The
+selected radio is the group's tab stop; if none is selected, the first enabled
+radio is the tab stop. Arrow keys move selection and focus, wrapping around
+and skipping disabled radios.
+
+Use the explicit native `for`/`id` association for an external clickable
+label. Because the interactive ARIA radio is inside the component's shadow
+root, also reference the label with `aria-labelledby` (or use `aria-label`):
+
+```html
+<label id="plan-pro-label" for="plan-pro">Pro plan</label>
+<m3-radio-button
+  id="plan-pro"
+  name="plan"
+  value="pro"
+  aria-labelledby="plan-pro-label"
+></m3-radio-button>
+```
+
+Only labels explicitly associated with the host through `for`/`id` are
+observed; those listeners are removed when the radio disconnects. No
+neighboring elements are changed.
 
 ## Accessibility
 

--- a/packages/m3-radio-button/package.json
+++ b/packages/m3-radio-button/package.json
@@ -23,8 +23,9 @@
     "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist",
     "lint": "eslint src --max-warnings 0",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node ../../scripts/no-tests.mjs"
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json",
+    "test": "vitest run --config ../../vitest.browser.config.ts",
+    "test:watch": "vitest --config ../../vitest.browser.config.ts"
   },
   "repository": {
     "type": "git",
@@ -51,6 +52,7 @@
     "lit": "^3.3.3"
   },
   "devDependencies": {
+    "@open-wc/testing": "5.0.0",
     "typescript": "^5.9.3"
   }
 }

--- a/packages/m3-radio-button/src/m3-radio-button.test.ts
+++ b/packages/m3-radio-button/src/m3-radio-button.test.ts
@@ -1,0 +1,201 @@
+import { fixture, html, expect } from '@open-wc/testing';
+import { describe, it } from 'vitest';
+import './index.js';
+import type { M3RadioButton } from './m3-radio-button.js';
+
+const controls = (root: ParentNode): M3RadioButton[] =>
+  Array.from(root.querySelectorAll<M3RadioButton>('m3-radio-button'));
+
+const updateAll = async (radios: M3RadioButton[]): Promise<void> => {
+  await Promise.all(radios.map((radio) => radio.updateComplete));
+};
+
+const tabIndex = (radio: M3RadioButton): string | null =>
+  radio.shadowRoot!.querySelector('.radio-container')!.getAttribute('tabindex');
+
+describe('m3-radio-button scoped groups', () => {
+  it('isolates same-name groups by form owner and tree root', async () => {
+    const container = await fixture<HTMLDivElement>(html`
+      <div>
+        <form id="first">
+          <m3-radio-button name="theme" value="light" checked></m3-radio-button>
+          <m3-radio-button name="theme" value="dark"></m3-radio-button>
+        </form>
+        <form id="second">
+          <m3-radio-button
+            name="theme"
+            value="system"
+            checked
+          ></m3-radio-button>
+        </form>
+        <div id="shadow-host"></div>
+      </div>
+    `);
+    const [light, dark] = controls(container.querySelector('#first')!);
+    const system = controls(container.querySelector('#second')!)[0];
+    const shadow = container
+      .querySelector('#shadow-host')!
+      .attachShadow({ mode: 'open' });
+    shadow.innerHTML =
+      '<m3-radio-button name="theme" value="shadow" checked></m3-radio-button>';
+    const shadowRadio = controls(shadow)[0];
+    await updateAll([light, dark, system, shadowRadio]);
+
+    dark.click();
+    await updateAll([light, dark, system, shadowRadio]);
+
+    expect(light.checked).to.equal(false);
+    expect(dark.checked).to.equal(true);
+    expect(system.checked).to.equal(true);
+    expect(shadowRadio.checked).to.equal(true);
+    expect(
+      new FormData(container.querySelector('#first') as HTMLFormElement).get(
+        'theme',
+      ),
+    ).to.equal('dark');
+    expect(
+      new FormData(container.querySelector('#second') as HTMLFormElement).get(
+        'theme',
+      ),
+    ).to.equal('system');
+  });
+
+  it('uses one roving tab stop and arrows skip disabled radios', async () => {
+    const group = await fixture<HTMLDivElement>(html`
+      <div>
+        <m3-radio-button name="size" value="small" checked></m3-radio-button>
+        <m3-radio-button name="size" value="medium" disabled></m3-radio-button>
+        <m3-radio-button name="size" value="large"></m3-radio-button>
+      </div>
+    `);
+    const [small, medium, large] = controls(group);
+    await updateAll([small, medium, large]);
+
+    expect(tabIndex(small)).to.equal('0');
+    expect(tabIndex(medium)).to.equal('-1');
+    expect(tabIndex(large)).to.equal('-1');
+    small.focus();
+    small
+      .shadowRoot!.querySelector<HTMLElement>('.radio-container')!
+      .dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'ArrowRight',
+          bubbles: true,
+          composed: true,
+        }),
+      );
+    await updateAll([small, medium, large]);
+
+    expect(small.checked).to.equal(false);
+    expect(large.checked).to.equal(true);
+    expect(tabIndex(small)).to.equal('-1');
+    expect(tabIndex(large)).to.equal('0');
+    expect(large.shadowRoot!.activeElement).to.equal(
+      large.shadowRoot!.querySelector('.radio-container'),
+    );
+  });
+
+  it('keeps checked state, events, and FormData synchronized', async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form>
+        <m3-radio-button name="plan" value="free" checked></m3-radio-button>
+        <m3-radio-button name="plan" value="pro"></m3-radio-button>
+      </form>
+    `);
+    const [free, pro] = controls(form);
+    await updateAll([free, pro]);
+    let inputs = 0;
+    let changes = 0;
+    pro.addEventListener('input', () => {
+      inputs += 1;
+    });
+    pro.addEventListener('change', () => {
+      changes += 1;
+    });
+
+    pro.click();
+    await updateAll([free, pro]);
+    pro.click();
+    await updateAll([free, pro]);
+
+    expect(free.checked).to.equal(false);
+    expect(pro.checked).to.equal(true);
+    expect(inputs).to.equal(1);
+    expect(changes).to.equal(1);
+    expect(new FormData(form).get('plan')).to.equal('pro');
+  });
+
+  it('recomputes local groups after dynamic insertion and removal without touching sibling DOM', async () => {
+    const container = await fixture<HTMLDivElement>(html`
+      <div>
+        <m3-radio-button
+          name="density"
+          value="compact"
+          checked
+        ></m3-radio-button>
+      </div>
+    `);
+    const compact = controls(container)[0];
+    await compact.updateComplete;
+    const label = document.createElement('label');
+    label.textContent = 'Unrelated sibling';
+    container.append(label);
+    const labelMarkup = label.outerHTML;
+    const comfortable = document.createElement(
+      'm3-radio-button',
+    ) as M3RadioButton;
+    comfortable.name = 'density';
+    comfortable.value = 'comfortable';
+    container.append(comfortable);
+    await updateAll([compact, comfortable]);
+
+    expect(tabIndex(compact)).to.equal('0');
+    expect(tabIndex(comfortable)).to.equal('-1');
+    compact.remove();
+    await comfortable.updateComplete;
+
+    expect(tabIndex(comfortable)).to.equal('0');
+    expect(label.outerHTML).to.equal(labelMarkup);
+  });
+
+  it('supports external labels and cleans their scoped listeners through repeated lifecycle changes', async () => {
+    const container = await fixture<HTMLDivElement>(html`
+      <div>
+        <label id="dark-label" for="dark">Dark theme</label>
+        <m3-radio-button
+          id="dark"
+          name="theme"
+          value="dark"
+          aria-labelledby="dark-label"
+        ></m3-radio-button>
+      </div>
+    `);
+    const [radio] = controls(container);
+    await radio.updateComplete;
+    const label = container.querySelector('label') as HTMLLabelElement;
+    label.click();
+    await radio.updateComplete;
+
+    expect(radio.checked).to.equal(true);
+    expect(radio.labels).to.have.length(1);
+    expect(
+      radio
+        .shadowRoot!.querySelector('.radio-container')!
+        .getAttribute('aria-labelledby'),
+    ).to.equal('dark-label');
+    radio.remove();
+    label.click();
+    expect(radio.checked).to.equal(true);
+    container.append(radio);
+    await radio.updateComplete;
+    radio.checked = false;
+    await radio.updateComplete;
+    label.click();
+    await radio.updateComplete;
+    expect(radio.checked).to.equal(true);
+    radio.remove();
+    radio.checked = false;
+    label.click();
+    expect(radio.checked).to.equal(false);
+  });
+});

--- a/packages/m3-radio-button/src/m3-radio-button.test.ts
+++ b/packages/m3-radio-button/src/m3-radio-button.test.ts
@@ -125,6 +125,113 @@ describe('m3-radio-button scoped groups', () => {
     expect(new FormData(form).get('plan')).to.equal('pro');
   });
 
+  it('normalizes a checked radio renamed into another checked group', async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form>
+        <m3-radio-button name="alpha" value="alpha-peer"></m3-radio-button>
+        <m3-radio-button
+          id="renamed"
+          name="alpha"
+          value="renamed"
+          checked
+        ></m3-radio-button>
+        <m3-radio-button
+          name="beta"
+          value="beta-peer"
+          checked
+        ></m3-radio-button>
+      </form>
+    `);
+    const [alphaPeer, renamed, betaPeer] = controls(form);
+    await updateAll([alphaPeer, renamed, betaPeer]);
+
+    renamed.name = 'beta';
+    await updateAll([alphaPeer, renamed, betaPeer]);
+
+    expect(alphaPeer.checked).to.equal(false);
+    expect(renamed.checked).to.equal(true);
+    expect(betaPeer.checked).to.equal(false);
+    expect(tabIndex(alphaPeer)).to.equal('0');
+    expect(tabIndex(renamed)).to.equal('0');
+    expect(tabIndex(betaPeer)).to.equal('-1');
+    expect(new FormData(form).get('alpha')).to.equal(null);
+    expect(new FormData(form).get('beta')).to.equal('renamed');
+  });
+
+  it('normalizes a checked radio reassociated with a form that already has a checked peer', async () => {
+    const container = await fixture<HTMLDivElement>(html`
+      <div>
+        <form id="first">
+          <m3-radio-button name="plan" value="basic"></m3-radio-button>
+          <m3-radio-button
+            id="moved"
+            name="plan"
+            value="pro"
+            checked
+          ></m3-radio-button>
+        </form>
+        <form id="second">
+          <m3-radio-button
+            name="plan"
+            value="enterprise"
+            checked
+          ></m3-radio-button>
+        </form>
+      </div>
+    `);
+    const first = container.querySelector<HTMLFormElement>('#first')!;
+    const second = container.querySelector<HTMLFormElement>('#second')!;
+    const [basic, moved] = controls(first);
+    const [enterprise] = controls(second);
+    await updateAll([basic, moved, enterprise]);
+
+    moved.setAttribute('form', 'second');
+    await updateAll([basic, moved, enterprise]);
+
+    expect(moved.form).to.equal(second);
+    expect(basic.checked).to.equal(false);
+    expect(moved.checked).to.equal(true);
+    expect(enterprise.checked).to.equal(false);
+    expect(tabIndex(basic)).to.equal('0');
+    expect(tabIndex(moved)).to.equal('0');
+    expect(tabIndex(enterprise)).to.equal('-1');
+    expect(new FormData(first).get('plan')).to.equal(null);
+    expect(new FormData(second).get('plan')).to.equal('pro');
+  });
+
+  it('normalizes a checked radio moved into a root that has a checked peer', async () => {
+    const container = await fixture<HTMLDivElement>(html`
+      <div>
+        <m3-radio-button name="root" value="document-peer"></m3-radio-button>
+        <m3-radio-button
+          id="moving"
+          name="root"
+          value="moving"
+          checked
+        ></m3-radio-button>
+        <div id="shadow-host"></div>
+      </div>
+    `);
+    const [documentPeer, moving] = controls(container);
+    const shadow = container
+      .querySelector('#shadow-host')!
+      .attachShadow({ mode: 'open' });
+    shadow.innerHTML =
+      '<m3-radio-button name="root" value="shadow-peer" checked></m3-radio-button>';
+    const [shadowPeer] = controls(shadow);
+    await updateAll([documentPeer, moving, shadowPeer]);
+
+    shadow.append(moving);
+    await updateAll([documentPeer, moving, shadowPeer]);
+
+    expect(documentPeer.checked).to.equal(false);
+    expect(moving.checked).to.equal(true);
+    expect(shadowPeer.checked).to.equal(false);
+    expect(tabIndex(documentPeer)).to.equal('0');
+    expect(tabIndex(moving)).to.equal('0');
+    expect(tabIndex(shadowPeer)).to.equal('-1');
+  });
+
   it('recomputes local groups after dynamic insertion and removal without touching sibling DOM', async () => {
     const container = await fixture<HTMLDivElement>(html`
       <div>

--- a/packages/m3-radio-button/src/m3-radio-button.ts
+++ b/packages/m3-radio-button/src/m3-radio-button.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit';
+import { html, type PropertyValues } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { FormAssociatedElement } from '@banegasn/m3-form-associated';
 import { m3RadioButtonStyles } from './m3-radio-button.styles.js';
@@ -7,9 +7,10 @@ import { motionDuration } from './motion-duration.js';
 /**
  * Material Design 3 radio button with native form participation.
  *
- * Radio grouping follows the platform rule: radios with the same `name` and
- * the same owner form are mutually exclusive. A selection emits one native
- * `input` and one native `change` event on the selected control.
+ * Radio grouping is local to a tree root. Radios with the same non-empty
+ * `name` and owner form are mutually exclusive; separate forms and shadow
+ * roots are intentionally independent. A selection emits one native `input`
+ * and one native `change` event on the selected control.
  */
 @customElement('m3-radio-button')
 export class M3RadioButton extends FormAssociatedElement {
@@ -21,13 +22,18 @@ export class M3RadioButton extends FormAssociatedElement {
   @property({ type: Boolean, reflect: true }) required = false;
   @property({ type: String, reflect: true }) name: string | null = null;
   @property({ type: String, reflect: true }) value: string | null = null;
-  @property({ type: String, attribute: 'aria-label' }) ariaLabel: string | null = null;
-  @property({ type: String, attribute: 'aria-labelledby' }) ariaLabelledBy: string | null = null;
-  @property({ type: String, reflect: true }) size: 'small' | 'medium' | 'large' = 'small';
+  @property({ type: String, attribute: 'aria-label' }) ariaLabel:
+    string | null = null;
+  @property({ type: String, attribute: 'aria-labelledby' }) ariaLabelledBy:
+    string | null = null;
+  @property({ type: String, reflect: true }) size:
+    'small' | 'medium' | 'large' = 'small';
 
   @state() private _pressed = false;
   @state() private _ripple = false;
   private _defaultChecked = false;
+  private _lastScopeRoot: Document | ShadowRoot | null = null;
+  private readonly _labelListeners = new Map<HTMLLabelElement, EventListener>();
 
   render() {
     return html`
@@ -38,7 +44,7 @@ export class M3RadioButton extends FormAssociatedElement {
         aria-disabled=${this.isFormDisabled}
         aria-label=${this.ariaLabel || ''}
         aria-labelledby=${this.ariaLabelledBy || ''}
-        tabindex=${this.isFormDisabled ? -1 : 0}
+        tabindex=${this._tabIndex()}
         @click=${this._handleClick}
         @keydown=${this._handleKeyDown}
         @keyup=${this._handleKeyUp}
@@ -46,7 +52,12 @@ export class M3RadioButton extends FormAssociatedElement {
         @mouseup=${this._handleMouseUp}
         @mouseleave=${this._handleMouseLeave}
       >
-        <div class="radio-outer" ?checked=${this.checked} ?disabled=${this.isFormDisabled} ?pressed=${this._pressed}>
+        <div
+          class="radio-outer"
+          ?checked=${this.checked}
+          ?disabled=${this.isFormDisabled}
+          ?pressed=${this._pressed}
+        >
           ${this.checked ? html`<div class="radio-inner"></div>` : ''}
         </div>
         ${this._ripple ? html`<div class="ripple"></div>` : ''}
@@ -59,8 +70,42 @@ export class M3RadioButton extends FormAssociatedElement {
     this._syncFormState();
   }
 
-  updated(): void {
+  connectedCallback(): void {
+    super.connectedCallback();
+    this._lastScopeRoot = this._scopeRoot();
+    this._connectLabels();
+    this._refreshScopedRadios();
+  }
+
+  disconnectedCallback(): void {
+    this._disconnectLabels();
+    this._refreshScopedRadios(this._lastScopeRoot);
+    this._lastScopeRoot = null;
+    super.disconnectedCallback();
+  }
+
+  updated(changedProperties: PropertyValues<this>): void {
+    if (changedProperties.has('checked') && this.checked)
+      this._clearCheckedPeers();
     this._syncFormState();
+    if (
+      changedProperties.has('checked') ||
+      changedProperties.has('name') ||
+      changedProperties.has('disabled') ||
+      changedProperties.has('required')
+    ) {
+      this._refreshScopedRadios();
+    }
+  }
+
+  formAssociatedCallback(form: HTMLFormElement | null): void {
+    super.formAssociatedCallback(form);
+    this._refreshScopedRadios();
+  }
+
+  formDisabledCallback(disabled: boolean): void {
+    super.formDisabledCallback(disabled);
+    this._refreshScopedRadios();
   }
 
   private _handleClick(event: MouseEvent): void {
@@ -87,7 +132,8 @@ export class M3RadioButton extends FormAssociatedElement {
   }
 
   private _handleKeyUp(event: KeyboardEvent): void {
-    if (this.isFormDisabled || (event.key !== ' ' && event.key !== 'Enter')) return;
+    if (this.isFormDisabled || (event.key !== ' ' && event.key !== 'Enter'))
+      return;
     event.preventDefault();
     this._pressed = false;
     this._select();
@@ -108,9 +154,9 @@ export class M3RadioButton extends FormAssociatedElement {
   private _select(emitEvents = true): void {
     if (this.checked || this.isFormDisabled) return;
     this.checked = true;
-    this._radioGroup().forEach((radio) => {
-      if (radio !== this && radio.checked) radio.checked = false;
-    });
+    this._clearCheckedPeers();
+    this._syncFormState();
+    this._refreshScopedRadios();
     this._triggerRipple();
     if (emitEvents) {
       this.emitInput();
@@ -129,20 +175,85 @@ export class M3RadioButton extends FormAssociatedElement {
 
   private _radioGroup(): M3RadioButton[] {
     if (!this.name) return [this];
-    return Array.from(document.querySelectorAll<M3RadioButton>('m3-radio-button')).filter((radio) =>
-      radio.name === this.name && radio.form === this.form,
+    return this._scopedRadios().filter(
+      (radio) => radio.name === this.name && radio.form === this.form,
     );
+  }
+
+  private _scopeRoot(): Document | ShadowRoot | null {
+    const root = this.getRootNode();
+    return root instanceof Document || root instanceof ShadowRoot ? root : null;
+  }
+
+  private _scopedRadios(root = this._scopeRoot()): M3RadioButton[] {
+    return root
+      ? Array.from(root.querySelectorAll<M3RadioButton>('m3-radio-button'))
+      : [this];
+  }
+
+  private _clearCheckedPeers(): void {
+    this._radioGroup().forEach((radio) => {
+      if (radio !== this && radio.checked) {
+        radio.checked = false;
+        radio._syncFormState();
+      }
+    });
+  }
+
+  private _tabIndex(): number {
+    if (this.isFormDisabled) return -1;
+    const enabled = this._radioGroup().filter((radio) => !radio.isFormDisabled);
+    const active = enabled.find((radio) => radio.checked) ?? enabled[0];
+    return active === this ? 0 : -1;
+  }
+
+  private _refreshScopedRadios(root = this._scopeRoot()): void {
+    this._scopedRadios(root).forEach((radio) => {
+      if (radio !== this) radio.requestUpdate();
+    });
+  }
+
+  private _connectLabels(): void {
+    Array.from(this.labels ?? []).forEach((label) => {
+      if (
+        !(label instanceof HTMLLabelElement) ||
+        this._labelListeners.has(label)
+      )
+        return;
+      const listener: EventListener = () => {
+        if (this.isFormDisabled) return;
+        this.focus();
+        this._select();
+      };
+      label.addEventListener('click', listener);
+      this._labelListeners.set(label, listener);
+    });
+  }
+
+  private _disconnectLabels(): void {
+    this._labelListeners.forEach((listener, label) =>
+      label.removeEventListener('click', listener),
+    );
+    this._labelListeners.clear();
   }
 
   private _syncFormState(): void {
     const disabled = this.isFormDisabled;
-    this.setFormValue(!disabled && this.checked ? this.value ?? 'on' : null, this.checked ? 'checked' : 'unchecked');
-    const requiredRadio = this._radioGroup().some((radio) => radio.required && !radio.isFormDisabled);
-    const selected = this._radioGroup().some((radio) => radio.checked && !radio.isFormDisabled);
+    this.setFormValue(
+      !disabled && this.checked ? (this.value ?? 'on') : null,
+      this.checked ? 'checked' : 'unchecked',
+    );
+    const requiredRadio = this._radioGroup().some(
+      (radio) => radio.required && !radio.isFormDisabled,
+    );
+    const selected = this._radioGroup().some(
+      (radio) => radio.checked && !radio.isFormDisabled,
+    );
     this.setFormValidity(
       !disabled && requiredRadio && !selected ? { valueMissing: true } : {},
       !disabled && requiredRadio && !selected ? 'Please select an option.' : '',
-      this.shadowRoot?.querySelector<HTMLElement>('.radio-container') ?? undefined,
+      this.shadowRoot?.querySelector<HTMLElement>('.radio-container') ??
+        undefined,
     );
   }
 
@@ -150,9 +261,12 @@ export class M3RadioButton extends FormAssociatedElement {
     this._ripple = true;
     void this.updateComplete.then(() => {
       const ripple = this.shadowRoot?.querySelector('.ripple');
-      setTimeout(() => {
-        this._ripple = false;
-      }, ripple ? motionDuration(ripple, '--_ripple-duration') : 0);
+      setTimeout(
+        () => {
+          this._ripple = false;
+        },
+        ripple ? motionDuration(ripple, '--_ripple-duration') : 0,
+      );
     });
   }
 
@@ -160,7 +274,9 @@ export class M3RadioButton extends FormAssociatedElement {
     this.checked = this._defaultChecked;
   }
 
-  protected restoreFormControlState(state: string | File | FormData | null): void {
+  protected restoreFormControlState(
+    state: string | File | FormData | null,
+  ): void {
     if (typeof state === 'string') this.checked = state === 'checked';
   }
 

--- a/packages/m3-radio-button/src/m3-radio-button.ts
+++ b/packages/m3-radio-button/src/m3-radio-button.ts
@@ -4,6 +4,12 @@ import { FormAssociatedElement } from '@banegasn/m3-form-associated';
 import { m3RadioButtonStyles } from './m3-radio-button.styles.js';
 import { motionDuration } from './motion-duration.js';
 
+interface RadioGroupScope {
+  root: Document | ShadowRoot;
+  name: string | null;
+  form: HTMLFormElement | null;
+}
+
 /**
  * Material Design 3 radio button with native form participation.
  *
@@ -33,6 +39,7 @@ export class M3RadioButton extends FormAssociatedElement {
   @state() private _ripple = false;
   private _defaultChecked = false;
   private _lastScopeRoot: Document | ShadowRoot | null = null;
+  private _groupScope: RadioGroupScope | null = null;
   private readonly _labelListeners = new Map<HTMLLabelElement, EventListener>();
 
   render() {
@@ -74,13 +81,15 @@ export class M3RadioButton extends FormAssociatedElement {
     super.connectedCallback();
     this._lastScopeRoot = this._scopeRoot();
     this._connectLabels();
-    this._refreshScopedRadios();
+    this._reconcileGroupScope();
+    this.requestUpdate();
   }
 
   disconnectedCallback(): void {
     this._disconnectLabels();
-    this._refreshScopedRadios(this._lastScopeRoot);
+    this._refreshScopedRadios(this._groupScope?.root ?? this._lastScopeRoot);
     this._lastScopeRoot = null;
+    this._groupScope = null;
     super.disconnectedCallback();
   }
 
@@ -88,6 +97,7 @@ export class M3RadioButton extends FormAssociatedElement {
     if (changedProperties.has('checked') && this.checked)
       this._clearCheckedPeers();
     this._syncFormState();
+    if (changedProperties.has('name')) this._reconcileGroupScope();
     if (
       changedProperties.has('checked') ||
       changedProperties.has('name') ||
@@ -100,7 +110,8 @@ export class M3RadioButton extends FormAssociatedElement {
 
   formAssociatedCallback(form: HTMLFormElement | null): void {
     super.formAssociatedCallback(form);
-    this._refreshScopedRadios();
+    this._reconcileGroupScope();
+    this.requestUpdate();
   }
 
   formDisabledCallback(disabled: boolean): void {
@@ -189,6 +200,33 @@ export class M3RadioButton extends FormAssociatedElement {
     return root
       ? Array.from(root.querySelectorAll<M3RadioButton>('m3-radio-button'))
       : [this];
+  }
+
+  private _currentGroupScope(): RadioGroupScope | null {
+    const root = this._scopeRoot();
+    return root ? { root, name: this.name, form: this.form } : null;
+  }
+
+  private _reconcileGroupScope(): void {
+    const previous = this._groupScope;
+    const current = this._currentGroupScope();
+    const changed = !this._sameGroupScope(previous, current);
+    if (this.checked && current && changed) this._clearCheckedPeers();
+    this._groupScope = current;
+    if (previous?.root) this._refreshScopedRadios(previous.root);
+    if (current && current.root !== previous?.root)
+      this._refreshScopedRadios(current.root);
+  }
+
+  private _sameGroupScope(
+    first: RadioGroupScope | null,
+    second: RadioGroupScope | null,
+  ): boolean {
+    return (
+      first?.root === second?.root &&
+      first?.name === second?.name &&
+      first?.form === second?.form
+    );
   }
 
   private _clearCheckedPeers(): void {

--- a/packages/m3-radio-button/tsconfig.test.json
+++ b/packages/m3-radio-button/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.test.json",
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -383,6 +383,9 @@ importers:
         specifier: ^3.3.3
         version: 3.3.3
     devDependencies:
+      '@open-wc/testing':
+        specifier: 5.0.0
+        version: 5.0.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3

--- a/vitest.browser.config.ts
+++ b/vitest.browser.config.ts
@@ -25,6 +25,7 @@ const browserPorts: Record<string, number> = {
   'm3-fab-menu': 63_329,
   'm3-split-button': 63_330,
   'm3-dialog': 63_331,
+  'm3-radio-button': 63_332,
 };
 
 const port = browserPorts[workspaceName];


### PR DESCRIPTION
Fixes #10

## Summary
- Replace document-wide radio discovery with local document/shadow-root groups matched by non-empty name and owner form.
- Add roving tabindex and wrapping arrow navigation that skips disabled peers.
- Support only explicit external `label[for]` / host `id` associations; listener lifecycle is local and cleaned up on disconnect.
- Add a dedicated three-browser radio suite and document the public grouping and label contract.

## Acceptance mapping
- No document-global custom radio event: radio coordination is local root discovery; there are no document event listeners or broadcasts.
- Lifecycle safety: explicit label listeners are owned by the radio, removed on disconnect, and covered by repeated connect/disconnect tests.
- Group isolation: browser tests cover same-name controls across separate owner forms and an open shadow root.
- Native-like interaction and forms: tests cover roving focus, arrows, disabled skip, checked state, input/change emission, and FormData.
- Explicit external labels: browser tests cover `for`/`id` plus `aria-labelledby`.

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (Chromium, Firefox, WebKit)
- `pnpm tokens:check`
- `pnpm exec turbo run build`
- `pnpm audit:prod`
- `pnpm smoke:packages`
- `pnpm smoke:svelte-vite`
- `pnpm verify:package-licenses`