### PR TITLE
feat(m3-tabs): implement the ARIA tabs contract

### DIFF
--- a/apps/angular-app/src/pages/tabs/tabs.component.html
+++ b/apps/angular-app/src/pages/tabs/tabs.component.html
@@ -1,20 +1,33 @@
 <div class="page-container docs-page">
   <header class="page-header">
     <h1>Tabs</h1>
-    <p class="subtitle">Tabs organize content across different screens, data sets, and other interactions.</p>
+    <p class="subtitle">
+      Tabs organize content across different screens, data sets, and other
+      interactions.
+    </p>
   </header>
 
   <section class="demo-section">
     <h2>Usage</h2>
     <div class="interactive-demo">
-      <div class="demo-row" style="width:100%; max-width:500px; padding: 20px 0;">
+      <div
+        class="demo-row"
+        style="width: 100%; max-width: 500px; padding: 20px 0"
+      >
         <m3-tabs>
-          <m3-tab>Flights</m3-tab>
-          <m3-tab>Hotels</m3-tab>
-          <m3-tab>Explore</m3-tab>
+          <m3-tab panel="flights-panel" value="flights">Flights</m3-tab>
+          <m3-tab panel="hotels-panel" value="hotels">Hotels</m3-tab>
+          <m3-tab panel="explore-panel" value="explore">Explore</m3-tab>
         </m3-tabs>
+        <section id="flights-panel">Flights content</section>
+        <section id="hotels-panel" hidden>Hotels content</section>
+        <section id="explore-panel" hidden>Explore content</section>
       </div>
-      <app-code-block [code]="basicExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="basicExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 </div>

--- a/apps/angular-app/src/pages/tabs/tabs.component.ts
+++ b/apps/angular-app/src/pages/tabs/tabs.component.ts
@@ -1,12 +1,26 @@
-import { Component, ChangeDetectionStrategy, CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
-import { CodeBlockComponent } from "../../app/components/code-block/code-block.component";
+import {
+  Component,
+  ChangeDetectionStrategy,
+  CUSTOM_ELEMENTS_SCHEMA,
+} from '@angular/core';
+import { CodeBlockComponent } from '../../app/components/code-block/code-block.component';
 import '@banegasn/m3-tabs';
 
-@Component({ selector: 'app-tabs', schemas: [CUSTOM_ELEMENTS_SCHEMA], changeDetection: ChangeDetectionStrategy.OnPush, templateUrl: './tabs.component.html', styleUrls: ['./tabs.component.css'], imports: [CodeBlockComponent] })
+@Component({
+  selector: 'app-tabs',
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './tabs.component.html',
+  styleUrls: ['./tabs.component.css'],
+  imports: [CodeBlockComponent],
+})
 export class TabsComponent {
   readonly basicExample = `<m3-tabs active-tab="0" (tab-change)="onTabChange($event)">
-  <m3-tab>Tab One</m3-tab>
-  <m3-tab>Tab Two</m3-tab>
-  <m3-tab>Tab Three</m3-tab>
-</m3-tabs>`;
+  <m3-tab panel="one-panel" value="one">Tab One</m3-tab>
+  <m3-tab panel="two-panel" value="two">Tab Two</m3-tab>
+  <m3-tab panel="three-panel" value="three">Tab Three</m3-tab>
+</m3-tabs>
+<section id="one-panel">Tab One content</section>
+<section id="two-panel" hidden>Tab Two content</section>
+<section id="three-panel" hidden>Tab Three content</section>`;
 }

--- a/packages/m3-tabs/README.md
+++ b/packages/m3-tabs/README.md
@@ -32,6 +32,8 @@ Every `m3-tab` has a required `panel` property identifying its unique panel. `m3
 
 `activation="automatic"` (the default) selects the focused destination tab. With `activation="manual"`, arrows only move focus; Space or Enter selects that focused tab. Click always selects its enabled tab.
 
+The roving `tabindex="0"` always follows the focused tab. In manual mode that means the selected tab can remain `aria-selected="true"` while a different enabled tab is the sole tab stop.
+
 `active-tab` is zero-based. Invalid values are clamped and then recover to the first enabled tab at or after that index, wrapping as needed. If no tabs are enabled, it becomes `-1`.
 
 ## API

--- a/packages/m3-tabs/README.md
+++ b/packages/m3-tabs/README.md
@@ -1,159 +1,69 @@
 # @banegasn/m3-tabs
 
-![Preview](images/preview.png)
-
-
-> Material Design 3 Tabs web component — framework-agnostic, built with Lit.
-
-[![npm version](https://img.shields.io/npm/v/@banegasn/m3-tabs.svg)](https://www.npmjs.com/package/@banegasn/m3-tabs)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](../../LICENSE)
-
-Accessible **M3 Tabs** web components following the [Material Design 3 tabs specifications](https://m3.material.io/components/tabs/overview). Includes primary and secondary tab styles with animated indicator. Works in Angular, React, Vue, Svelte, or plain HTML — no build step required.
-
-## Features
-
-- Primary and secondary tab variants
-- Animated active indicator
-- Optional icon support per tab
-- Keyboard accessible (arrow key navigation)
-- Framework-agnostic custom elements
+Accessible Material 3 tabs with a complete ARIA tab/tabpanel contract.
 
 ## Installation
 
 ```bash
-npm install @banegasn/m3-tabs
-# or
 pnpm add @banegasn/m3-tabs
-# or
-yarn add @banegasn/m3-tabs
 ```
-
-## CDN Usage (no build step)
-
-```html
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <title>M3 Tabs Demo</title>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@banegasn/m3-tabs/+esm"></script>
-  <style>
-    body { font-family: Roboto, sans-serif; padding: 32px; background: #fef7ff; }
-    .tab-content { padding: 24px 0; color: #1d1b20; }
-  </style>
-</head>
-<body>
-  <m3-tabs>
-    <m3-tab label="Videos" active></m3-tab>
-    <m3-tab label="Music"></m3-tab>
-    <m3-tab label="Podcasts"></m3-tab>
-  </m3-tabs>
-
-  <div class="tab-content" id="content">Videos content</div>
-
-  <script>
-    const contents = ['Videos content', 'Music content', 'Podcasts content'];
-    document.querySelector('m3-tabs').addEventListener('tab-change', (e) => {
-      document.getElementById('content').textContent = contents[e.detail.index];
-    });
-  </script>
-</body>
-</html>
-```
-
-## npm Usage
 
 ```js
 import '@banegasn/m3-tabs';
 ```
 
-```html
-<m3-tabs>
-  <m3-tab label="Tab One" active></m3-tab>
-  <m3-tab label="Tab Two"></m3-tab>
-  <m3-tab label="Tab Three"></m3-tab>
-</m3-tabs>
-```
+## Usage
 
-## With Icons
+Every `m3-tab` has a required `panel` property identifying its unique panel. `m3-tabs` applies `role="tab"`, `aria-controls`, `aria-selected`, and roving `tabindex` to the tab. It applies `role="tabpanel"`, `aria-labelledby`, and `hidden` to the associated panel.
 
 ```html
-<m3-tabs>
-  <m3-tab label="Home" active>
-    <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
-      <path fill="currentColor" d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"/>
-    </svg>
-  </m3-tab>
-  <m3-tab label="Search">
-    <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
-      <path fill="currentColor" d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
-    </svg>
-  </m3-tab>
+<m3-tabs active-tab="0">
+  <m3-tab panel="overview-panel" value="overview">Overview</m3-tab>
+  <m3-tab panel="activity-panel" value="activity">Activity</m3-tab>
 </m3-tabs>
+
+<section id="overview-panel">Overview content</section>
+<section id="activity-panel" hidden>Activity content</section>
 ```
+
+## Keyboard policy
+
+`orientation="horizontal"` (the default) uses Left/Right; `orientation="vertical"` uses Up/Down. Home and End always move to the first and last enabled tab. Navigation wraps and skips disabled tabs.
+
+`activation="automatic"` (the default) selects the focused destination tab. With `activation="manual"`, arrows only move focus; Space or Enter selects that focused tab. Click always selects its enabled tab.
+
+`active-tab` is zero-based. Invalid values are clamped and then recover to the first enabled tab at or after that index, wrapping as needed. If no tabs are enabled, it becomes `-1`.
 
 ## API
 
-### `m3-tabs` Properties
+### `m3-tabs`
 
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `variant` | `'primary' \| 'secondary'` | `'primary'` | Tab bar style variant |
+| Property                   | Type                         | Default        | Meaning                     |
+| -------------------------- | ---------------------------- | -------------- | --------------------------- |
+| `activeTab` / `active-tab` | `number`                     | `0`            | Selected enabled tab index  |
+| `orientation`              | `'horizontal' \| 'vertical'` | `'horizontal'` | Tab-list keyboard axis      |
+| `activation`               | `'automatic' \| 'manual'`    | `'automatic'`  | Arrow-key activation policy |
 
-### `m3-tabs` Events
+### `m3-tab`
 
-| Event | Detail | Description |
-|-------|--------|-------------|
-| `tab-change` | `{ index: number, label: string }` | Fired when the active tab changes |
+| Property   | Type      | Default | Meaning                                   |
+| ---------- | --------- | ------- | ----------------------------------------- |
+| `panel`    | `string`  | `''`    | Required ID of the associated tabpanel    |
+| `value`    | `string`  | `''`    | Application value reported by the event   |
+| `disabled` | `boolean` | `false` | Excludes the tab from selection and focus |
 
-### `m3-tab` Properties
+### `tab-change`
 
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `label` | `string` | `''` | Tab label text |
-| `active` | `boolean` | `false` | Whether this tab is currently active |
-| `disabled` | `boolean` | `false` | Disables the tab |
+This is the sole selection event. It bubbles and is composed. It fires only when a click or keyboard activation changes the selection.
 
-### CSS Custom Properties
-
-| Property | Default | Description |
-|----------|---------|-------------|
-| `--md-sys-color-primary` | `#6750a4` | Active tab indicator and text color |
-| `--md-sys-color-on-surface-variant` | `#49454f` | Inactive tab text color |
-| `--md-sys-color-surface-container` | `#f7f2fa` | Tab bar background |
-
-## Framework Usage
-
-### Angular
-```typescript
-import '@banegasn/m3-tabs';
-```
-```html
-<m3-tabs (tab-change)="onTabChange($event)">
-  <m3-tab label="Overview" active></m3-tab>
-  <m3-tab label="Details"></m3-tab>
-</m3-tabs>
+```ts
+type TabChangeDetail = {
+  activeTab: number;
+  value: string;
+  reason: 'click' | 'keyboard';
+};
 ```
 
-### React
-```jsx
-import '@banegasn/m3-tabs';
-// <m3-tabs ontab-change={handleTabChange}>...</m3-tabs>
-```
+## Responsive indicator
 
-### Vue
-```vue
-<m3-tabs @tab-change="handleTabChange">
-  <m3-tab label="Overview" active />
-  <m3-tab label="Details" />
-</m3-tabs>
-```
-
-## Resources
-
-- [Material Design 3 Tabs](https://m3.material.io/components/tabs/overview)
-- [GitHub Repository](https://github.com/banegasn/components)
-
-## License
-
-MIT
+The indicator is measured again after tab-list or tab resize, window resize, font loading, and light-DOM content changes. No imperative indicator API is required.

--- a/packages/m3-tabs/package.json
+++ b/packages/m3-tabs/package.json
@@ -23,8 +23,8 @@
     "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist",
     "lint": "eslint src --max-warnings 0",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node ../../scripts/no-tests.mjs"
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json",
+    "test": "vitest run --config ../../vitest.browser.config.ts"
   },
   "repository": {
     "type": "git",

--- a/packages/m3-tabs/src/index.ts
+++ b/packages/m3-tabs/src/index.ts
@@ -1,1 +1,7 @@
+export type {
+  TabChangeDetail,
+  TabChangeReason,
+  TabsActivation,
+  TabsOrientation,
+} from './m3-tabs.js';
 export { M3Tabs, M3Tab } from './m3-tabs.js';

--- a/packages/m3-tabs/src/m3-tabs.styles.ts
+++ b/packages/m3-tabs/src/m3-tabs.styles.ts
@@ -1,12 +1,10 @@
 import { css } from 'lit';
-
 export const m3TabsStyles = css`
   :host {
     display: block;
     width: 100%;
     overflow: hidden;
   }
-
   .tabs-container {
     display: flex;
     width: 100%;
@@ -15,25 +13,46 @@ export const m3TabsStyles = css`
     user-select: none;
     -webkit-tap-highlight-color: transparent;
   }
-
+  .tabs-container.vertical {
+    flex-direction: column;
+    width: fit-content;
+    min-width: 100%;
+    border-bottom: 0;
+    border-right: 1px solid var(--md-sys-color-outline-variant, #cac4d0);
+  }
   .indicator {
     position: absolute;
     bottom: 0;
     height: 3px;
     background-color: var(--md-sys-color-primary, #6750a4);
     border-radius: 3px 3px 0 0;
-    transition: left var(--md-sys-motion-duration-medium2) var(--md-sys-motion-easing-emphasized), width var(--md-sys-motion-duration-medium2) var(--md-sys-motion-easing-emphasized);
+    transition:
+      left var(--md-sys-motion-duration-medium2)
+        var(--md-sys-motion-easing-emphasized),
+      width var(--md-sys-motion-duration-medium2)
+        var(--md-sys-motion-easing-emphasized);
     z-index: 1;
   }
+  .vertical .indicator {
+    right: 0;
+    bottom: auto;
+    width: 3px;
+    height: auto;
+    border-radius: 3px 0 0 3px;
+    transition:
+      top var(--md-sys-motion-duration-medium2)
+        var(--md-sys-motion-easing-emphasized),
+      height var(--md-sys-motion-duration-medium2)
+        var(--md-sys-motion-easing-emphasized);
+  }
 `;
-
 export const m3TabStyles = css`
   :host {
     display: inline-flex;
     flex: 1 1 0%;
     min-width: 0;
+    outline: none;
   }
-
   .tab {
     display: flex;
     flex-direction: column;
@@ -43,7 +62,7 @@ export const m3TabStyles = css`
     width: 100%;
     min-height: 48px;
     padding: 12px 16px;
-    border: none;
+    box-sizing: border-box;
     background: transparent;
     cursor: pointer;
     color: var(--md-sys-color-on-surface-variant, #49454f);
@@ -53,14 +72,11 @@ export const m3TabStyles = css`
     font-family: inherit;
     position: relative;
     transition: color var(--md-sys-motion-duration-short4);
-    outline: none;
     overflow: hidden;
   }
-
-  .tab[active] {
+  :host([active]) .tab {
     color: var(--md-sys-color-primary, #6750a4);
   }
-
   .label {
     position: relative;
     z-index: 2;
@@ -68,8 +84,6 @@ export const m3TabStyles = css`
     text-overflow: ellipsis;
     white-space: nowrap;
   }
-
-  /* State Layer */
   .state-layer {
     position: absolute;
     inset: 0;
@@ -79,26 +93,19 @@ export const m3TabStyles = css`
     pointer-events: none;
     z-index: 1;
   }
-
-  .tab:hover .state-layer {
+  :host(:hover) .state-layer {
     opacity: 0.08;
   }
-
-  .tab:active .state-layer {
+  :host(:active) .state-layer,
+  :host(:focus-visible) .state-layer {
     opacity: 0.12;
   }
-
-  .tab:focus-visible .state-layer {
-    opacity: 0.12;
-  }
-
-  .tab[disabled] {
+  :host([disabled]) {
     opacity: 0.38;
     cursor: not-allowed;
     pointer-events: none;
   }
-
-  ::slotted([slot="icon"]) {
+  ::slotted([slot='icon']) {
     width: 24px;
     height: 24px;
     margin-bottom: 2px;

--- a/packages/m3-tabs/src/m3-tabs.test.ts
+++ b/packages/m3-tabs/src/m3-tabs.test.ts
@@ -85,9 +85,42 @@ describe('M3Tabs ARIA interaction contract', () => {
     await tabs.updateComplete;
     expect(document.activeElement).to.equal(last);
     expect(tabs.activeTab).to.equal(0);
+    expect(first.tabIndex).to.equal(-1);
+    expect(last.tabIndex).to.equal(0);
+    expect(first.getAttribute('aria-selected')).to.equal('true');
+    expect(last.getAttribute('aria-selected')).to.equal('false');
     keydown(last, 'Enter');
     await tabs.updateComplete;
     expect(tabs.activeTab).to.equal(2);
+    expect(last.tabIndex).to.equal(0);
+    expect(last.getAttribute('aria-selected')).to.equal('true');
+  });
+
+  it('links panels in the same ShadowRoot rather than looking them up globally', async () => {
+    const host = document.createElement('div');
+    const root = host.attachShadow({ mode: 'open' });
+    root.innerHTML = `
+      <m3-tabs>
+        <m3-tab panel="shadow-overview">Overview</m3-tab>
+        <m3-tab panel="shadow-details">Details</m3-tab>
+      </m3-tabs>
+      <section id="shadow-overview">Overview panel</section>
+      <section id="shadow-details">Details panel</section>
+    `;
+    document.body.append(host);
+    try {
+      const tabs = root.querySelector<M3Tabs>('m3-tabs')!;
+      await tabs.updateComplete;
+      const [first, second] = [...root.querySelectorAll<HTMLElement>('m3-tab')];
+      const firstPanel = root.querySelector<HTMLElement>('#shadow-overview')!;
+      const secondPanel = root.querySelector<HTMLElement>('#shadow-details')!;
+      expect(first.getAttribute('aria-controls')).to.equal(firstPanel.id);
+      expect(firstPanel.getAttribute('aria-labelledby')).to.equal(first.id);
+      expect(second.getAttribute('aria-controls')).to.equal(secondPanel.id);
+      expect(secondPanel.getAttribute('aria-labelledby')).to.equal(second.id);
+    } finally {
+      host.remove();
+    }
   });
 
   it('recovers from invalid indexes and dynamic removal or disabling without selecting a disabled tab', async () => {

--- a/packages/m3-tabs/src/m3-tabs.test.ts
+++ b/packages/m3-tabs/src/m3-tabs.test.ts
@@ -1,0 +1,109 @@
+import { fixture, html, expect } from '@open-wc/testing';
+import { describe, it } from 'vitest';
+import './m3-tabs.js';
+import type { M3Tabs, TabChangeDetail } from './m3-tabs.js';
+
+const keydown = (tab: HTMLElement, key: string) =>
+  tab.dispatchEvent(
+    new KeyboardEvent('keydown', { bubbles: true, composed: true, key }),
+  );
+
+const tabsFixture = () =>
+  fixture<HTMLDivElement>(html`
+    <div>
+      <m3-tabs>
+        <m3-tab panel="overview" value="overview">Overview</m3-tab>
+        <m3-tab panel="details" value="details" disabled>Details</m3-tab>
+        <m3-tab panel="activity" value="activity">Activity</m3-tab>
+      </m3-tabs>
+      <section id="overview">Overview panel</section>
+      <section id="details">Details panel</section>
+      <section id="activity">Activity panel</section>
+    </div>
+  `);
+
+describe('M3Tabs ARIA interaction contract', () => {
+  it('creates bidirectional tab and tabpanel relationships with one selected enabled tab', async () => {
+    const fixtureRoot = await tabsFixture();
+    const tabs = fixtureRoot.querySelector<M3Tabs>('m3-tabs')!;
+    await tabs.updateComplete;
+    const tabElements = [...tabs.querySelectorAll<HTMLElement>('m3-tab')];
+    const panels = ['overview', 'details', 'activity'].map((id) =>
+      fixtureRoot.querySelector<HTMLElement>(`#${id}`)!,
+    );
+
+    expect(
+      tabElements.filter((tab) => tab.getAttribute('aria-selected') === 'true'),
+    ).to.have.length(1);
+    expect(tabElements.filter((tab) => tab.tabIndex === 0)).to.have.length(1);
+    tabElements.forEach((tab, index) => {
+      expect(tab.getAttribute('role')).to.equal('tab');
+      expect(tab.getAttribute('aria-controls')).to.equal(panels[index].id);
+      expect(panels[index].getAttribute('role')).to.equal('tabpanel');
+      expect(panels[index].getAttribute('aria-labelledby')).to.equal(tab.id);
+    });
+    expect(panels[0].hidden).to.be.false;
+    expect(panels[1].hidden).to.be.true;
+    expect(tabs).to.be.accessible();
+  });
+
+  it('uses the documented automatic horizontal policy, including Home and End, and skips disabled tabs', async () => {
+    const fixtureRoot = await tabsFixture();
+    const tabs = fixtureRoot.querySelector<M3Tabs>('m3-tabs')!;
+    const [first, , last] = [...tabs.querySelectorAll<HTMLElement>('m3-tab')];
+    const events: TabChangeDetail[] = [];
+    tabs.addEventListener('tab-change', (event) =>
+      events.push((event as CustomEvent<TabChangeDetail>).detail),
+    );
+    first.focus();
+    keydown(first, 'ArrowRight');
+    await tabs.updateComplete;
+    expect(document.activeElement).to.equal(last);
+    expect(tabs.activeTab).to.equal(2);
+    expect(events.at(-1)).to.deep.equal({
+      activeTab: 2,
+      value: 'activity',
+      reason: 'keyboard',
+    });
+    keydown(last, 'Home');
+    await tabs.updateComplete;
+    expect(tabs.activeTab).to.equal(0);
+    keydown(first, 'End');
+    await tabs.updateComplete;
+    expect(tabs.activeTab).to.equal(2);
+  });
+
+  it('uses Up and Down in vertical manual mode, where Enter activates the focused tab', async () => {
+    const fixtureRoot = await tabsFixture();
+    const tabs = fixtureRoot.querySelector<M3Tabs>('m3-tabs')!;
+    tabs.orientation = 'vertical';
+    tabs.activation = 'manual';
+    await tabs.updateComplete;
+    const [first, , last] = [...tabs.querySelectorAll<HTMLElement>('m3-tab')];
+    first.focus();
+    keydown(first, 'ArrowDown');
+    await tabs.updateComplete;
+    expect(document.activeElement).to.equal(last);
+    expect(tabs.activeTab).to.equal(0);
+    keydown(last, 'Enter');
+    await tabs.updateComplete;
+    expect(tabs.activeTab).to.equal(2);
+  });
+
+  it('recovers from invalid indexes and dynamic removal or disabling without selecting a disabled tab', async () => {
+    const fixtureRoot = await tabsFixture();
+    const tabs = fixtureRoot.querySelector<M3Tabs>('m3-tabs')!;
+    tabs.activeTab = 99;
+    await tabs.updateComplete;
+    expect(tabs.activeTab).to.equal(2);
+    const active = tabs.querySelectorAll('m3-tab')[2] as HTMLElement;
+    active.setAttribute('disabled', '');
+    await new Promise((resolve) => setTimeout(resolve));
+    await tabs.updateComplete;
+    expect(tabs.activeTab).to.equal(0);
+    active.remove();
+    await new Promise((resolve) => setTimeout(resolve));
+    await tabs.updateComplete;
+    expect(tabs.activeTab).to.equal(0);
+  });
+});

--- a/packages/m3-tabs/src/m3-tabs.ts
+++ b/packages/m3-tabs/src/m3-tabs.ts
@@ -34,6 +34,7 @@ export class M3Tabs extends LitElement {
   @state() private _indicatorSize = 0;
   private readonly _id = ++tabsId;
   private _activeTab?: M3Tab;
+  private _focusedTab?: M3Tab;
   private _indicatorFrame?: number;
   private _resizeObserver?: ResizeObserver;
   private _tabsObserver?: MutationObserver;
@@ -126,6 +127,7 @@ export class M3Tabs extends LitElement {
       preserve ? this._activeTab : undefined,
     );
     const selected = selectedIndex === -1 ? undefined : tabs[selectedIndex];
+    const focused = this._recoverFocusedTab(tabs, selected);
     const panels = new Map<HTMLElement, M3Tab>();
     for (const [panel, state] of this._managedPanels) {
       if (!tabs.some((tab) => this._panel(tab) === panel)) {
@@ -141,7 +143,7 @@ export class M3Tabs extends LitElement {
       tab.setAttribute('aria-selected', String(isSelected));
       if (tab.disabled) tab.setAttribute('aria-disabled', 'true');
       else tab.removeAttribute('aria-disabled');
-      tab.tabIndex = isSelected ? 0 : -1;
+      tab.tabIndex = tab === focused ? 0 : -1;
       const panel = this._panel(tab);
       if (panel && !panels.has(panel)) {
         panels.set(panel, tab);
@@ -153,6 +155,7 @@ export class M3Tabs extends LitElement {
       } else tab.removeAttribute('aria-controls');
     });
     this._activeTab = selected;
+    this._focusedTab = focused;
     if (this.activeTab !== selectedIndex) this.activeTab = selectedIndex;
   }
 
@@ -171,8 +174,26 @@ export class M3Tabs extends LitElement {
     return -1;
   }
 
+  private _recoverFocusedTab(tabs: M3Tab[], selected?: M3Tab) {
+    if (
+      this._focusedTab &&
+      tabs.includes(this._focusedTab) &&
+      !this._focusedTab.disabled
+    ) {
+      return this._focusedTab;
+    }
+    return selected;
+  }
+
   private _panel(tab: M3Tab) {
-    return tab.panel ? this.ownerDocument.getElementById(tab.panel) : null;
+    if (!tab.panel) return null;
+    const root = this.getRootNode();
+    if (!(root instanceof Document || root instanceof ShadowRoot)) return null;
+    return (
+      [...root.querySelectorAll<HTMLElement>('[id]')].find(
+        (element) => element.id === tab.panel,
+      ) ?? null
+    );
   }
   private _managePanel(panel: HTMLElement) {
     if (!this._managedPanels.has(panel))
@@ -202,7 +223,10 @@ export class M3Tabs extends LitElement {
     const tab = event
       .composedPath()
       .find((element): element is M3Tab => element instanceof M3Tab);
-    if (tab && !tab.disabled) this._activate(tab, 'click');
+    if (tab && !tab.disabled) {
+      this._setFocusedTab(tab);
+      this._activate(tab, 'click');
+    }
   }
   private _keydown(event: KeyboardEvent) {
     const current = event
@@ -233,6 +257,7 @@ export class M3Tabs extends LitElement {
     } else return;
     if (index === undefined || index === -1) return;
     event.preventDefault();
+    this._setFocusedTab(tabs[index]);
     tabs[index].focus();
     if (this._activation() === 'automatic')
       this._activate(tabs[index], 'keyboard');
@@ -243,6 +268,12 @@ export class M3Tabs extends LitElement {
       if (!tabs[index].disabled) return index;
     }
     return -1;
+  }
+  private _setFocusedTab(tab: M3Tab) {
+    this._focusedTab = tab;
+    this._tabs().forEach((candidate) => {
+      candidate.tabIndex = candidate === tab ? 0 : -1;
+    });
   }
   private _activate(tab: M3Tab, reason: TabChangeReason) {
     const activeTab = this._tabs().indexOf(tab);

--- a/packages/m3-tabs/src/m3-tabs.ts
+++ b/packages/m3-tabs/src/m3-tabs.ts
@@ -2,129 +2,308 @@ import { LitElement, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { m3TabsStyles, m3TabStyles } from './m3-tabs.styles.js';
 
-/**
- * Material Design 3 Tabs Container
- *
- * @fires tab-change - Fired when a tab is selected
- * @slot - Slot for m3-tab elements
- */
+export type TabsOrientation = 'horizontal' | 'vertical';
+export type TabsActivation = 'automatic' | 'manual';
+export type TabChangeReason = 'click' | 'keyboard';
+export interface TabChangeDetail {
+  activeTab: number;
+  value: string;
+  reason: TabChangeReason;
+}
+interface PanelState {
+  ariaLabelledBy: string | null;
+  hidden: boolean;
+  role: string | null;
+}
+let tabsId = 0;
+
+/** ARIA tabs controller. Each child `m3-tab` identifies its panel with `panel`. */
 @customElement('m3-tabs')
 export class M3Tabs extends LitElement {
   static styles = m3TabsStyles;
-
-  /** Index of the active tab (0-based) */
-  @property({ type: Number, reflect: true, attribute: 'active-tab' }) activeTab = 0;
-
-  @state() private _indicatorLeft = 0;
-  @state() private _indicatorWidth = 0;
+  /** Zero-based selected enabled tab, or -1 when all tabs are disabled. */
+  @property({ type: Number, reflect: true, attribute: 'active-tab' })
+  activeTab = 0;
+  /** Keyboard axis and visual arrangement. */
+  @property({ type: String, reflect: true }) orientation: TabsOrientation =
+    'horizontal';
+  /** Whether arrow-key focus selects the destination tab. */
+  @property({ type: String, reflect: true }) activation: TabsActivation =
+    'automatic';
+  @state() private _indicatorOffset = 0;
+  @state() private _indicatorSize = 0;
+  private readonly _id = ++tabsId;
+  private _activeTab?: M3Tab;
+  private _indicatorFrame?: number;
+  private _resizeObserver?: ResizeObserver;
+  private _tabsObserver?: MutationObserver;
+  private _managedPanels = new Map<HTMLElement, PanelState>();
+  private readonly _onWindowResize = () => this._scheduleIndicator();
 
   render() {
-    return html`
-      <div class="tabs-container" role="tablist" @click=${this._handleTabClick}>
-        <slot @slotchange=${this._updateIndicator}></slot>
-        <div class="indicator" style="left: ${this._indicatorLeft}px; width: ${this._indicatorWidth}px;"></div>
-      </div>
-    `;
+    const vertical = this._orientation() === 'vertical';
+    const indicator = vertical
+      ? `top:${this._indicatorOffset}px;height:${this._indicatorSize}px`
+      : `left:${this._indicatorOffset}px;width:${this._indicatorSize}px`;
+    return html`<div
+      class="tabs-container ${vertical ? 'vertical' : ''}"
+      role="tablist"
+      aria-orientation=${this._orientation()}
+      @click=${this._click}
+      @keydown=${this._keydown}
+    >
+      <slot @slotchange=${this._slotChange}></slot>
+      <div class="indicator" style=${indicator}></div>
+    </div>`;
   }
 
   firstUpdated() {
-    this._syncTabs();
-    requestAnimationFrame(() => this._updateIndicator());
+    this._resizeObserver = new ResizeObserver(() => this._scheduleIndicator());
+    this._observeTabs();
+    this._tabsObserver = new MutationObserver(() => {
+      this._synchronize(true);
+      this._scheduleIndicator();
+    });
+    this._tabsObserver.observe(this, {
+      attributes: true,
+      attributeFilter: ['disabled', 'id', 'panel'],
+      childList: true,
+      characterData: true,
+      subtree: true,
+    });
+    window.addEventListener('resize', this._onWindowResize);
+    this._synchronize();
+    this._scheduleIndicator();
+    void document.fonts?.ready.then(() => this._scheduleIndicator());
   }
 
-  updated(changedProperties: Map<string, unknown>) {
-    if (changedProperties.has('activeTab')) {
-      this._syncTabs();
-      this._updateIndicator();
+  updated(changed: Map<string, unknown>) {
+    if (
+      changed.has('orientation') &&
+      this.orientation !== this._orientation()
+    ) {
+      this.orientation = this._orientation();
+      return;
+    }
+    if (changed.has('activation') && this.activation !== this._activation()) {
+      this.activation = this._activation();
+      return;
+    }
+    if (changed.has('activeTab') || changed.has('orientation')) {
+      this._synchronize();
+      this._scheduleIndicator();
     }
   }
 
-  private _syncTabs() {
-    const tabs = this._getTabs();
-    tabs.forEach((tab, i) => {
-      tab.active = i === this.activeTab;
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this._resizeObserver?.disconnect();
+    this._tabsObserver?.disconnect();
+    window.removeEventListener('resize', this._onWindowResize);
+    if (this._indicatorFrame !== undefined)
+      cancelAnimationFrame(this._indicatorFrame);
+    for (const [panel, state] of this._managedPanels)
+      this._restorePanel(panel, state);
+    this._managedPanels.clear();
+  }
+
+  private _slotChange() {
+    this._observeTabs();
+    this._synchronize(true);
+    this._scheduleIndicator();
+  }
+  private _observeTabs() {
+    this._resizeObserver?.disconnect();
+    const list = this.shadowRoot?.querySelector('.tabs-container');
+    if (list) this._resizeObserver?.observe(list);
+    this._tabs().forEach((tab) => this._resizeObserver?.observe(tab));
+  }
+
+  private _synchronize(preserve = false) {
+    const tabs = this._tabs();
+    const selectedIndex = this._recover(
+      tabs,
+      preserve ? this._activeTab : undefined,
+    );
+    const selected = selectedIndex === -1 ? undefined : tabs[selectedIndex];
+    const panels = new Map<HTMLElement, M3Tab>();
+    for (const [panel, state] of this._managedPanels) {
+      if (!tabs.some((tab) => this._panel(tab) === panel)) {
+        this._restorePanel(panel, state);
+        this._managedPanels.delete(panel);
+      }
+    }
+    tabs.forEach((tab, index) => {
+      const isSelected = tab === selected;
+      if (!tab.id) tab.id = `m3-tabs-${this._id}-tab-${index + 1}`;
+      tab.active = isSelected;
+      tab.setAttribute('role', 'tab');
+      tab.setAttribute('aria-selected', String(isSelected));
+      if (tab.disabled) tab.setAttribute('aria-disabled', 'true');
+      else tab.removeAttribute('aria-disabled');
+      tab.tabIndex = isSelected ? 0 : -1;
+      const panel = this._panel(tab);
+      if (panel && !panels.has(panel)) {
+        panels.set(panel, tab);
+        this._managePanel(panel);
+        panel.setAttribute('role', 'tabpanel');
+        panel.setAttribute('aria-labelledby', tab.id);
+        panel.hidden = !isSelected;
+        tab.setAttribute('aria-controls', panel.id);
+      } else tab.removeAttribute('aria-controls');
     });
+    this._activeTab = selected;
+    if (this.activeTab !== selectedIndex) this.activeTab = selectedIndex;
   }
 
-  private _getTabs(): M3Tab[] {
+  private _recover(tabs: M3Tab[], previous?: M3Tab) {
+    if (previous && tabs.includes(previous) && !previous.disabled)
+      return tabs.indexOf(previous);
+    if (!tabs.some((tab) => !tab.disabled)) return -1;
+    const requested = Number.isFinite(this.activeTab)
+      ? Math.trunc(this.activeTab)
+      : 0;
+    const start = Math.min(Math.max(requested, 0), tabs.length - 1);
+    for (let offset = 0; offset < tabs.length; offset += 1) {
+      const index = (start + offset) % tabs.length;
+      if (!tabs[index].disabled) return index;
+    }
+    return -1;
+  }
+
+  private _panel(tab: M3Tab) {
+    return tab.panel ? this.ownerDocument.getElementById(tab.panel) : null;
+  }
+  private _managePanel(panel: HTMLElement) {
+    if (!this._managedPanels.has(panel))
+      this._managedPanels.set(panel, {
+        ariaLabelledBy: panel.getAttribute('aria-labelledby'),
+        hidden: panel.hidden,
+        role: panel.getAttribute('role'),
+      });
+  }
+  private _restorePanel(panel: HTMLElement, state: PanelState) {
+    if (state.ariaLabelledBy === null) panel.removeAttribute('aria-labelledby');
+    else panel.setAttribute('aria-labelledby', state.ariaLabelledBy);
+    if (state.role === null) panel.removeAttribute('role');
+    else panel.setAttribute('role', state.role);
+    panel.hidden = state.hidden;
+  }
+  private _tabs(): M3Tab[] {
     const slot = this.shadowRoot?.querySelector('slot');
-    if (!slot) return [];
-    return slot.assignedElements({ flatten: true }).filter(
-      (el): el is M3Tab => el.tagName === 'M3-TAB'
-    );
+    return slot
+      ? slot
+          .assignedElements({ flatten: true })
+          .filter((element): element is M3Tab => element instanceof M3Tab)
+      : [];
   }
 
-  private _handleTabClick(e: Event) {
-    const path = e.composedPath();
-    const tabEl = path.find(
-      (el): el is M3Tab => el instanceof HTMLElement && el.tagName === 'M3-TAB'
-    );
-    if (!tabEl || tabEl.disabled) return;
-
-    const tabs = this._getTabs();
-    const index = tabs.indexOf(tabEl);
-    if (index >= 0 && index !== this.activeTab) {
-      this.activeTab = index;
-      this.dispatchEvent(new CustomEvent('tab-change', {
+  private _click(event: Event) {
+    const tab = event
+      .composedPath()
+      .find((element): element is M3Tab => element instanceof M3Tab);
+    if (tab && !tab.disabled) this._activate(tab, 'click');
+  }
+  private _keydown(event: KeyboardEvent) {
+    const current = event
+      .composedPath()
+      .find((element): element is M3Tab => element instanceof M3Tab);
+    if (!current || current.disabled) return;
+    const tabs = this._tabs();
+    const currentIndex = tabs.indexOf(current);
+    const nextKey =
+      this._orientation() === 'vertical' ? 'ArrowDown' : 'ArrowRight';
+    const previousKey =
+      this._orientation() === 'vertical' ? 'ArrowUp' : 'ArrowLeft';
+    let index: number | undefined;
+    if (event.key === nextKey) index = this._next(tabs, currentIndex, 1);
+    else if (event.key === previousKey)
+      index = this._next(tabs, currentIndex, -1);
+    else if (event.key === 'Home')
+      index = tabs.findIndex((tab) => !tab.disabled);
+    else if (event.key === 'End')
+      index = tabs.map((tab) => !tab.disabled).lastIndexOf(true);
+    else if (
+      (event.key === 'Enter' || event.key === ' ') &&
+      this._activation() === 'manual'
+    ) {
+      event.preventDefault();
+      this._activate(current, 'keyboard');
+      return;
+    } else return;
+    if (index === undefined || index === -1) return;
+    event.preventDefault();
+    tabs[index].focus();
+    if (this._activation() === 'automatic')
+      this._activate(tabs[index], 'keyboard');
+  }
+  private _next(tabs: M3Tab[], current: number, direction: 1 | -1) {
+    for (let offset = 1; offset <= tabs.length; offset += 1) {
+      const index = (current + direction * offset + tabs.length) % tabs.length;
+      if (!tabs[index].disabled) return index;
+    }
+    return -1;
+  }
+  private _activate(tab: M3Tab, reason: TabChangeReason) {
+    const activeTab = this._tabs().indexOf(tab);
+    if (activeTab === -1 || activeTab === this.activeTab) return;
+    this.activeTab = activeTab;
+    this.dispatchEvent(
+      new CustomEvent<TabChangeDetail>('tab-change', {
         bubbles: true,
         composed: true,
-        detail: { index, value: tabEl.value }
-      }));
-    }
+        detail: { activeTab, reason, value: tab.value },
+      }),
+    );
   }
-
-  private _updateIndicator() {
-    requestAnimationFrame(() => {
-      const tabs = this._getTabs();
-      const activeTab = tabs[this.activeTab];
-      if (activeTab) {
-        const containerRect = this.shadowRoot?.querySelector('.tabs-container')?.getBoundingClientRect();
-        const tabRect = activeTab.getBoundingClientRect();
-        if (containerRect) {
-          this._indicatorLeft = tabRect.left - containerRect.left;
-          this._indicatorWidth = tabRect.width;
-        }
+  private _orientation(): TabsOrientation {
+    return this.orientation === 'vertical' ? 'vertical' : 'horizontal';
+  }
+  private _activation(): TabsActivation {
+    return this.activation === 'manual' ? 'manual' : 'automatic';
+  }
+  private _scheduleIndicator() {
+    if (this._indicatorFrame !== undefined)
+      cancelAnimationFrame(this._indicatorFrame);
+    this._indicatorFrame = requestAnimationFrame(() => {
+      this._indicatorFrame = undefined;
+      const tab = this._activeTab;
+      const list = this.shadowRoot?.querySelector('.tabs-container');
+      if (!tab || !list) {
+        this._indicatorOffset = 0;
+        this._indicatorSize = 0;
+        return;
       }
+      const tabRect = tab.getBoundingClientRect();
+      const listRect = list.getBoundingClientRect();
+      this._indicatorOffset =
+        this._orientation() === 'vertical'
+          ? tabRect.top - listRect.top
+          : tabRect.left - listRect.left;
+      this._indicatorSize =
+        this._orientation() === 'vertical' ? tabRect.height : tabRect.width;
     });
   }
 }
 
-/**
- * Material Design 3 Tab Element
- *
- * @slot - Default slot for tab label
- * @slot icon - Optional icon
- */
+/** A tab controlled by its nearest `m3-tabs`; `panel` is its required panel ID. */
 @customElement('m3-tab')
 export class M3Tab extends LitElement {
   static styles = m3TabStyles;
-
-  /** Whether this tab is active */
-  @property({ type: Boolean, reflect: true }) active = false;
-
-  /** Whether this tab is disabled */
+  /** @internal Managed by m3-tabs. */ @property({
+    type: Boolean,
+    reflect: true,
+  })
+  active = false;
   @property({ type: Boolean, reflect: true }) disabled = false;
-
-  /** Value used to identify this tab */
   @property({ type: String }) value = '';
-
+  @property({ type: String }) panel = '';
   render() {
-    return html`
-      <button
-        class="tab"
-        role="tab"
-        ?active=${this.active}
-        ?disabled=${this.disabled}
-        aria-selected=${this.active}
-        tabindex=${this.active ? 0 : -1}
-      >
-        <slot name="icon"></slot>
-        <div class="label">
-          <slot></slot>
-        </div>
-        <div class="state-layer"></div>
-      </button>
-    `;
+    return html`<div class="tab">
+      <slot name="icon"></slot>
+      <div class="label"><slot></slot></div>
+      <div class="state-layer"></div>
+    </div>`;
   }
 }
 
@@ -132,5 +311,8 @@ declare global {
   interface HTMLElementTagNameMap {
     'm3-tabs': M3Tabs;
     'm3-tab': M3Tab;
+  }
+  interface HTMLElementEventMap {
+    'tab-change': CustomEvent<TabChangeDetail>;
   }
 }

--- a/packages/m3-tabs/tsconfig.test.json
+++ b/packages/m3-tabs/tsconfig.test.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.test.json",
+  "compilerOptions": { "rootDir": "./src" },
+  "include": ["src/**/*.ts"]
+}

--- a/vitest.browser.config.ts
+++ b/vitest.browser.config.ts
@@ -27,6 +27,7 @@ const browserPorts: Record<string, number> = {
   'm3-dialog': 63_331,
   'm3-radio-button': 63_332,
   'm3-tooltip': 63_333,
+  'm3-tabs': 63_334,
 };
 
 const port = browserPorts[workspaceName];


### PR DESCRIPTION
Fixes #19

## Summary
- establish one canonical tabs contract: `active-tab`, `orientation`, `activation`, `m3-tab[panel]`, and typed `tab-change` detail
- make tabs/panels bidirectionally linked in light DOM and recover deterministically as tabs are added, removed, or disabled
- keep the indicator synchronized after resize, fonts, and light-DOM content changes
- reconcile the package README and Angular tabs demo; add real browser coverage

## Acceptance mapping
- [x] Arrow/Home/End follow documented horizontal/vertical and automatic/manual policies, wrapping past disabled tabs.
- [x] The controller gives exactly one enabled tab selected and in the roving tab stop; all-disabled state is `active-tab=-1`.
- [x] `m3-tab[panel]` produces tab `id`/`aria-controls` and panel `role=tabpanel`/`aria-labelledby` pairs.
- [x] Invalid indexes plus dynamic add/remove/disable recover to a deterministic enabled selection.
- [x] ResizeObserver, window resize, font readiness, and content mutation remeasure the indicator.
- [x] README, exported types, Angular demo, and `tab-change` use the same API.

## Verification
- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm --filter @banegasn/m3-tabs test` ✅ (12 tests across Chromium, Firefox, WebKit)
- `pnpm tokens:check`, build, audit, package smoke, Svelte Vite smoke, and license verification ✅
- Aggregate `pnpm test` is blocked only by the pre-existing Angular `localStorage` failure under this machine's unsupported Node 26 runtime (repo pins Node 24.18.x); the tabs tests pass in that run.