### PR TITLE
feat(m3-tooltip): complete accessible tooltip contract

### DIFF
--- a/apps/angular-app/src/pages/tooltip/tooltip.component.html
+++ b/apps/angular-app/src/pages/tooltip/tooltip.component.html
@@ -14,4 +14,17 @@
       <app-code-block [code]="basicExample" language="html" variant="sample"></app-code-block>
     </div>
   </section>
+
+  <section class="demo-section">
+    <h2>Interactive Rich Tooltip</h2>
+    <p>Move from the trigger into the surface, or use the link with the keyboard. Press Escape to dismiss.</p>
+    <div class="interactive-demo">
+      <m3-tooltip variant="rich" placement="right">
+        <m3-button variant="outlined">More details</m3-button>
+        <strong slot="title">Storage limit</strong>
+        <span slot="content">You have 2 GB remaining. <a href="/storage">Manage storage</a></span>
+      </m3-tooltip>
+      <app-code-block [code]="richExample" language="html" variant="sample"></app-code-block>
+    </div>
+  </section>
 </div>

--- a/apps/angular-app/src/pages/tooltip/tooltip.component.ts
+++ b/apps/angular-app/src/pages/tooltip/tooltip.component.ts
@@ -15,4 +15,10 @@ export class TooltipComponent {
   readonly basicExample = `<m3-tooltip text="Save" placement="top">
   <m3-button>Save</m3-button>
 </m3-tooltip>`;
+
+  readonly richExample = `<m3-tooltip variant="rich" placement="right">
+  <m3-button>More details</m3-button>
+  <strong slot="title">Storage limit</strong>
+  <span slot="content">You have 2 GB remaining. <a href="/storage">Manage storage</a></span>
+</m3-tooltip>`;
 }

--- a/packages/m3-tooltip/README.md
+++ b/packages/m3-tooltip/README.md
@@ -8,14 +8,15 @@
 [![npm version](https://img.shields.io/npm/v/@banegasn/m3-tooltip.svg)](https://www.npmjs.com/package/@banegasn/m3-tooltip)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](../../LICENSE)
 
-An accessible **M3 Tooltip** web component following the [Material Design 3 tooltip specifications](https://m3.material.io/components/tooltips/overview). Supports plain and rich tooltip variants with smart positioning. Works in Angular, React, Vue, Svelte, or plain HTML — no build step required.
+An accessible **M3 Tooltip** web component following the [Material Design 3 tooltip specifications](https://m3.material.io/components/tooltips/overview). It supports descriptive plain tooltips and interactive rich tooltips with viewport-aware positioning. Works in Angular, React, Vue, Svelte, or plain HTML — no build step required.
 
 ## Features
 
 - Plain and rich tooltip variants
-- Smart auto-positioning (top, bottom, left, right)
-- Keyboard and hover triggered
-- Accessible with ARIA `tooltip` role
+- Preferred placement with viewport-edge flipping
+- Hover and keyboard-focus triggers with a generated `aria-describedby` relationship
+- Escape dismissal that leaves trigger focus in place
+- Interactive rich tooltip content
 - Framework-agnostic custom element
 
 ## Installation
@@ -48,8 +49,8 @@ yarn add @banegasn/m3-tooltip
     <m3-button variant="filled">Save</m3-button>
   </m3-tooltip>
 
-  <!-- Tooltip with bottom placement -->
-  <m3-tooltip text="Delete this item" placement="bottom">
+  <!-- Tooltip with bottom placement and a 300ms hover delay -->
+  <m3-tooltip text="Delete this item" placement="bottom" delay="300">
     <m3-button variant="outlined">Delete</m3-button>
   </m3-tooltip>
 
@@ -77,16 +78,33 @@ import '@banegasn/m3-tooltip';
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
 | `text` | `string` | `''` | Plain tooltip text |
-| `placement` | `'top' \| 'bottom' \| 'left' \| 'right'` | `'top'` | Preferred tooltip position |
-| `delay` | `number` | `500` | Show delay in milliseconds |
+| `variant` | `'plain' \| 'rich'` | `'plain'` | Plain descriptive tooltip or interactive rich tooltip |
+| `placement` | `'top' \| 'bottom' \| 'left' \| 'right'` | `'top'` | Preferred position; flips when it would overflow the viewport |
+| `delay` | `number` | `500` | Pointer-hover show delay in milliseconds; keyboard focus shows immediately |
 
 ### Slots
 
 | Slot | Description |
 |------|-------------|
-| (default) | The trigger element |
-| `title` | Rich tooltip title (activates rich variant) |
-| `content` | Rich tooltip body content |
+| (default) | The single trigger element. Its `aria-describedby` receives the generated tooltip ID. |
+| `title` | Rich-tooltip heading. Use with `variant="rich"`. |
+| `content` | Rich-tooltip body and optional interactive content. Use with `variant="rich"`. |
+
+## Rich tooltip
+
+Rich tooltips use a dialog surface so links, buttons, and other controls remain usable. Moving between the trigger and the rich surface, or focusing content inside it, keeps it open. Pressing <kbd>Escape</kbd> dismisses either variant without moving focus.
+
+```html
+<m3-tooltip variant="rich" placement="right">
+  <button aria-label="More details">Details</button>
+  <strong slot="title">Storage limit</strong>
+  <span slot="content">You have 2 GB remaining. <a href="/storage">Manage storage</a></span>
+</m3-tooltip>
+```
+
+## Trigger ownership
+
+`m3-tooltip` owns exactly one direct, un-slotted element child as its trigger. It adds its stable generated ID to that element’s `aria-describedby` list and removes only its own ID when the trigger changes or the tooltip disconnects. This keeps existing ID references intact.
 
 ### CSS Custom Properties
 

--- a/packages/m3-tooltip/package.json
+++ b/packages/m3-tooltip/package.json
@@ -23,8 +23,8 @@
     "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist",
     "lint": "eslint src --max-warnings 0",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node ../../scripts/no-tests.mjs"
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json",
+    "test": "vitest run --config ../../vitest.browser.config.ts"
   },
   "repository": {
     "type": "git",

--- a/packages/m3-tooltip/src/m3-tooltip.styles.ts
+++ b/packages/m3-tooltip/src/m3-tooltip.styles.ts
@@ -1,88 +1,47 @@
 import { css } from 'lit';
 
 export const m3TooltipStyles = css`
-  :host {
-    display: inline-block;
-    position: relative;
-    --_show-delay: var(--md-sys-motion-duration-long2);
-    --_hide-delay: var(--md-sys-motion-duration-short2);
-  }
+  :host { display: inline-block; }
 
   .tooltip-surface {
-    position: absolute;
+    position: fixed;
     z-index: 999;
+    max-width: min(320px, calc(100vw - 16px));
+    max-height: calc(100vh - 16px);
+    overflow: auto;
     padding: 4px 8px;
     border-radius: var(--md-comp-tooltip-shape, 4px);
     font-size: 0.75rem;
     line-height: 1rem;
-    white-space: nowrap;
-    pointer-events: none;
     opacity: 0;
-    transform: scale(0.8);
+    pointer-events: none;
+    transform: scale(0.96);
     transition: opacity var(--md-sys-motion-duration-short3) var(--md-sys-motion-easing-emphasized-decelerate), transform var(--md-sys-motion-duration-short3) var(--md-sys-motion-easing-emphasized-decelerate);
   }
 
-  /* Plain tooltip */
-  :host([variant="plain"]) .tooltip-surface,
-  :host(:not([variant])) .tooltip-surface {
+  .tooltip-surface:not([positioned]) { visibility: hidden; }
+  .tooltip-surface[visible] { opacity: 1; transform: scale(1); }
+
+  :host([variant="plain"]) .tooltip-surface {
     background-color: var(--md-sys-color-inverse-surface, #322f35);
     color: var(--md-sys-color-inverse-on-surface, #f5eff7);
-    max-width: 200px;
-    white-space: normal;
   }
 
-  /* Rich tooltip */
   :host([variant="rich"]) .tooltip-surface {
+    padding: 12px 16px;
+    border-radius: var(--md-comp-tooltip-shape, 12px);
     background-color: var(--md-sys-color-surface-container, #f3edf7);
     color: var(--md-sys-color-on-surface, #1d1b20);
-    border-radius: var(--md-comp-tooltip-shape, 12px);
-    padding: 12px 16px;
-    max-width: 320px;
-    white-space: normal;
-    box-shadow: 0 2px 6px 2px rgba(0,0,0,0.15), 0 1px 2px rgba(0,0,0,0.3);
+    box-shadow: 0 2px 6px 2px rgba(0, 0, 0, 0.15), 0 1px 2px rgba(0, 0, 0, 0.3);
+    pointer-events: auto;
   }
 
-  .tooltip-surface[visible] {
-    opacity: 1;
-    transform: scale(1);
-  }
+  .rich-title { margin-bottom: 4px; font-weight: 700; }
+  .rich-content { font-size: 0.875rem; line-height: 1.25rem; }
+  .tooltip-surface[data-placement="top"] { transform-origin: bottom center; }
+  .tooltip-surface[data-placement="bottom"] { transform-origin: top center; }
+  .tooltip-surface[data-placement="left"] { transform-origin: center right; }
+  .tooltip-surface[data-placement="right"] { transform-origin: center left; }
 
-  /* Placement */
-  :host([placement="top"]) .tooltip-surface {
-    bottom: calc(100% + 8px);
-    left: 50%;
-    transform: translateX(-50%) scale(0.8);
-  }
-  :host([placement="top"]) .tooltip-surface[visible] {
-    transform: translateX(-50%) scale(1);
-  }
-
-  :host([placement="bottom"]) .tooltip-surface,
-  :host(:not([placement])) .tooltip-surface {
-    top: calc(100% + 8px);
-    left: 50%;
-    transform: translateX(-50%) scale(0.8);
-  }
-  :host([placement="bottom"]) .tooltip-surface[visible],
-  :host(:not([placement])) .tooltip-surface[visible] {
-    transform: translateX(-50%) scale(1);
-  }
-
-  :host([placement="left"]) .tooltip-surface {
-    right: calc(100% + 8px);
-    top: 50%;
-    transform: translateY(-50%) scale(0.8);
-  }
-  :host([placement="left"]) .tooltip-surface[visible] {
-    transform: translateY(-50%) scale(1);
-  }
-
-  :host([placement="right"]) .tooltip-surface {
-    left: calc(100% + 8px);
-    top: 50%;
-    transform: translateY(-50%) scale(0.8);
-  }
-  :host([placement="right"]) .tooltip-surface[visible] {
-    transform: translateY(-50%) scale(1);
-  }
+  @media (prefers-reduced-motion: reduce) { .tooltip-surface { transition: none; } }
 `;

--- a/packages/m3-tooltip/src/m3-tooltip.test.ts
+++ b/packages/m3-tooltip/src/m3-tooltip.test.ts
@@ -1,0 +1,137 @@
+import { expect, fixture, html } from '@open-wc/testing';
+import { describe, it } from 'vitest';
+import './m3-tooltip.js';
+import type { M3Tooltip } from './m3-tooltip.js';
+
+const nextFrame = () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+async function settle(tooltip: M3Tooltip) {
+  await tooltip.updateComplete;
+  await nextFrame();
+  await tooltip.updateComplete;
+}
+
+function surface(tooltip: M3Tooltip) {
+  return tooltip.shadowRoot!.querySelector<HTMLElement>('.tooltip-surface')!;
+}
+
+describe('M3Tooltip public interaction contract', () => {
+  it('shows a plain tooltip from hover and keyboard focus', async () => {
+    const tooltip = await fixture<M3Tooltip>(html`
+      <m3-tooltip text="Save document" delay="0"><button>Save</button></m3-tooltip>
+    `);
+    const trigger = tooltip.querySelector<HTMLButtonElement>('button')!;
+
+    trigger.dispatchEvent(new MouseEvent('mouseenter'));
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(tooltip);
+    expect(surface(tooltip).hasAttribute('visible')).to.equal(true);
+
+    trigger.dispatchEvent(new MouseEvent('mouseleave', { relatedTarget: document.body }));
+    await settle(tooltip);
+    expect(surface(tooltip).hasAttribute('visible')).to.equal(false);
+
+    trigger.focus();
+    await settle(tooltip);
+    expect(document.activeElement).to.equal(trigger);
+    expect(surface(tooltip).hasAttribute('visible')).to.equal(true);
+  });
+
+  it('provides a stable described-by ID whose accessible text is the tooltip text', async () => {
+    const tooltip = await fixture<M3Tooltip>(html`
+      <m3-tooltip text="Keyboard shortcut: ⌘S"><button aria-describedby="existing">Save</button></m3-tooltip>
+    `);
+    const trigger = tooltip.querySelector<HTMLButtonElement>('button')!;
+    const tooltipSurface = surface(tooltip);
+    const ids = trigger.getAttribute('aria-describedby')!.split(/\s+/);
+
+    expect(tooltipSurface.id).to.match(/^m3-tooltip-\d+$/);
+    expect(ids).to.include('existing');
+    expect(ids).to.include(tooltipSurface.id);
+    // The light-tree description is what browsers resolve for the trigger's
+    // computed accessible description; its ID matches the stable surface ID.
+    expect(document.getElementById(tooltipSurface.id)!.textContent).to.equal('Keyboard shortcut: ⌘S');
+    await expect(tooltip).to.be.accessible();
+  });
+
+  it('dismisses with Escape without moving focus', async () => {
+    const tooltip = await fixture<M3Tooltip>(html`
+      <m3-tooltip text="Save"><button>Save</button></m3-tooltip>
+    `);
+    const trigger = tooltip.querySelector<HTMLButtonElement>('button')!;
+    trigger.focus();
+    await settle(tooltip);
+
+    trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, composed: true }));
+    await settle(tooltip);
+    expect(surface(tooltip).hasAttribute('visible')).to.equal(false);
+    expect(document.activeElement).to.equal(trigger);
+  });
+
+  it('keeps a rich tooltip open while its content is hovered, focused, and used', async () => {
+    const tooltip = await fixture<M3Tooltip>(html`
+      <m3-tooltip variant="rich" delay="0">
+        <button>More options</button>
+        <span slot="title">More options</span>
+        <button slot="content" id="action">Learn more</button>
+      </m3-tooltip>
+    `);
+    const trigger = tooltip.querySelector<HTMLButtonElement>('button:not([slot])')!;
+    const action = tooltip.querySelector<HTMLButtonElement>('#action')!;
+    trigger.dispatchEvent(new MouseEvent('mouseenter'));
+    await settle(tooltip);
+
+    const tooltipSurface = surface(tooltip);
+    expect(tooltipSurface.getAttribute('role')).to.equal('dialog');
+    expect(getComputedStyle(tooltipSurface).pointerEvents).to.equal('auto');
+    trigger.dispatchEvent(new MouseEvent('mouseleave', { relatedTarget: action }));
+    let clicked = false;
+    action.addEventListener('click', () => { clicked = true; });
+    action.click();
+    action.dispatchEvent(new FocusEvent('focusin', { bubbles: true, composed: true }));
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    await settle(tooltip);
+    expect(tooltipSurface.hasAttribute('visible')).to.equal(true);
+    expect(clicked).to.equal(true);
+
+    tooltipSurface.dispatchEvent(new MouseEvent('mouseleave', { relatedTarget: document.body }));
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    await settle(tooltip);
+    expect(tooltipSurface.hasAttribute('visible')).to.equal(false);
+  });
+
+  it('honors the documented delay and flips placement at viewport edges', async () => {
+    const tooltip = await fixture<M3Tooltip>(html`
+      <m3-tooltip text="Edge" placement="top" delay="40" style="position: fixed; top: 0; left: 20px">
+        <button>Edge trigger</button>
+      </m3-tooltip>
+    `);
+    const trigger = tooltip.querySelector<HTMLButtonElement>('button')!;
+    trigger.dispatchEvent(new MouseEvent('mouseenter'));
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(surface(tooltip).hasAttribute('visible')).to.equal(false);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    await settle(tooltip);
+    expect(surface(tooltip).hasAttribute('visible')).to.equal(true);
+    expect(surface(tooltip).dataset.placement).to.equal('bottom');
+  });
+
+  it('cleans timers, trigger listeners, and IDREF mutations across reconnects', async () => {
+    const container = await fixture<HTMLDivElement>(html`
+      <div><m3-tooltip text="Save" delay="40"><button aria-describedby="existing">Save</button></m3-tooltip></div>
+    `);
+    const tooltip = container.querySelector<M3Tooltip>('m3-tooltip')!;
+    const trigger = tooltip.querySelector<HTMLButtonElement>('button')!;
+    const tooltipId = surface(tooltip).id;
+    trigger.dispatchEvent(new MouseEvent('mouseenter'));
+    tooltip.remove();
+    await new Promise((resolve) => setTimeout(resolve, 60));
+
+    expect(trigger.getAttribute('aria-describedby')).to.equal('existing');
+    expect(document.getElementById(tooltipId)).to.equal(null);
+    container.append(tooltip);
+    await settle(tooltip);
+    expect(trigger.getAttribute('aria-describedby')!.split(/\s+/)).to.include(tooltipId);
+    expect(surface(tooltip).hasAttribute('visible')).to.equal(false);
+  });
+});

--- a/packages/m3-tooltip/src/m3-tooltip.test.ts
+++ b/packages/m3-tooltip/src/m3-tooltip.test.ts
@@ -134,4 +134,35 @@ describe('M3Tooltip public interaction contract', () => {
     expect(trigger.getAttribute('aria-describedby')!.split(/\s+/)).to.include(tooltipId);
     expect(surface(tooltip).hasAttribute('visible')).to.equal(false);
   });
+
+  it('does not recreate a description while detached after property updates', async () => {
+    const container = await fixture<HTMLDivElement>(html`
+      <div>
+        <m3-tooltip text="Original">
+          <button aria-describedby="existing">Details</button>
+          <span slot="title">Updated heading</span>
+          <span slot="content">Updated content</span>
+        </m3-tooltip>
+      </div>
+    `);
+    const tooltip = container.querySelector<M3Tooltip>('m3-tooltip')!;
+    const trigger = tooltip.querySelector<HTMLButtonElement>('button')!;
+    const tooltipId = surface(tooltip).id;
+
+    tooltip.remove();
+    tooltip.text = 'Changed while detached';
+    tooltip.variant = 'rich';
+    await tooltip.updateComplete;
+    expect(tooltip.querySelectorAll(`span[slot="description"]#${tooltipId}`).length).to.equal(0);
+    expect(trigger.getAttribute('aria-describedby')).to.equal('existing');
+
+    container.append(tooltip);
+    await settle(tooltip);
+    const descriptions = tooltip.querySelectorAll<HTMLSpanElement>(`span[slot="description"]#${tooltipId}`);
+    const ids = trigger.getAttribute('aria-describedby')!.split(/\s+/);
+    expect(descriptions).to.have.length(1);
+    expect(descriptions[0]!.textContent).to.equal('Updated heading Updated content');
+    expect(ids.filter((id) => id === tooltipId)).to.have.length(1);
+    expect(ids).to.include('existing');
+  });
 });

--- a/packages/m3-tooltip/src/m3-tooltip.ts
+++ b/packages/m3-tooltip/src/m3-tooltip.ts
@@ -1,88 +1,345 @@
 import { LitElement, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { m3TooltipStyles } from './m3-tooltip.styles.js';
-import { motionDuration } from './motion-duration.js';
+
+export type M3TooltipPlacement = 'top' | 'bottom' | 'left' | 'right';
+export type M3TooltipVariant = 'plain' | 'rich';
+
+const VIEWPORT_PADDING = 8;
+const TOOLTIP_GAP = 8;
+const RICH_HIDE_DELAY = 100;
+let nextTooltipId = 0;
 
 /**
- * Material Design 3 Tooltip Component
+ * Material Design 3 Tooltip Component.
  *
- * @slot - Default slot for the trigger element
+ * Exactly one direct, un-slotted element child is the trigger. Plain tooltips
+ * describe that trigger; rich tooltips can additionally receive focus and
+ * contain interactive content through their named slots.
  *
- * @cssprop --md-sys-color-inverse-surface - Plain tooltip background
- * @cssprop --md-sys-color-inverse-on-surface - Plain tooltip text
+ * @slot - The trigger element
+ * @slot title - Rich-tooltip heading
+ * @slot content - Rich-tooltip body and interactive content
  */
 @customElement('m3-tooltip')
 export class M3Tooltip extends LitElement {
   static styles = m3TooltipStyles;
 
-  /** Tooltip text */
+  /** Plain-tooltip text. */
   @property({ type: String }) text = '';
 
-  /** Variant: plain (default) or rich */
+  /** Plain (descriptive) or rich (interactive) tooltip. */
   @property({ type: String, reflect: true })
-  variant: 'plain' | 'rich' = 'plain';
+  variant: M3TooltipVariant = 'plain';
 
-  /** Placement */
+  /** Preferred placement. The resolved placement may flip at viewport edges. */
   @property({ type: String, reflect: true })
-  placement: 'top' | 'bottom' | 'left' | 'right' = 'bottom';
+  placement: M3TooltipPlacement = 'top';
+
+  /** Delay, in milliseconds, before pointer hover shows the tooltip. */
+  @property({ type: Number, reflect: true })
+  delay = 500;
 
   @state() private _visible = false;
+  @state() private _positioned = false;
+  @state() private _resolvedPlacement: M3TooltipPlacement = 'top';
+
+  private readonly _tooltipId = `m3-tooltip-${++nextTooltipId}`;
+  private _trigger: HTMLElement | null = null;
+  private _description: HTMLSpanElement | null = null;
   private _showTimeout: ReturnType<typeof setTimeout> | null = null;
   private _hideTimeout: ReturnType<typeof setTimeout> | null = null;
+  private _positionFrame: number | null = null;
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._ensureDescription();
+    this._setTrigger(this._findTrigger());
+    window.addEventListener('resize', this._queuePosition);
+    document.addEventListener('scroll', this._queuePosition, true);
+    window.visualViewport?.addEventListener('resize', this._queuePosition);
+  }
+
+  disconnectedCallback() {
+    this._clearTimeouts();
+    this._cancelPosition();
+    window.removeEventListener('resize', this._queuePosition);
+    document.removeEventListener('scroll', this._queuePosition, true);
+    window.visualViewport?.removeEventListener('resize', this._queuePosition);
+    this._setTrigger(null);
+    this._description?.remove();
+    this._description = null;
+    super.disconnectedCallback();
+  }
 
   render() {
+    const isRich = this.variant === 'rich';
+    const hasTitle = this._hasRichTitle();
+
     return html`
+      <slot @slotchange=${this._handleTriggerSlotChange}></slot>
       <div
-        @mouseenter=${this._handleMouseEnter}
-        @mouseleave=${this._handleMouseLeave}
-        @focus=${this._handleFocus}
-        @blur=${this._handleBlur}
-      >
-        <slot></slot>
-      </div>
-      <div
+        id=${this._tooltipId}
         class="tooltip-surface"
-        role="tooltip"
+        part="surface"
+        role=${isRich ? 'dialog' : 'tooltip'}
+        aria-label=${ifDefined(isRich && !hasTitle ? 'Rich tooltip' : undefined)}
+        aria-labelledby=${ifDefined(isRich && hasTitle ? `${this._tooltipId}-title` : undefined)}
+        tabindex=${ifDefined(isRich ? '0' : undefined)}
+        data-placement=${this._resolvedPlacement}
         ?visible=${this._visible}
-        aria-hidden=${!this._visible}
+        ?positioned=${this._positioned}
+        aria-hidden=${String(!this._visible)}
+        @mouseenter=${this._handleSurfaceMouseEnter}
+        @mouseleave=${this._handleSurfaceMouseLeave}
+        @focusin=${this._handleSurfaceFocusIn}
+        @focusout=${this._handleSurfaceFocusOut}
+        @keydown=${this._handleKeydown}
       >
-        ${this.text}
+        ${isRich
+          ? html`
+              <div id=${`${this._tooltipId}-title`} class="rich-title"><slot name="title" @slotchange=${this._handleRichSlotChange}></slot></div>
+              <div class="rich-content"><slot name="content" @slotchange=${this._handleRichSlotChange}></slot></div>
+            `
+          : this.text}
       </div>
     `;
   }
 
-  private _handleMouseEnter() {
-    this._clearTimeouts();
+  updated(changedProperties: Map<string, unknown>) {
+    this._ensureDescription();
+    this._syncDescription();
+    this._setTrigger(this._findTrigger());
+    if (changedProperties.has('_visible') || changedProperties.has('placement') || changedProperties.has('variant') || changedProperties.has('text')) {
+      this._queuePosition();
+    }
+  }
+
+  private _handleTriggerSlotChange = () => this._setTrigger(this._findTrigger());
+
+  private _handleRichSlotChange = () => {
+    this.requestUpdate();
+    this._syncDescription();
+    this._queuePosition();
+  };
+
+  private _handleTriggerMouseEnter = () => this._scheduleShow();
+
+  private _handleTriggerMouseLeave = (event: MouseEvent) => {
+    if (!this._isTooltipNode(event.relatedTarget)) this._scheduleHide();
+  };
+
+  private _handleTriggerFocusIn = () => this._showNow();
+
+  private _handleTriggerFocusOut = (event: FocusEvent) => {
+    if (!this._isTooltipNode(event.relatedTarget)) this._scheduleHide();
+  };
+
+  private _handleSurfaceMouseEnter = () => {
+    this._clearHideTimeout();
+    this._showNow();
+  };
+
+  private _handleSurfaceMouseLeave = (event: MouseEvent) => {
+    if (!this._isTooltipNode(event.relatedTarget)) this._scheduleHide();
+  };
+
+  private _handleSurfaceFocusIn = () => {
+    this._clearHideTimeout();
+    this._showNow();
+  };
+
+  private _handleSurfaceFocusOut = (event: FocusEvent) => {
+    if (!this._isTooltipNode(event.relatedTarget)) this._scheduleHide();
+  };
+
+  private _handleKeydown = (event: KeyboardEvent) => {
+    if (event.key === 'Escape') this._hideNow();
+  };
+
+  private _scheduleShow() {
+    this._clearHideTimeout();
+    if (this._visible || this._showTimeout !== null) return;
     this._showTimeout = setTimeout(() => {
-      this._visible = true;
-    }, motionDuration(this, '--_show-delay'));
+      this._showTimeout = null;
+      this._showNow();
+    }, Math.max(0, Number.isFinite(this.delay) ? this.delay : 0));
   }
 
-  private _handleMouseLeave() {
-    this._clearTimeouts();
+  private _scheduleHide() {
+    this._clearShowTimeout();
+    if (!this._visible || this._hideTimeout !== null) return;
     this._hideTimeout = setTimeout(() => {
-      this._visible = false;
-    }, motionDuration(this, '--_hide-delay'));
+      this._hideTimeout = null;
+      this._hideNow();
+    }, this.variant === 'rich' ? RICH_HIDE_DELAY : 0);
   }
 
-  private _handleFocus() {
-    this._clearTimeouts();
-    this._visible = true;
+  private _showNow() {
+    this._clearShowTimeout();
+    this._clearHideTimeout();
+    if (!this._visible) {
+      this._positioned = false;
+      this._visible = true;
+    }
+    this._queuePosition();
   }
 
-  private _handleBlur() {
+  private _hideNow() {
     this._clearTimeouts();
     this._visible = false;
+    this._positioned = false;
+  }
+
+  private _clearShowTimeout() {
+    if (this._showTimeout !== null) {
+      clearTimeout(this._showTimeout);
+      this._showTimeout = null;
+    }
+  }
+
+  private _clearHideTimeout() {
+    if (this._hideTimeout !== null) {
+      clearTimeout(this._hideTimeout);
+      this._hideTimeout = null;
+    }
   }
 
   private _clearTimeouts() {
-    if (this._showTimeout) { clearTimeout(this._showTimeout); this._showTimeout = null; }
-    if (this._hideTimeout) { clearTimeout(this._hideTimeout); this._hideTimeout = null; }
+    this._clearShowTimeout();
+    this._clearHideTimeout();
   }
 
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    this._clearTimeouts();
+  private _findTrigger(): HTMLElement | null {
+    return Array.from(this.children).find((child): child is HTMLElement =>
+      child instanceof HTMLElement && child !== this._description && !child.hasAttribute('slot'),
+    ) ?? null;
+  }
+
+  private _setTrigger(trigger: HTMLElement | null) {
+    if (trigger === this._trigger) return;
+    if (this._trigger) {
+      this._trigger.removeEventListener('mouseenter', this._handleTriggerMouseEnter);
+      this._trigger.removeEventListener('mouseleave', this._handleTriggerMouseLeave);
+      this._trigger.removeEventListener('focusin', this._handleTriggerFocusIn);
+      this._trigger.removeEventListener('focusout', this._handleTriggerFocusOut);
+      this._trigger.removeEventListener('keydown', this._handleKeydown);
+      this._removeDescriptionFrom(this._trigger);
+    }
+    this._trigger = trigger;
+    if (!trigger) return;
+    this._addDescriptionTo(trigger);
+    trigger.addEventListener('mouseenter', this._handleTriggerMouseEnter);
+    trigger.addEventListener('mouseleave', this._handleTriggerMouseLeave);
+    trigger.addEventListener('focusin', this._handleTriggerFocusIn);
+    trigger.addEventListener('focusout', this._handleTriggerFocusOut);
+    trigger.addEventListener('keydown', this._handleKeydown);
+  }
+
+  private _addDescriptionTo(trigger: HTMLElement) {
+    const ids = trigger.getAttribute('aria-describedby')?.split(/\s+/).filter(Boolean) ?? [];
+    if (!ids.includes(this._tooltipId)) trigger.setAttribute('aria-describedby', [...ids, this._tooltipId].join(' '));
+  }
+
+  private _removeDescriptionFrom(trigger: HTMLElement) {
+    const remaining = (trigger.getAttribute('aria-describedby')?.split(/\s+/).filter(Boolean) ?? []).filter((id) => id !== this._tooltipId);
+    if (remaining.length > 0) trigger.setAttribute('aria-describedby', remaining.join(' '));
+    else trigger.removeAttribute('aria-describedby');
+  }
+
+  private _ensureDescription() {
+    if (this._description?.isConnected) return;
+    const description = document.createElement('span');
+    // IDREFs are resolved in the trigger's tree; the visual surface retains
+    // the same stable ID in its shadow-tree scope.
+    description.id = this._tooltipId;
+    description.slot = 'description';
+    description.hidden = true;
+    this.append(description);
+    this._description = description;
+    this._syncDescription();
+  }
+
+  private _syncDescription() {
+    if (!this._description) return;
+    this._description.textContent = this.variant === 'rich'
+      ? [this._slotText('title'), this._slotText('content')].filter(Boolean).join(' ')
+      : this.text;
+  }
+
+  private _slotText(name: 'title' | 'content') {
+    return Array.from(this.querySelectorAll<HTMLElement>(`[slot="${name}"]`))
+      .map((element) => element.textContent?.trim() ?? '')
+      .filter(Boolean)
+      .join(' ');
+  }
+
+  private _hasRichTitle() {
+    return this._slotText('title').length > 0;
+  }
+
+  private _isTooltipNode(node: EventTarget | null): boolean {
+    if (!(node instanceof Node)) return false;
+    const surface = this.shadowRoot?.querySelector<HTMLElement>('.tooltip-surface');
+    return node === this._trigger || Boolean(
+      this._trigger?.contains(node)
+      || surface?.contains(node)
+      || (node instanceof HTMLElement && node.getAttribute('slot') === 'content' && this.contains(node)),
+    );
+  }
+
+  private _queuePosition = () => {
+    if (!this._visible || this._positionFrame !== null) return;
+    this._positionFrame = requestAnimationFrame(() => {
+      this._positionFrame = null;
+      this._positionSurface();
+    });
+  };
+
+  private _cancelPosition() {
+    if (this._positionFrame !== null) {
+      cancelAnimationFrame(this._positionFrame);
+      this._positionFrame = null;
+    }
+  }
+
+  private _positionSurface() {
+    const surface = this.shadowRoot?.querySelector<HTMLElement>('.tooltip-surface');
+    if (!this._visible || !surface || !this._trigger) return;
+    const trigger = this._trigger.getBoundingClientRect();
+    const surfaceRect = surface.getBoundingClientRect();
+    const candidates = [this.placement, this._oppositePlacement(this.placement), 'top', 'bottom', 'right', 'left'] as M3TooltipPlacement[];
+    const positions = candidates.filter((placement, index) => candidates.indexOf(placement) === index).map((placement) => ({ placement, ...this._placementPosition(placement, trigger, surfaceRect) }));
+    const best = positions.find(({ left, top }) => this._fitsViewport(left, top, surfaceRect))
+      ?? positions.sort((a, b) => this._visibleArea(b.left, b.top, surfaceRect) - this._visibleArea(a.left, a.top, surfaceRect))[0]!;
+    const maxLeft = Math.max(VIEWPORT_PADDING, window.innerWidth - surfaceRect.width - VIEWPORT_PADDING);
+    const maxTop = Math.max(VIEWPORT_PADDING, window.innerHeight - surfaceRect.height - VIEWPORT_PADDING);
+    surface.style.left = `${Math.min(Math.max(best.left, VIEWPORT_PADDING), maxLeft)}px`;
+    surface.style.top = `${Math.min(Math.max(best.top, VIEWPORT_PADDING), maxTop)}px`;
+    this._resolvedPlacement = best.placement;
+    this._positioned = true;
+  }
+
+  private _placementPosition(placement: M3TooltipPlacement, trigger: DOMRect, surface: DOMRect) {
+    switch (placement) {
+      case 'bottom': return { left: trigger.left + trigger.width / 2 - surface.width / 2, top: trigger.bottom + TOOLTIP_GAP };
+      case 'left': return { left: trigger.left - surface.width - TOOLTIP_GAP, top: trigger.top + trigger.height / 2 - surface.height / 2 };
+      case 'right': return { left: trigger.right + TOOLTIP_GAP, top: trigger.top + trigger.height / 2 - surface.height / 2 };
+      case 'top': return { left: trigger.left + trigger.width / 2 - surface.width / 2, top: trigger.top - surface.height - TOOLTIP_GAP };
+    }
+  }
+
+  private _oppositePlacement(placement: M3TooltipPlacement): M3TooltipPlacement {
+    return ({ top: 'bottom', bottom: 'top', left: 'right', right: 'left' })[placement] as M3TooltipPlacement;
+  }
+
+  private _fitsViewport(left: number, top: number, surface: DOMRect) {
+    return left >= VIEWPORT_PADDING && top >= VIEWPORT_PADDING && left + surface.width <= window.innerWidth - VIEWPORT_PADDING && top + surface.height <= window.innerHeight - VIEWPORT_PADDING;
+  }
+
+  private _visibleArea(left: number, top: number, surface: DOMRect) {
+    return Math.max(0, Math.min(left + surface.width, window.innerWidth - VIEWPORT_PADDING) - Math.max(left, VIEWPORT_PADDING)) * Math.max(0, Math.min(top + surface.height, window.innerHeight - VIEWPORT_PADDING) - Math.max(top, VIEWPORT_PADDING));
   }
 }
 

--- a/packages/m3-tooltip/src/m3-tooltip.ts
+++ b/packages/m3-tooltip/src/m3-tooltip.ts
@@ -108,6 +108,9 @@ export class M3Tooltip extends LitElement {
   }
 
   updated(changedProperties: Map<string, unknown>) {
+    // Lit can finish an update after this element has been detached. Do not
+    // recreate owned light-DOM nodes or mutate a trigger until reconnection.
+    if (!this.isConnected) return;
     this._ensureDescription();
     this._syncDescription();
     this._setTrigger(this._findTrigger());
@@ -249,7 +252,20 @@ export class M3Tooltip extends LitElement {
   }
 
   private _ensureDescription() {
-    if (this._description?.isConnected) return;
+    if (!this.isConnected) return;
+    if (this._description?.parentNode === this) return;
+
+    const existing = Array.from(this.children).find((child): child is HTMLSpanElement =>
+      child instanceof HTMLSpanElement
+      && child.id === this._tooltipId
+      && child.slot === 'description',
+    );
+    if (existing) {
+      this._description = existing;
+      this._syncDescription();
+      return;
+    }
+
     const description = document.createElement('span');
     // IDREFs are resolved in the trigger's tree; the visual surface retains
     // the same stable ID in its shadow-tree scope.

--- a/packages/m3-tooltip/tsconfig.test.json
+++ b/packages/m3-tooltip/tsconfig.test.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.test.json",
+  "compilerOptions": { "rootDir": "./src" },
+  "include": ["src/**/*.ts"]
+}

--- a/vitest.browser.config.ts
+++ b/vitest.browser.config.ts
@@ -26,6 +26,7 @@ const browserPorts: Record<string, number> = {
   'm3-split-button': 63_330,
   'm3-dialog': 63_331,
   'm3-radio-button': 63_332,
+  'm3-tooltip': 63_333,
 };
 
 const port = browserPorts[workspaceName];


### PR DESCRIPTION
Fixes #20

## Acceptance mapping
- Hover and keyboard focus: managed trigger listeners, with browser contracts in Chromium, Firefox, and WebKit.
- Accessible description: stable generated tooltip ID is appended to the trigger’s `aria-describedby` while preserving existing IDREFs.
- Escape: hides the visible tooltip without moving trigger focus.
- Rich interaction: rich tooltips use an interactive dialog surface; trigger/surface hover and focus transitions persist while content is used.
- Delay and placement: typed `delay`/`placement` properties match the README, and placement flips at viewport edges.
- Lifecycle cleanup: disconnect clears timers/listeners, removes only the owned IDREF, and reconnects cleanly.

## Validation
- `tsc` production and browser-test configs
- ESLint
- token and motion validation
- `m3-tooltip` browser contracts: 18 passing across Chromium, Firefox, and WebKit
- Angular development build