### PR TITLE
fix(a11y): omit unset semantic attributes

### DIFF
--- a/packages/m3-badge/package.json
+++ b/packages/m3-badge/package.json
@@ -23,8 +23,8 @@
     "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist",
     "lint": "eslint src --max-warnings 0",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node ../../scripts/no-tests.mjs"
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json",
+    "test": "vitest run --config ../../vitest.browser.config.ts"
   },
   "repository": {
     "type": "git",

--- a/packages/m3-badge/src/m3-badge.test.ts
+++ b/packages/m3-badge/src/m3-badge.test.ts
@@ -1,0 +1,36 @@
+import { expect, fixture, html } from '@open-wc/testing';
+import { describe, it } from 'vitest';
+import './m3-badge.js';
+import type { M3Badge } from './m3-badge.js';
+
+describe('M3Badge semantics', () => {
+  it('keeps dot badges out of the accessibility tree', async () => {
+    const element = await fixture<M3Badge>(html`<m3-badge></m3-badge>`);
+    const badge = element.shadowRoot!.querySelector<HTMLElement>('.badge')!;
+
+    expect(badge.getAttribute('aria-hidden')).to.equal('true');
+    expect(badge.hasAttribute('role')).to.be.false;
+    expect(badge.hasAttribute('aria-label')).to.be.false;
+  });
+
+  it('exposes a named badge as a concise status', async () => {
+    const element = await fixture<M3Badge>(
+      html`<m3-badge label="3"></m3-badge>`,
+    );
+    const badge = element.shadowRoot!.querySelector<HTMLElement>('.badge')!;
+
+    expect(badge.getAttribute('role')).to.equal('status');
+    expect(badge.getAttribute('aria-label')).to.equal('3 notifications');
+    expect(badge.hasAttribute('aria-hidden')).to.be.false;
+  });
+
+  it('removes hidden badges from the accessibility tree even when named', async () => {
+    const element = await fixture<M3Badge>(
+      html`<m3-badge label="3" hidden></m3-badge>`,
+    );
+    const badge = element.shadowRoot!.querySelector<HTMLElement>('.badge')!;
+
+    expect(badge.getAttribute('aria-hidden')).to.equal('true');
+    expect(badge.hasAttribute('role')).to.be.false;
+  });
+});

--- a/packages/m3-badge/src/m3-badge.ts
+++ b/packages/m3-badge/src/m3-badge.ts
@@ -1,4 +1,4 @@
-import { LitElement, html } from 'lit';
+import { LitElement, html, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { m3BadgeStyles } from './m3-badge.styles.js';
 
@@ -21,14 +21,17 @@ export class M3Badge extends LitElement {
   @property({ type: Boolean, reflect: true }) hidden = false;
 
   render() {
+    const isNamed = Boolean(this.label) && !this.hidden;
+
     return html`
       <slot></slot>
       <div
         class="badge"
         ?has-label=${!!this.label}
         ?hidden-badge=${this.hidden}
-        role="status"
-        aria-label=${this.label ? `${this.label} notifications` : 'notification'}
+        role=${isNamed ? 'status' : nothing}
+        aria-hidden=${isNamed ? nothing : 'true'}
+        aria-label=${isNamed ? `${this.label} notifications` : nothing}
       >
         ${this.label || ''}
       </div>

--- a/packages/m3-badge/tsconfig.test.json
+++ b/packages/m3-badge/tsconfig.test.json
@@ -1,7 +1,4 @@
 {
   "extends": "../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../.."
-  },
   "include": ["src/**/*.test.ts", "src/**/*.d.ts"]
 }

--- a/packages/m3-button/src/m3-button.test.ts
+++ b/packages/m3-button/src/m3-button.test.ts
@@ -1,5 +1,6 @@
 import { html, fixture, expect } from '@open-wc/testing';
 import { describe, it } from 'vitest';
+import { expectVisibleNameWithoutOptionalAttributes } from '../../../test/semantic-attributes.js';
 import './m3-button.js';
 import type { M3Button } from './m3-button.js';
 
@@ -52,5 +53,17 @@ describe('M3Button icon slot', () => {
     expect(el.shadowRoot!.querySelector('.icon')!.hasAttribute('hidden')).to.be
       .true;
     el.remove();
+  });
+});
+
+describe('M3Button semantic attributes', () => {
+  it('keeps its visible label as the browser-accessible name when aria-label is unset', async () => {
+    const element = await fixture<M3Button>(
+      html`<m3-button>Save changes</m3-button>`,
+    );
+    const button =
+      element.shadowRoot!.querySelector<HTMLButtonElement>('button')!;
+
+    await expectVisibleNameWithoutOptionalAttributes(button, ['aria-label']);
   });
 });

--- a/packages/m3-button/src/m3-button.ts
+++ b/packages/m3-button/src/m3-button.ts
@@ -1,20 +1,20 @@
-import { html } from 'lit';
+import { html, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { FormAssociatedElement } from '@banegasn/m3-form-associated';
 import { m3ButtonStyles } from './m3-button.styles.js';
 
 /**
  * Material Design 3 Button Component
- * 
+ *
  * A flexible button component following Material Design 3 specifications with
  * support for multiple variants, icons, and accessibility features.
- * 
+ *
  * Native click semantics are exposed on the host. Submit and reset types act
  * on the owner form selected by the host's native `form` attribute.
- * 
+ *
  * @slot - Default slot for button label text
  * @slot icon - Optional icon to display before the label
- * 
+ *
  * @cssprop --md-comp-button-container-height - Height of the button (default: varies by size)
  * @cssprop --md-comp-button-container-shape - Border radius (default: varies by shape)
  * @cssprop --md-comp-button-label-text-size - Font size of label (default: varies by size)
@@ -127,8 +127,8 @@ export class M3Button extends FormAssociatedElement {
       <button
         type="button"
         ?disabled=${this.isFormDisabled || this.loading}
-        aria-label=${this.ariaLabel || ''}
-        aria-busy=${this.loading}
+        aria-label=${this.ariaLabel || nothing}
+        aria-busy=${this.loading ? 'true' : nothing}
         @click=${this._handleClick}
       >
         ${this.loading ? html`<span class="loading-spinner"></span>` : ''}
@@ -183,7 +183,9 @@ export class M3Button extends FormAssociatedElement {
     // Native buttons have no mutable form value to reset.
   }
 
-  protected restoreFormControlState(_state: string | File | FormData | null): void {
+  protected restoreFormControlState(
+    _state: string | File | FormData | null,
+  ): void {
     // Native buttons have no restorable form state.
   }
 

--- a/packages/m3-card/src/m3-card.test.ts
+++ b/packages/m3-card/src/m3-card.test.ts
@@ -1,5 +1,6 @@
 import { fixture, html, expect } from '@open-wc/testing';
 import { describe, it } from 'vitest';
+import { expectVisibleNameWithoutOptionalAttributes } from '../../../test/semantic-attributes.js';
 import './m3-card.js';
 import type { M3Card } from './m3-card.js';
 
@@ -8,13 +9,42 @@ describe('M3Card tokens', () => {
     const card = await fixture<M3Card>(html`<m3-card></m3-card>`);
     const surface = card.shadowRoot!.querySelector('.card')!;
 
-    expect(getComputedStyle(surface).backgroundColor).to.equal('rgb(247, 242, 250)');
+    expect(getComputedStyle(surface).backgroundColor).to.equal(
+      'rgb(247, 242, 250)',
+    );
   });
 
   it('accepts the canonical component token', async () => {
     const card = await fixture<M3Card>(html`
       <m3-card style="--md-comp-card-container-color: rgb(1, 2, 3)"></m3-card>
     `);
-    expect(getComputedStyle(card.shadowRoot!.querySelector('.card')!).backgroundColor).to.equal('rgb(1, 2, 3)');
+    expect(
+      getComputedStyle(card.shadowRoot!.querySelector('.card')!)
+        .backgroundColor,
+    ).to.equal('rgb(1, 2, 3)');
+  });
+});
+
+describe('M3Card semantic attributes', () => {
+  it("keeps a clickable card's slotted text as its browser-accessible name", async () => {
+    const card = await fixture<M3Card>(
+      html`<m3-card clickable>Project overview</m3-card>`,
+    );
+    const surface = card.shadowRoot!.querySelector<HTMLElement>('.card')!;
+
+    await expectVisibleNameWithoutOptionalAttributes(surface, ['aria-label']);
+  });
+
+  it('omits optional role and tabindex from a static card', async () => {
+    const card = await fixture<M3Card>(
+      html`<m3-card>Project overview</m3-card>`,
+    );
+    const surface = card.shadowRoot!.querySelector<HTMLElement>('.card')!;
+
+    await expectVisibleNameWithoutOptionalAttributes(surface, [
+      'role',
+      'tabindex',
+      'aria-label',
+    ]);
   });
 });

--- a/packages/m3-card/src/m3-card.ts
+++ b/packages/m3-card/src/m3-card.ts
@@ -1,23 +1,23 @@
-import { LitElement, html } from 'lit';
+import { LitElement, html, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { m3CardStyles } from './m3-card.styles.js';
 
 /**
  * Material Design 3 Card Component
- * 
+ *
  * A flexible card component following Material Design 3 specifications.
  * Cards contain content and actions about a single subject.
- * 
+ *
  * Based on official Material 3 guidelines:
  * https://m3.material.io/components/cards/guidelines
- * 
+ *
  * @fires card-click - Fired when the card is clicked (if clickable)
- * 
+ *
  * @slot - Default slot for card content
  * @slot header - Optional header content (e.g., title, subtitle)
  * @slot media - Optional media content (e.g., image, video)
  * @slot actions - Optional action buttons at the bottom
- * 
+ *
  * @cssprop --md-comp-card-container-shape - Border radius (default: 12px for medium shape)
  * @cssprop --md-comp-card-container-color - Background color
  * @cssprop --md-comp-card-elevation - Box shadow elevation
@@ -79,31 +79,31 @@ export class M3Card extends LitElement {
   role: string | null = null;
 
   render() {
-    const role = this.clickable ? (this.role || 'button') : this.role;
+    const role = this.clickable ? this.role || 'button' : this.role;
     const tabindex = this.clickable && !this.disabled ? '0' : undefined;
-    
+
     return html`
       <div
         class="card"
-        role=${role || ''}
-        tabindex=${tabindex || ''}
-        aria-label=${this.ariaLabel || ''}
-        aria-disabled=${this.disabled}
+        role=${role || nothing}
+        tabindex=${tabindex ?? nothing}
+        aria-label=${this.ariaLabel || nothing}
+        aria-disabled=${this.disabled ? 'true' : nothing}
         @click=${this._handleClick}
         @keydown=${this._handleKeyDown}
       >
         <div class="card-media">
           <slot name="media"></slot>
         </div>
-        
+
         <div class="card-header">
           <slot name="header"></slot>
         </div>
-        
+
         <div class="card-content">
           <slot></slot>
         </div>
-        
+
         <div class="card-actions">
           <slot name="actions"></slot>
         </div>
@@ -116,14 +116,16 @@ export class M3Card extends LitElement {
       return;
     }
 
-    this.dispatchEvent(new CustomEvent('card-click', {
-      bubbles: true,
-      composed: true,
-      detail: {
-        variant: this.variant,
-        width: this.width
-      }
-    }));
+    this.dispatchEvent(
+      new CustomEvent('card-click', {
+        bubbles: true,
+        composed: true,
+        detail: {
+          variant: this.variant,
+          width: this.width,
+        },
+      }),
+    );
   }
 
   private _handleKeyDown(e: KeyboardEvent) {

--- a/packages/m3-checkbox/src/m3-checkbox.ts
+++ b/packages/m3-checkbox/src/m3-checkbox.ts
@@ -1,13 +1,13 @@
-import { html } from 'lit';
+import { html, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { FormAssociatedElement } from '@banegasn/m3-form-associated';
 import { m3CheckboxStyles } from './m3-checkbox.styles.js';
 
 /**
  * Material Design 3 Checkbox Component
- * 
+ *
  * A checkbox component following Material Design 3 specifications.
- * 
+ *
  * Emits native `input` and `change` events when the checked state changes.
  */
 @customElement('m3-checkbox')
@@ -21,7 +21,8 @@ export class M3Checkbox extends FormAssociatedElement {
   @property({ type: String, reflect: true }) name: string | null = null;
   @property({ type: String, reflect: true }) value: string | null = null;
   @property({ type: Boolean, reflect: true }) required = false;
-  @property({ type: String, attribute: 'aria-label' }) ariaLabel: string | null = null;
+  @property({ type: String, attribute: 'aria-label' }) ariaLabel:
+    string | null = null;
 
   @state() private _pressed = false;
   @state() private _hovered = false;
@@ -34,8 +35,8 @@ export class M3Checkbox extends FormAssociatedElement {
         class="checkbox-container"
         role="checkbox"
         aria-checked=${this.indeterminate ? 'mixed' : this.checked}
-        aria-disabled=${this.isFormDisabled}
-        aria-label=${this.ariaLabel || ''}
+        aria-disabled=${this.isFormDisabled ? 'true' : nothing}
+        aria-label=${this.ariaLabel || nothing}
         tabindex=${this.isFormDisabled ? -1 : 0}
         @click=${this._handleClick}
         @keydown=${this._handleKeyDown}
@@ -46,13 +47,38 @@ export class M3Checkbox extends FormAssociatedElement {
         @mouseup=${this._handleMouseUp}
       >
         <div class="state-layer"></div>
-        <div class="outline" ?checked=${this.checked} ?disabled=${this.isFormDisabled} ?indeterminate=${this.indeterminate}>
-          <div class="background" ?checked=${this.checked} ?disabled=${this.isFormDisabled} ?indeterminate=${this.indeterminate}>
-            ${this.indeterminate
-              ? html`<svg class="icon" viewBox="0 0 18 18"><rect x="4" y="8" width="10" height="2" fill="currentColor"/></svg>`
-              : this.checked
-                ? html`<svg class="icon" viewBox="0 0 18 18"><path d="M7 13.5L3 9.5l1.4-1.4L7 10.7l7.6-7.6L16 4.5l-9 9z" fill="currentColor"/></svg>`
-                : ''}
+        <div
+          class="outline"
+          ?checked=${this.checked}
+          ?disabled=${this.isFormDisabled}
+          ?indeterminate=${this.indeterminate}
+        >
+          <div
+            class="background"
+            ?checked=${this.checked}
+            ?disabled=${this.isFormDisabled}
+            ?indeterminate=${this.indeterminate}
+          >
+            ${
+              this.indeterminate
+                ? html`<svg class="icon" viewBox="0 0 18 18">
+                    <rect
+                      x="4"
+                      y="8"
+                      width="10"
+                      height="2"
+                      fill="currentColor"
+                    />
+                  </svg>`
+                : this.checked
+                  ? html`<svg class="icon" viewBox="0 0 18 18">
+                      <path
+                        d="M7 13.5L3 9.5l1.4-1.4L7 10.7l7.6-7.6L16 4.5l-9 9z"
+                        fill="currentColor"
+                      />
+                    </svg>`
+                  : ''
+            }
           </div>
         </div>
       </div>
@@ -119,18 +145,24 @@ export class M3Checkbox extends FormAssociatedElement {
     } else {
       this.checked = !this.checked;
     }
-    
+
     this.emitInput();
     this.emitChange();
   }
 
   private _syncFormState(): void {
     const disabled = this.isFormDisabled;
-    this.setFormValue(!disabled && this.checked ? this.value ?? 'on' : null, this.checked ? 'checked' : 'unchecked');
+    this.setFormValue(
+      !disabled && this.checked ? (this.value ?? 'on') : null,
+      this.checked ? 'checked' : 'unchecked',
+    );
     this.setFormValidity(
       !disabled && this.required && !this.checked ? { valueMissing: true } : {},
-      !disabled && this.required && !this.checked ? 'Please check this box.' : '',
-      this.shadowRoot?.querySelector<HTMLElement>('.checkbox-container') ?? undefined,
+      !disabled && this.required && !this.checked
+        ? 'Please check this box.'
+        : '',
+      this.shadowRoot?.querySelector<HTMLElement>('.checkbox-container') ??
+        undefined,
     );
   }
 
@@ -139,7 +171,9 @@ export class M3Checkbox extends FormAssociatedElement {
     this.indeterminate = this._defaultIndeterminate;
   }
 
-  protected restoreFormControlState(state: string | File | FormData | null): void {
+  protected restoreFormControlState(
+    state: string | File | FormData | null,
+  ): void {
     if (typeof state === 'string') {
       this.checked = state === 'checked';
       this.indeterminate = false;

--- a/packages/m3-chip/src/m3-chip.test.ts
+++ b/packages/m3-chip/src/m3-chip.test.ts
@@ -1,5 +1,6 @@
 import { html, fixture, expect } from '@open-wc/testing';
 import { describe, it } from 'vitest';
+import { expectVisibleNameWithoutOptionalAttributes } from '../../../test/semantic-attributes.js';
 import './m3-chip.js';
 import type { M3Chip } from './m3-chip.js';
 
@@ -58,5 +59,18 @@ describe('M3Chip icon slot', () => {
       el.shadowRoot!.querySelector('.leading-icon')!.hasAttribute('hidden'),
     ).to.be.true;
     el.remove();
+  });
+});
+
+describe('M3Chip semantic attributes', () => {
+  it('keeps its slotted label as the browser-accessible name when aria-label is unset', async () => {
+    const element = await fixture<M3Chip>(html`<m3-chip>Priority</m3-chip>`);
+    const button =
+      element.shadowRoot!.querySelector<HTMLButtonElement>('button')!;
+
+    await expectVisibleNameWithoutOptionalAttributes(button, [
+      'aria-label',
+      'aria-selected',
+    ]);
   });
 });

--- a/packages/m3-chip/src/m3-chip.ts
+++ b/packages/m3-chip/src/m3-chip.ts
@@ -1,4 +1,4 @@
-import { LitElement, html } from 'lit';
+import { LitElement, html, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { m3ChipStyles } from './m3-chip.styles.js';
 
@@ -37,21 +37,23 @@ export class M3Chip extends LitElement {
   @property({ type: Boolean, reflect: true }) removable = false;
 
   /** ARIA label */
-  @property({ type: String, attribute: 'aria-label' }) ariaLabel: string | null = null;
+  @property({ type: String, attribute: 'aria-label' }) ariaLabel:
+    string | null = null;
 
   @state()
   private _hasIcon = false;
 
   render() {
-    const showLeadingIcon = (this.variant === 'filter' && this.selected) || this._hasIcon;
+    const showLeadingIcon =
+      (this.variant === 'filter' && this.selected) || this._hasIcon;
 
     return html`
       <button
         class="chip"
         ?disabled=${this.disabled}
         role=${this.variant === 'filter' ? 'option' : 'button'}
-        aria-selected=${this.variant === 'filter' ? this.selected : undefined as any}
-        aria-label=${this.ariaLabel || ''}
+        aria-selected=${this.variant === 'filter' ? this.selected : nothing}
+        aria-label=${this.ariaLabel || nothing}
         @click=${this._handleClick}
       >
         <span class="leading-icon" ?hidden=${!showLeadingIcon}>
@@ -66,11 +68,20 @@ export class M3Chip extends LitElement {
           <slot></slot>
         </span>
 
-        ${this.removable ? html`
-          <span class="trailing-icon" @click=${this._handleRemove}>
-            <svg viewBox="0 0 18 18" width="18" height="18"><path d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z" fill="currentColor"/></svg>
-          </span>
-        ` : ''}
+        ${
+          this.removable
+            ? html`
+                <span class="trailing-icon" @click=${this._handleRemove}>
+                  <svg viewBox="0 0 18 18" width="18" height="18">
+                    <path
+                      d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </span>
+              `
+            : ''
+        }
         <div class="state-layer"></div>
       </button>
     `;
@@ -98,28 +109,34 @@ export class M3Chip extends LitElement {
 
     if (this.variant === 'filter') {
       this.selected = !this.selected;
-      this.dispatchEvent(new CustomEvent('chip-select', {
-        bubbles: true,
-        composed: true,
-        detail: { selected: this.selected }
-      }));
+      this.dispatchEvent(
+        new CustomEvent('chip-select', {
+          bubbles: true,
+          composed: true,
+          detail: { selected: this.selected },
+        }),
+      );
     }
 
-    this.dispatchEvent(new CustomEvent('chip-click', {
-      bubbles: true,
-      composed: true,
-      detail: { variant: this.variant, selected: this.selected }
-    }));
+    this.dispatchEvent(
+      new CustomEvent('chip-click', {
+        bubbles: true,
+        composed: true,
+        detail: { variant: this.variant, selected: this.selected },
+      }),
+    );
   }
 
   private _handleRemove(e: Event) {
     e.stopPropagation();
     if (this.disabled) return;
 
-    this.dispatchEvent(new CustomEvent('chip-remove', {
-      bubbles: true,
-      composed: true
-    }));
+    this.dispatchEvent(
+      new CustomEvent('chip-remove', {
+        bubbles: true,
+        composed: true,
+      }),
+    );
   }
 }
 

--- a/packages/m3-chip/tsconfig.test.json
+++ b/packages/m3-chip/tsconfig.test.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.test.json",
   "compilerOptions": {
-    "rootDir": "./src"
+    "rootDir": "../.."
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.test.ts", "src/**/*.d.ts"]
 }

--- a/packages/m3-divider/src/m3-divider.ts
+++ b/packages/m3-divider/src/m3-divider.ts
@@ -1,4 +1,4 @@
-import { LitElement, html } from 'lit';
+import { LitElement, html, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { m3DividerStyles } from './m3-divider.styles.js';
 
@@ -68,7 +68,7 @@ export class M3Divider extends LitElement {
       <hr
         class="divider"
         .ariaOrientation=${this.orientation}
-        role=${this.role}
+        role=${this.role || nothing}
       />
     `;
   }

--- a/packages/m3-fab-menu/src/m3-fab-menu.test.ts
+++ b/packages/m3-fab-menu/src/m3-fab-menu.test.ts
@@ -17,22 +17,45 @@ describe('M3FabMenu public interaction contract', () => {
     expect(trigger.getAttribute('aria-label')).to.equal('Create item');
     expect(trigger.getAttribute('aria-controls')).to.equal(menu.id);
 
-    trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, composed: true }));
+    trigger.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'ArrowDown',
+        bubbles: true,
+        composed: true,
+      }),
+    );
     await el.updateComplete;
-    await (menu as unknown as { updateComplete: Promise<unknown> }).updateComplete;
+    await (menu as unknown as { updateComplete: Promise<unknown> })
+      .updateComplete;
     await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
     expect(el.open).to.be.true;
     expect(trigger.getAttribute('aria-expanded')).to.equal('true');
-    expect((menu.querySelector('m3-menu-item') as HTMLElement).shadowRoot!.activeElement).to.exist;
+    expect(
+      (menu.querySelector('m3-menu-item') as HTMLElement).shadowRoot!
+        .activeElement,
+    ).to.exist;
   });
 
   it('reports dismissal and keeps a disabled trigger inert', async () => {
     const el = await fixture<M3FabMenu>(html`
-      <m3-fab-menu disabled><m3-menu slot="menu"><m3-menu-item>New</m3-menu-item></m3-menu></m3-fab-menu>
+      <m3-fab-menu disabled
+        ><m3-menu slot="menu"
+          ><m3-menu-item>New</m3-menu-item></m3-menu
+        ></m3-fab-menu
+      >
     `);
     const trigger = el.shadowRoot!.querySelector<HTMLButtonElement>('.fab')!;
     trigger.click();
     await el.updateComplete;
     expect(el.open).to.be.false;
+  });
+
+  it('omits an empty optional trigger label', async () => {
+    const el = await fixture<M3FabMenu>(
+      html`<m3-fab-menu label=""></m3-fab-menu>`,
+    );
+    const trigger = el.shadowRoot!.querySelector<HTMLButtonElement>('.fab')!;
+
+    expect(trigger.hasAttribute('aria-label')).to.be.false;
   });
 });

--- a/packages/m3-fab-menu/src/m3-fab-menu.ts
+++ b/packages/m3-fab-menu/src/m3-fab-menu.ts
@@ -1,16 +1,21 @@
 import { LitElement, html } from 'lit';
-import { customElement, property, queryAssignedElements } from 'lit/decorators.js';
+import {
+  customElement,
+  property,
+  queryAssignedElements,
+} from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { m3FabMenuStyles } from './m3-fab-menu.styles.js';
 
-type MenuOpenReason = 'trigger' | 'programmatic' | 'escape' | 'outside' | 'selection' | 'tab';
+type MenuOpenReason =
+  'trigger' | 'programmatic' | 'escape' | 'outside' | 'selection' | 'tab';
 
 interface MenuElement extends HTMLElement {
-    open: boolean;
-    show(reason?: 'trigger' | 'programmatic', opener?: HTMLElement | null): void;
-    dismiss(reason?: MenuOpenReason): void;
-    focusFirstItem(): void;
-    focusLastItem(): void;
+  open: boolean;
+  show(reason?: 'trigger' | 'programmatic', opener?: HTMLElement | null): void;
+  dismiss(reason?: MenuOpenReason): void;
+  focusFirstItem(): void;
+  focusLastItem(): void;
 }
 
 let menuId = 0;
@@ -22,167 +27,189 @@ let menuId = 0;
  */
 @customElement('m3-fab-menu')
 export class M3FabMenu extends LitElement {
-    static styles = m3FabMenuStyles;
+  static styles = m3FabMenuStyles;
 
-    @property({ type: Boolean, reflect: true })
-    open = false;
+  @property({ type: Boolean, reflect: true })
+  open = false;
 
-    @property({ type: Boolean, reflect: true })
-    disabled = false;
+  @property({ type: Boolean, reflect: true })
+  disabled = false;
 
-    @property({ type: String, attribute: 'label' })
-    label = 'Menu';
+  @property({ type: String, attribute: 'label' })
+  label = 'Menu';
 
-    @queryAssignedElements({ slot: 'menu', flatten: true })
-    private _menus!: HTMLElement[];
+  @queryAssignedElements({ slot: 'menu', flatten: true })
+  private _menus!: HTMLElement[];
 
-    private _pendingReason: MenuOpenReason | undefined;
+  private _pendingReason: MenuOpenReason | undefined;
 
-    connectedCallback() {
-        super.connectedCallback();
-        this.addEventListener('menu-open-change', this._handleMenuOpenChange);
-        this.addEventListener('menu-dismiss', this._handleMenuDismiss);
+  connectedCallback() {
+    super.connectedCallback();
+    this.addEventListener('menu-open-change', this._handleMenuOpenChange);
+    this.addEventListener('menu-dismiss', this._handleMenuDismiss);
+  }
+
+  disconnectedCallback() {
+    this.removeEventListener('menu-open-change', this._handleMenuOpenChange);
+    this.removeEventListener('menu-dismiss', this._handleMenuDismiss);
+    super.disconnectedCallback();
+  }
+
+  updated(changedProperties: Map<string, unknown>) {
+    if (!changedProperties.has('open')) {
+      return;
     }
 
-    disconnectedCallback() {
-        this.removeEventListener('menu-open-change', this._handleMenuOpenChange);
-        this.removeEventListener('menu-dismiss', this._handleMenuDismiss);
-        super.disconnectedCallback();
+    const reason = this._pendingReason ?? 'programmatic';
+    this._pendingReason = undefined;
+    const menu = this._menu();
+    if (menu && menu.open !== this.open) {
+      if (this.open) {
+        menu.show(
+          reason === 'programmatic' ? 'programmatic' : 'trigger',
+          this._menuTrigger(),
+        );
+      } else {
+        menu.dismiss(reason);
+      }
     }
+    this.dispatchEvent(
+      new CustomEvent('fab-menu-open-change', {
+        bubbles: true,
+        composed: true,
+        detail: { open: this.open, reason },
+      }),
+    );
+  }
 
-    updated(changedProperties: Map<string, unknown>) {
-        if (!changedProperties.has('open')) {
-            return;
-        }
-
-        const reason = this._pendingReason ?? 'programmatic';
-        this._pendingReason = undefined;
-        const menu = this._menu();
-        if (menu && menu.open !== this.open) {
-            if (this.open) {
-                menu.show(reason === 'programmatic' ? 'programmatic' : 'trigger', this._menuTrigger());
-            } else {
-                menu.dismiss(reason);
-            }
-        }
-        this.dispatchEvent(new CustomEvent('fab-menu-open-change', {
-            bubbles: true,
-            composed: true,
-            detail: { open: this.open, reason }
-        }));
-    }
-
-    render() {
-        const menu = this._menu();
-        const controls = menu?.id || undefined;
-        return html`
+  render() {
+    const menu = this._menu();
+    const controls = menu?.id || undefined;
+    return html`
       <slot name="menu" @slotchange=${this._handleMenuSlotChange}></slot>
       <button
         class="fab ${this.open ? 'active' : ''}"
         type="button"
         ?disabled=${this.disabled}
-        aria-label=${this.label}
+        aria-label=${ifDefined(this.label || undefined)}
         aria-haspopup="menu"
         aria-expanded=${String(this.open)}
         aria-controls=${ifDefined(controls || undefined)}
         @click=${this._toggle}
         @keydown=${this._handleKeydown}
       >
-        <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 -960 960 960" width="24" fill="currentColor" aria-hidden="true">
-          <path d="M440-440H200v-80h240v-240h80v240h240v80H520v240h-80v-240Z"/>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          height="24"
+          viewBox="0 -960 960 960"
+          width="24"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path d="M440-440H200v-80h240v-240h80v240h240v80H520v240h-80v-240Z" />
         </svg>
       </button>
     `;
-    }
+  }
 
-    private _handleMenuSlotChange = () => {
+  private _handleMenuSlotChange = () => {
+    const menu = this._menu();
+    if (!menu) {
+      return;
+    }
+    if (!menu.id) {
+      menu.id = `m3-fab-menu-menu-${++menuId}`;
+    }
+    if (menu.open !== this.open) {
+      menu.open = this.open;
+    }
+    this.requestUpdate();
+  };
+
+  private _handleMenuOpenChange = (event: Event) => {
+    if (event.target === this) {
+      return;
+    }
+    const detail = (
+      event as CustomEvent<{ open: boolean; reason: MenuOpenReason }>
+    ).detail;
+    this._pendingReason = detail.reason;
+    this.open = detail.open;
+  };
+
+  private _handleMenuDismiss = (event: Event) => {
+    if (event.target === this) {
+      return;
+    }
+    const detail = (event as CustomEvent<{ reason: MenuOpenReason }>).detail;
+    if (detail.reason !== 'tab') {
+      this.shadowRoot?.querySelector<HTMLButtonElement>('.fab')?.focus();
+    }
+    this.dispatchEvent(
+      new CustomEvent('fab-menu-dismiss', {
+        bubbles: true,
+        composed: true,
+        detail,
+      }),
+    );
+  };
+
+  private _toggle = (event: MouseEvent) => {
+    if (this.disabled) {
+      return;
+    }
+    (event.currentTarget as HTMLButtonElement).focus();
+    this._requestOpen(!this.open, 'trigger');
+  };
+
+  private _handleKeydown = (event: KeyboardEvent) => {
+    if (this.disabled) {
+      return;
+    }
+    if (event.key === 'Escape' && this.open) {
+      event.preventDefault();
+      this._requestOpen(false, 'escape');
+      return;
+    }
+    if (
+      !this.open &&
+      ['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(event.key)
+    ) {
+      event.preventDefault();
+      this._requestOpen(true, 'trigger');
+      queueMicrotask(() => {
         const menu = this._menu();
-        if (!menu) {
-            return;
+        if (event.key === 'ArrowUp' || event.key === 'End') {
+          menu?.focusLastItem();
+        } else {
+          menu?.focusFirstItem();
         }
-        if (!menu.id) {
-            menu.id = `m3-fab-menu-menu-${++menuId}`;
-        }
-        if (menu.open !== this.open) {
-            menu.open = this.open;
-        }
-        this.requestUpdate();
-    };
-
-    private _handleMenuOpenChange = (event: Event) => {
-        if (event.target === this) {
-            return;
-        }
-        const detail = (event as CustomEvent<{ open: boolean; reason: MenuOpenReason }>).detail;
-        this._pendingReason = detail.reason;
-        this.open = detail.open;
-    };
-
-    private _handleMenuDismiss = (event: Event) => {
-        if (event.target === this) {
-            return;
-        }
-        const detail = (event as CustomEvent<{ reason: MenuOpenReason }>).detail;
-        if (detail.reason !== 'tab') {
-            this.shadowRoot?.querySelector<HTMLButtonElement>('.fab')?.focus();
-        }
-        this.dispatchEvent(new CustomEvent('fab-menu-dismiss', {
-            bubbles: true,
-            composed: true,
-            detail
-        }));
-    };
-
-    private _toggle = (event: MouseEvent) => {
-        if (this.disabled) {
-            return;
-        }
-        (event.currentTarget as HTMLButtonElement).focus();
-        this._requestOpen(!this.open, 'trigger');
-    };
-
-    private _handleKeydown = (event: KeyboardEvent) => {
-        if (this.disabled) {
-            return;
-        }
-        if (event.key === 'Escape' && this.open) {
-            event.preventDefault();
-            this._requestOpen(false, 'escape');
-            return;
-        }
-        if (!this.open && ['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(event.key)) {
-            event.preventDefault();
-            this._requestOpen(true, 'trigger');
-            queueMicrotask(() => {
-                const menu = this._menu();
-                if (event.key === 'ArrowUp' || event.key === 'End') {
-                    menu?.focusLastItem();
-                } else {
-                    menu?.focusFirstItem();
-                }
-            });
-        }
-    };
-
-    private _requestOpen(open: boolean, reason: MenuOpenReason) {
-        if (this.open === open) {
-            return;
-        }
-        this._pendingReason = reason;
-        this.open = open;
+      });
     }
+  };
 
-    private _menu(): MenuElement | null {
-        return (this._menus?.find((element) => element.tagName === 'M3-MENU') as MenuElement | undefined) ?? null;
+  private _requestOpen(open: boolean, reason: MenuOpenReason) {
+    if (this.open === open) {
+      return;
     }
+    this._pendingReason = reason;
+    this.open = open;
+  }
 
-    private _menuTrigger(): HTMLButtonElement | null {
-        return this.shadowRoot?.querySelector<HTMLButtonElement>('.fab') ?? null;
-    }
+  private _menu(): MenuElement | null {
+    return (
+      (this._menus?.find((element) => element.tagName === 'M3-MENU') as
+        MenuElement | undefined) ?? null
+    );
+  }
+
+  private _menuTrigger(): HTMLButtonElement | null {
+    return this.shadowRoot?.querySelector<HTMLButtonElement>('.fab') ?? null;
+  }
 }
 
 declare global {
-    interface HTMLElementTagNameMap {
-        'm3-fab-menu': M3FabMenu;
-    }
+  interface HTMLElementTagNameMap {
+    'm3-fab-menu': M3FabMenu;
+  }
 }

--- a/packages/m3-icon-button/src/m3-icon-button.ts
+++ b/packages/m3-icon-button/src/m3-icon-button.ts
@@ -1,4 +1,4 @@
-import { LitElement, html } from 'lit';
+import { LitElement, html, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { m3IconButtonStyles } from './m3-icon-button.styles.js';
 
@@ -79,8 +79,8 @@ export class M3IconButton extends LitElement {
         class="icon-button"
         type=${this.type}
         ?disabled=${this.disabled}
-        aria-label=${this.ariaLabel || ''}
-        aria-pressed=${this.toggle ? this.selected : undefined as any}
+        aria-label=${this.ariaLabel || nothing}
+        aria-pressed=${this.toggle ? this.selected : nothing}
         @click=${this._handleClick}
       >
         <span class="icon">
@@ -99,18 +99,22 @@ export class M3IconButton extends LitElement {
 
     if (this.toggle) {
       this.selected = !this.selected;
-      this.dispatchEvent(new CustomEvent('icon-button-toggle', {
-        bubbles: true,
-        composed: true,
-        detail: { selected: this.selected }
-      }));
+      this.dispatchEvent(
+        new CustomEvent('icon-button-toggle', {
+          bubbles: true,
+          composed: true,
+          detail: { selected: this.selected },
+        }),
+      );
     }
 
-    this.dispatchEvent(new CustomEvent('icon-button-click', {
-      bubbles: true,
-      composed: true,
-      detail: { variant: this.variant, selected: this.selected }
-    }));
+    this.dispatchEvent(
+      new CustomEvent('icon-button-click', {
+        bubbles: true,
+        composed: true,
+        detail: { variant: this.variant, selected: this.selected },
+      }),
+    );
   }
 
   /**

--- a/packages/m3-list/src/m3-list-item.ts
+++ b/packages/m3-list/src/m3-list-item.ts
@@ -1,4 +1,4 @@
-import { LitElement, html } from 'lit';
+import { LitElement, html, nothing } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { customElement, property, state } from 'lit/decorators.js';
 import { m3ListItemStyles } from './m3-list-item.styles.js';
@@ -87,8 +87,8 @@ export class M3ListItem extends LitElement {
         role="listitem"
         tabindex=${this.clickable && !this.disabled ? '0' : '-1'}
         aria-selected=${ifDefined(this.selected ? 'true' : undefined)}
-        aria-label=${this.ariaLabel || ''}
-        aria-disabled=${this.disabled}
+        aria-label=${this.ariaLabel || nothing}
+        aria-disabled=${this.disabled ? 'true' : nothing}
         @click=${this._handleClick}
         @keydown=${this._handleKeydown}
       >
@@ -133,17 +133,21 @@ export class M3ListItem extends LitElement {
   private _handleClick() {
     if (this.disabled || !this.clickable) return;
 
-    this.dispatchEvent(new CustomEvent('item-click', {
-      bubbles: true,
-      composed: true,
-      detail: { value: this.value, selected: this.selected }
-    }));
+    this.dispatchEvent(
+      new CustomEvent('item-click', {
+        bubbles: true,
+        composed: true,
+        detail: { value: this.value, selected: this.selected },
+      }),
+    );
 
-    this.dispatchEvent(new CustomEvent('item-select', {
-      bubbles: true,
-      composed: true,
-      detail: { value: this.value, selected: !this.selected }
-    }));
+    this.dispatchEvent(
+      new CustomEvent('item-select', {
+        bubbles: true,
+        composed: true,
+        detail: { value: this.value, selected: !this.selected },
+      }),
+    );
   }
 
   private _handleKeydown(e: KeyboardEvent) {

--- a/packages/m3-list/src/m3-list.test.ts
+++ b/packages/m3-list/src/m3-list.test.ts
@@ -1,5 +1,6 @@
 import { html, fixture, expect } from '@open-wc/testing';
 import { describe, it } from 'vitest';
+import { expectVisibleNameWithoutOptionalAttributes } from '../../../test/semantic-attributes.js';
 import './m3-list.js';
 import './m3-list-item.js';
 import type { M3List } from './m3-list.js';
@@ -37,7 +38,9 @@ describe('M3List', () => {
 
 describe('M3ListItem', () => {
   it('renders a single-line item by default', async () => {
-    const el = await fixture<M3ListItem>(html`<m3-list-item>Headline</m3-list-item>`);
+    const el = await fixture<M3ListItem>(
+      html`<m3-list-item>Headline</m3-list-item>`,
+    );
     const li = el.shadowRoot!.querySelector('li');
     expect(li).to.exist;
     expect(li!.getAttribute('role')).to.equal('listitem');
@@ -66,14 +69,18 @@ describe('M3ListItem', () => {
   });
 
   it('reflects selected state', async () => {
-    const el = await fixture<M3ListItem>(html`<m3-list-item selected>Selected</m3-list-item>`);
+    const el = await fixture<M3ListItem>(
+      html`<m3-list-item selected>Selected</m3-list-item>`,
+    );
     expect(el.hasAttribute('selected')).to.be.true;
     const li = el.shadowRoot!.querySelector('li');
     expect(li!.getAttribute('aria-selected')).to.equal('true');
   });
 
   it('reflects disabled state', async () => {
-    const el = await fixture<M3ListItem>(html`<m3-list-item disabled>Disabled</m3-list-item>`);
+    const el = await fixture<M3ListItem>(
+      html`<m3-list-item disabled>Disabled</m3-list-item>`,
+    );
     expect(el.hasAttribute('disabled')).to.be.true;
     const li = el.shadowRoot!.querySelector('li');
     expect(li!.getAttribute('aria-disabled')).to.equal('true');
@@ -140,32 +147,48 @@ describe('M3ListItem', () => {
   });
 
   it('supports shape variants', async () => {
-    const el = await fixture<M3ListItem>(html`<m3-list-item shape="rounded">Rounded</m3-list-item>`);
+    const el = await fixture<M3ListItem>(
+      html`<m3-list-item shape="rounded">Rounded</m3-list-item>`,
+    );
     expect(el.getAttribute('shape')).to.equal('rounded');
   });
 
   it('dispatches item-click on click', async () => {
-    const el = await fixture<M3ListItem>(html`<m3-list-item>Clickable</m3-list-item>`);
+    const el = await fixture<M3ListItem>(
+      html`<m3-list-item>Clickable</m3-list-item>`,
+    );
     let clicked = false;
-    el.addEventListener('item-click', () => { clicked = true; });
+    el.addEventListener('item-click', () => {
+      clicked = true;
+    });
     el.shadowRoot!.querySelector('li')!.click();
     expect(clicked).to.be.true;
   });
 
   it('does not dispatch click when disabled', async () => {
-    const el = await fixture<M3ListItem>(html`<m3-list-item disabled>Disabled</m3-list-item>`);
+    const el = await fixture<M3ListItem>(
+      html`<m3-list-item disabled>Disabled</m3-list-item>`,
+    );
     let clicked = false;
-    el.addEventListener('item-click', () => { clicked = true; });
+    el.addEventListener('item-click', () => {
+      clicked = true;
+    });
     el.shadowRoot!.querySelector('li')!.click();
     expect(clicked).to.be.false;
   });
 
   it('responds to Enter key', async () => {
-    const el = await fixture<M3ListItem>(html`<m3-list-item>Keyboard</m3-list-item>`);
+    const el = await fixture<M3ListItem>(
+      html`<m3-list-item>Keyboard</m3-list-item>`,
+    );
     let clicked = false;
-    el.addEventListener('item-click', () => { clicked = true; });
+    el.addEventListener('item-click', () => {
+      clicked = true;
+    });
     const li = el.shadowRoot!.querySelector('li')!;
-    li.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    li.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
+    );
     expect(clicked).to.be.true;
   });
 
@@ -176,5 +199,16 @@ describe('M3ListItem', () => {
       </m3-list>
     `);
     await expect(el).to.be.accessible();
+  });
+
+  it('keeps the visible item label usable when aria-label is unset', async () => {
+    const list = await fixture<M3List>(html`
+      <m3-list><m3-list-item>Inbox</m3-list-item></m3-list>
+    `);
+    const el = list.querySelector<M3ListItem>('m3-list-item')!;
+    await el.updateComplete;
+    const item = el.shadowRoot!.querySelector<HTMLElement>('li')!;
+
+    await expectVisibleNameWithoutOptionalAttributes(item, ['aria-label']);
   });
 });

--- a/packages/m3-list/src/m3-list.ts
+++ b/packages/m3-list/src/m3-list.ts
@@ -1,4 +1,4 @@
-import { LitElement, html } from 'lit';
+import { LitElement, html, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { m3ListStyles } from './m3-list.styles.js';
 
@@ -31,7 +31,7 @@ export class M3List extends LitElement {
 
   render() {
     return html`
-      <ul class="list" role=${this.role}>
+      <ul class="list" role=${this.role || nothing}>
         <slot></slot>
       </ul>
     `;

--- a/packages/m3-list/tsconfig.test.json
+++ b/packages/m3-list/tsconfig.test.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.test.json",
   "compilerOptions": {
-    "rootDir": "./src"
+    "rootDir": "../.."
   },
   "include": ["src/**/*.ts"]
 }

--- a/packages/m3-navigation-bar/src/navigation-bar-item.ts
+++ b/packages/m3-navigation-bar/src/navigation-bar-item.ts
@@ -1,4 +1,4 @@
-import { LitElement, html } from 'lit';
+import { LitElement, html, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { navigationBarItemStyles } from './navigation-bar-item.styles.js';
 
@@ -23,11 +23,11 @@ export class M3NavigationBarItem extends LitElement {
 
   render() {
     return html`
-      <button 
-        class="item ${this.active ? 'active' : ''}" 
+      <button
+        class="item ${this.active ? 'active' : ''}"
         @click=${this._handleClick}
         aria-label=${this.label || 'Navigation item'}
-        aria-current=${this.active ? 'page' : 'false'}
+        aria-current=${this.active ? 'page' : nothing}
       >
         <div class="state-layer bubble"></div>
         <div class="indicator bubble"></div>
@@ -54,11 +54,13 @@ export class M3NavigationBarItem extends LitElement {
   }
 
   private _handleClick() {
-    this.dispatchEvent(new CustomEvent('item-click', {
-      bubbles: true,
-      composed: true,
-      detail: { label: this.label }
-    }));
+    this.dispatchEvent(
+      new CustomEvent('item-click', {
+        bubbles: true,
+        composed: true,
+        detail: { label: this.label },
+      }),
+    );
   }
 }
 
@@ -67,4 +69,3 @@ declare global {
     'm3-navigation-bar-item': M3NavigationBarItem;
   }
 }
-

--- a/packages/m3-navigation-rail/src/navigation-rail-item.ts
+++ b/packages/m3-navigation-rail/src/navigation-rail-item.ts
@@ -1,4 +1,4 @@
-import { LitElement, html } from 'lit';
+import { LitElement, html, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { navigationRailItemStyles } from './navigation-rail-item.styles.js';
 
@@ -20,11 +20,11 @@ export class M3NavigationRailItem extends LitElement {
 
   render() {
     return html`
-      <button 
-        class="item ${this.active ? 'active' : ''}" 
+      <button
+        class="item ${this.active ? 'active' : ''}"
         @click=${this._handleClick}
         aria-label=${this.label || 'Navigation item'}
-        aria-current=${this.active ? 'page' : 'false'}
+        aria-current=${this.active ? 'page' : nothing}
       >
         <div class="indicator"></div>
         <div class="icon">
@@ -38,11 +38,13 @@ export class M3NavigationRailItem extends LitElement {
   }
 
   private _handleClick() {
-    this.dispatchEvent(new CustomEvent('item-click', {
-      bubbles: true,
-      composed: true,
-      detail: { label: this.label }
-    }));
+    this.dispatchEvent(
+      new CustomEvent('item-click', {
+        bubbles: true,
+        composed: true,
+        detail: { label: this.label },
+      }),
+    );
   }
 }
 

--- a/packages/m3-progress/src/m3-progress.test.ts
+++ b/packages/m3-progress/src/m3-progress.test.ts
@@ -7,7 +7,9 @@ import type { M3Progress } from './m3-progress.js';
 const themeAttribute = 'data-progress-motion-theme';
 
 afterEach(() => {
-  document.head.querySelectorAll(`[${themeAttribute}]`).forEach((style) => style.remove());
+  document.head
+    .querySelectorAll(`[${themeAttribute}]`)
+    .forEach((style) => style.remove());
   document.documentElement.removeAttribute('data-motion');
 });
 
@@ -19,11 +21,56 @@ describe('M3Progress reduced motion', () => {
     document.head.append(style);
     document.documentElement.setAttribute('data-motion', 'reduced');
 
-    const el = await fixture<M3Progress>(html`<m3-progress indeterminate></m3-progress>`);
+    const el = await fixture<M3Progress>(
+      html`<m3-progress indeterminate></m3-progress>`,
+    );
     const indicator = el.shadowRoot!.querySelector('.indicator')!;
     const computed = getComputedStyle(indicator);
 
     expect(computed.animationPlayState).to.equal('paused');
-    expect(computed.getPropertyValue('--md-sys-motion-progress-start').trim()).to.equal('25%');
+    expect(
+      computed.getPropertyValue('--md-sys-motion-progress-start').trim(),
+    ).to.equal('25%');
+  });
+});
+
+describe('M3Progress semantics', () => {
+  it('keeps an unnamed indicator out of the accessibility tree', async () => {
+    const el = await fixture<M3Progress>(
+      html`<m3-progress value="0.4"></m3-progress>`,
+    );
+    const track = el.shadowRoot!.querySelector<HTMLElement>('.track')!;
+
+    expect(track.getAttribute('aria-hidden')).to.equal('true');
+    expect(track.hasAttribute('role')).to.be.false;
+    expect(track.hasAttribute('aria-valuenow')).to.be.false;
+    expect(track.hasAttribute('aria-label')).to.be.false;
+  });
+
+  it('exposes named determinate progress with its value', async () => {
+    const el = await fixture<M3Progress>(
+      html`<m3-progress
+        value="0.4"
+        aria-label="Upload progress"
+      ></m3-progress>`,
+    );
+    const track = el.shadowRoot!.querySelector<HTMLElement>('.track')!;
+
+    expect(track.getAttribute('role')).to.equal('progressbar');
+    expect(track.getAttribute('aria-label')).to.equal('Upload progress');
+    expect(track.getAttribute('aria-valuenow')).to.equal('40');
+  });
+
+  it('omits aria-valuenow for named indeterminate progress', async () => {
+    const el = await fixture<M3Progress>(
+      html`<m3-progress
+        indeterminate
+        aria-label="Loading results"
+      ></m3-progress>`,
+    );
+    const track = el.shadowRoot!.querySelector<HTMLElement>('.track')!;
+
+    expect(track.getAttribute('role')).to.equal('progressbar');
+    expect(track.hasAttribute('aria-valuenow')).to.be.false;
   });
 });

--- a/packages/m3-progress/src/m3-progress.ts
+++ b/packages/m3-progress/src/m3-progress.ts
@@ -1,4 +1,4 @@
-import { LitElement, html } from 'lit';
+import { LitElement, html, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { m3ProgressStyles } from './m3-progress.styles.js';
 
@@ -21,19 +21,22 @@ export class M3Progress extends LitElement {
   @property({ type: Boolean, reflect: true }) disabled = false;
 
   /** ARIA label */
-  @property({ type: String, attribute: 'aria-label' }) ariaLabel: string | null = null;
+  @property({ type: String, attribute: 'aria-label' }) ariaLabel:
+    string | null = null;
 
   render() {
     const percentage = Math.max(0, Math.min(1, this.value)) * 100;
+    const isNamed = Boolean(this.ariaLabel);
 
     return html`
       <div
         class="track"
-        role="progressbar"
-        aria-valuenow=${this.indeterminate ? undefined as any : percentage}
-        aria-valuemin="0"
-        aria-valuemax="100"
-        aria-label=${this.ariaLabel || 'Progress'}
+        role=${isNamed ? 'progressbar' : nothing}
+        aria-hidden=${isNamed ? nothing : 'true'}
+        aria-valuenow=${isNamed && !this.indeterminate ? percentage : nothing}
+        aria-valuemin=${isNamed ? '0' : nothing}
+        aria-valuemax=${isNamed ? '100' : nothing}
+        aria-label=${this.ariaLabel || nothing}
       >
         <div
           class="indicator"

--- a/packages/m3-radio-button/src/m3-radio-button.test.ts
+++ b/packages/m3-radio-button/src/m3-radio-button.test.ts
@@ -305,4 +305,15 @@ describe('m3-radio-button scoped groups', () => {
     label.click();
     expect(radio.checked).to.equal(false);
   });
+
+  it('omits unset ARIA name and IDREF attributes', async () => {
+    const radio = await fixture<M3RadioButton>(
+      html`<m3-radio-button></m3-radio-button>`,
+    );
+    const control =
+      radio.shadowRoot!.querySelector<HTMLElement>('.radio-container')!;
+
+    expect(control.hasAttribute('aria-label')).to.be.false;
+    expect(control.hasAttribute('aria-labelledby')).to.be.false;
+  });
 });

--- a/packages/m3-radio-button/src/m3-radio-button.ts
+++ b/packages/m3-radio-button/src/m3-radio-button.ts
@@ -1,4 +1,4 @@
-import { html, type PropertyValues } from 'lit';
+import { html, nothing, type PropertyValues } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { FormAssociatedElement } from '@banegasn/m3-form-associated';
 import { m3RadioButtonStyles } from './m3-radio-button.styles.js';
@@ -48,9 +48,9 @@ export class M3RadioButton extends FormAssociatedElement {
         class="radio-container"
         role="radio"
         aria-checked=${this.checked}
-        aria-disabled=${this.isFormDisabled}
-        aria-label=${this.ariaLabel || ''}
-        aria-labelledby=${this.ariaLabelledBy || ''}
+        aria-disabled=${this.isFormDisabled ? 'true' : nothing}
+        aria-label=${this.ariaLabel || nothing}
+        aria-labelledby=${this.ariaLabelledBy || nothing}
         tabindex=${this._tabIndex()}
         @click=${this._handleClick}
         @keydown=${this._handleKeyDown}

--- a/packages/m3-search-bar/src/m3-search-bar.ts
+++ b/packages/m3-search-bar/src/m3-search-bar.ts
@@ -1,7 +1,10 @@
-import { html } from 'lit';
+import { html, nothing } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { customElement, property, state, query } from 'lit/decorators.js';
-import { FormAssociatedElement, validityFlags } from '@banegasn/m3-form-associated';
+import {
+  FormAssociatedElement,
+  validityFlags,
+} from '@banegasn/m3-form-associated';
 import { m3SearchBarStyles } from './m3-search-bar.styles.js';
 
 /** Material Design 3 search bar with native form participation. */
@@ -14,10 +17,14 @@ export class M3SearchBar extends FormAssociatedElement {
   @property({ type: String, reflect: true }) value = '';
   @property({ type: Boolean, reflect: true }) disabled = false;
   @property({ type: String, reflect: true }) name: string | null = null;
-  @property({ type: String, attribute: 'aria-label' }) ariaLabel: string | null = null;
-  @property({ type: String, attribute: 'aria-labelledby' }) ariaLabelledBy: string | null = null;
-  @property({ type: Number, attribute: 'maxlength' }) maxLength: number | null = null;
-  @property({ type: Number, attribute: 'minlength' }) minLength: number | null = null;
+  @property({ type: String, attribute: 'aria-label' }) ariaLabel:
+    string | null = null;
+  @property({ type: String, attribute: 'aria-labelledby' }) ariaLabelledBy:
+    string | null = null;
+  @property({ type: Number, attribute: 'maxlength' }) maxLength: number | null =
+    null;
+  @property({ type: Number, attribute: 'minlength' }) minLength: number | null =
+    null;
   @property({ type: String }) pattern: string | null = null;
   @property({ type: Boolean, reflect: true }) required = false;
   @property({ type: String }) autocomplete: string | null = null;
@@ -45,8 +52,8 @@ export class M3SearchBar extends FormAssociatedElement {
               placeholder=${this.placeholder}
               ?disabled=${this.isFormDisabled}
               ?required=${this.required}
-              aria-label=${this.ariaLabel || ''}
-              aria-labelledby=${this.ariaLabelledBy || ''}
+              aria-label=${this.ariaLabel || nothing}
+              aria-labelledby=${this.ariaLabelledBy || nothing}
               maxlength=${ifDefined(this.maxLength ?? undefined)}
               minlength=${ifDefined(this.minLength ?? undefined)}
               pattern=${ifDefined(this.pattern ?? undefined)}
@@ -109,7 +116,10 @@ export class M3SearchBar extends FormAssociatedElement {
   }
 
   private _syncFormState(): void {
-    const flags = !this.isFormDisabled && this._input ? validityFlags(this._input.validity) : {};
+    const flags =
+      !this.isFormDisabled && this._input
+        ? validityFlags(this._input.validity)
+        : {};
     if (this.value) delete flags.valueMissing;
     else if (this.required && !this.isFormDisabled) flags.valueMissing = true;
     const invalid = Object.keys(flags).length > 0;
@@ -125,7 +135,9 @@ export class M3SearchBar extends FormAssociatedElement {
     this.value = this._defaultValue;
   }
 
-  protected restoreFormControlState(state: string | File | FormData | null): void {
+  protected restoreFormControlState(
+    state: string | File | FormData | null,
+  ): void {
     if (typeof state === 'string') this.value = state;
   }
 

--- a/packages/m3-slider/src/m3-slider.ts
+++ b/packages/m3-slider/src/m3-slider.ts
@@ -1,11 +1,11 @@
-import { html } from 'lit';
+import { html, nothing } from 'lit';
 import { customElement, property, state, query } from 'lit/decorators.js';
 import { FormAssociatedElement } from '@banegasn/m3-form-associated';
 import { m3SliderStyles } from './m3-slider.styles.js';
 
 /**
  * Material Design 3 Slider Component
- * 
+ *
  * Emits native `input` while dragging and `change` on a committed value.
  */
 @customElement('m3-slider')
@@ -19,8 +19,9 @@ export class M3Slider extends FormAssociatedElement {
   @property({ type: Boolean, reflect: true }) disabled = false;
   @property({ type: Number }) step = 1;
   @property({ type: String, reflect: true }) name: string | null = null;
-  @property({ type: String, attribute: 'aria-label' }) ariaLabel: string | null = null;
-  
+  @property({ type: String, attribute: 'aria-label' }) ariaLabel:
+    string | null = null;
+
   @query('.slider-input') inputEl!: HTMLInputElement;
 
   @state() private _focused = false;
@@ -29,7 +30,10 @@ export class M3Slider extends FormAssociatedElement {
   private _defaultValue = this.value;
 
   render() {
-    const fraction = Math.max(0, Math.min(1, (this.value - this.min) / (this.max - this.min)));
+    const fraction = Math.max(
+      0,
+      Math.min(1, (this.value - this.min) / (this.max - this.min)),
+    );
     const percentage = fraction * 100;
 
     return html`
@@ -42,9 +46,14 @@ export class M3Slider extends FormAssociatedElement {
           <div class="track-inactive"></div>
           <div class="track-active" style="width: ${percentage}%"></div>
         </div>
-        
+
         <div class="thumb-container" style="left: ${percentage}%">
-          <div class="state-layer" ?active=${this._active} ?hovered=${this._hovered} ?focused=${this._focused}></div>
+          <div
+            class="state-layer"
+            ?active=${this._active}
+            ?hovered=${this._hovered}
+            ?focused=${this._focused}
+          ></div>
           <div class="thumb"></div>
         </div>
 
@@ -56,7 +65,7 @@ export class M3Slider extends FormAssociatedElement {
           step=${this.step}
           .value=${String(this.value)}
           ?disabled=${this.isFormDisabled}
-          aria-label=${this.ariaLabel || ''}
+          aria-label=${this.ariaLabel || nothing}
           @input=${this._handleInput}
           @change=${this._handleChange}
           @focus=${this._handleFocus}
@@ -118,14 +127,19 @@ export class M3Slider extends FormAssociatedElement {
   }
 
   private _syncFormState(): void {
-    this.setFormValue(this.isFormDisabled ? null : String(this.value), String(this.value));
+    this.setFormValue(
+      this.isFormDisabled ? null : String(this.value),
+      String(this.value),
+    );
   }
 
   protected resetFormControl(): void {
     this.value = this._defaultValue;
   }
 
-  protected restoreFormControlState(state: string | File | FormData | null): void {
+  protected restoreFormControlState(
+    state: string | File | FormData | null,
+  ): void {
     if (typeof state === 'string' && state !== '') this.value = Number(state);
   }
 }

--- a/packages/m3-split-button/src/m3-split-button.test.ts
+++ b/packages/m3-split-button/src/m3-split-button.test.ts
@@ -13,7 +13,8 @@ describe('M3SplitButton public interaction contract', () => {
       </m3-split-button>
     `);
     await el.updateComplete;
-    const trigger = el.shadowRoot!.querySelector<HTMLButtonElement>('.menu-button')!;
+    const trigger =
+      el.shadowRoot!.querySelector<HTMLButtonElement>('.menu-button')!;
     const menu = el.querySelector('m3-menu')!;
     expect(trigger.getAttribute('aria-haspopup')).to.equal('menu');
     expect(trigger.getAttribute('aria-controls')).to.equal(menu.id);
@@ -21,12 +22,17 @@ describe('M3SplitButton public interaction contract', () => {
 
     trigger.click();
     await el.updateComplete;
-    await (menu as unknown as { updateComplete: Promise<unknown> }).updateComplete;
+    await (menu as unknown as { updateComplete: Promise<unknown> })
+      .updateComplete;
     expect(el.open).to.be.true;
     expect(trigger.getAttribute('aria-expanded')).to.equal('true');
 
     menu.shadowRoot!.querySelector<HTMLElement>('.surface')!.dispatchEvent(
-      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, composed: true }),
+      new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        composed: true,
+      }),
     );
     await el.updateComplete;
     expect(el.open).to.be.false;
@@ -34,15 +40,33 @@ describe('M3SplitButton public interaction contract', () => {
   });
 
   it('does not emit empty aria-controls or activate disabled actions', async () => {
-    const el = await fixture<M3SplitButton>(html`<m3-split-button disabled>Send</m3-split-button>`);
-    const [main, trigger] = Array.from(el.shadowRoot!.querySelectorAll<HTMLButtonElement>('button'));
+    const el = await fixture<M3SplitButton>(
+      html`<m3-split-button disabled>Send</m3-split-button>`,
+    );
+    const [main, trigger] = Array.from(
+      el.shadowRoot!.querySelectorAll<HTMLButtonElement>('button'),
+    );
     let clicked = false;
-    el.addEventListener('split-button-click', () => { clicked = true; });
+    el.addEventListener('split-button-click', () => {
+      clicked = true;
+    });
     expect(trigger.hasAttribute('aria-controls')).to.be.false;
     main.click();
     trigger.click();
     await el.updateComplete;
     expect(clicked).to.be.false;
     expect(el.open).to.be.false;
+  });
+
+  it('omits an empty optional menu label', async () => {
+    const el = await fixture<M3SplitButton>(
+      html`<m3-split-button>Send</m3-split-button>`,
+    );
+    const trigger =
+      el.shadowRoot!.querySelector<HTMLButtonElement>('.menu-button')!;
+    el.menuLabel = '';
+    await el.updateComplete;
+
+    expect(trigger.hasAttribute('aria-label')).to.be.false;
   });
 });

--- a/packages/m3-split-button/src/m3-split-button.ts
+++ b/packages/m3-split-button/src/m3-split-button.ts
@@ -1,16 +1,21 @@
 import { LitElement, html } from 'lit';
-import { customElement, property, queryAssignedElements } from 'lit/decorators.js';
+import {
+  customElement,
+  property,
+  queryAssignedElements,
+} from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { m3SplitButtonStyles } from './m3-split-button.styles.js';
 
-type MenuOpenReason = 'trigger' | 'programmatic' | 'escape' | 'outside' | 'selection' | 'tab';
+type MenuOpenReason =
+  'trigger' | 'programmatic' | 'escape' | 'outside' | 'selection' | 'tab';
 
 interface MenuElement extends HTMLElement {
-    open: boolean;
-    show(reason?: 'trigger' | 'programmatic', opener?: HTMLElement | null): void;
-    dismiss(reason?: MenuOpenReason): void;
-    focusFirstItem(): void;
-    focusLastItem(): void;
+  open: boolean;
+  show(reason?: 'trigger' | 'programmatic', opener?: HTMLElement | null): void;
+  dismiss(reason?: MenuOpenReason): void;
+  focusFirstItem(): void;
+  focusLastItem(): void;
 }
 
 let menuId = 0;
@@ -18,181 +23,214 @@ let menuId = 0;
 /** A primary action paired with an `m3-menu` in the named `menu` slot. */
 @customElement('m3-split-button')
 export class M3SplitButton extends LitElement {
-    static styles = m3SplitButtonStyles;
+  static styles = m3SplitButtonStyles;
 
-    @property({ type: String, reflect: true })
-    variant: 'filled' | 'outlined' | 'tonal' | 'elevated' = 'filled';
+  @property({ type: String, reflect: true })
+  variant: 'filled' | 'outlined' | 'tonal' | 'elevated' = 'filled';
 
-    @property({ type: Boolean, reflect: true })
-    open = false;
+  @property({ type: Boolean, reflect: true })
+  open = false;
 
-    @property({ type: Boolean, reflect: true })
-    disabled = false;
+  @property({ type: Boolean, reflect: true })
+  disabled = false;
 
-    @property({ type: String, attribute: 'menu-label' })
-    menuLabel = 'More options';
+  @property({ type: String, attribute: 'menu-label' })
+  menuLabel = 'More options';
 
-    @queryAssignedElements({ slot: 'menu', flatten: true })
-    private _menus!: HTMLElement[];
+  @queryAssignedElements({ slot: 'menu', flatten: true })
+  private _menus!: HTMLElement[];
 
-    private _pendingReason: MenuOpenReason | undefined;
+  private _pendingReason: MenuOpenReason | undefined;
 
-    connectedCallback() {
-        super.connectedCallback();
-        this.addEventListener('menu-open-change', this._handleMenuOpenChange);
-        this.addEventListener('menu-dismiss', this._handleMenuDismiss);
+  connectedCallback() {
+    super.connectedCallback();
+    this.addEventListener('menu-open-change', this._handleMenuOpenChange);
+    this.addEventListener('menu-dismiss', this._handleMenuDismiss);
+  }
+
+  disconnectedCallback() {
+    this.removeEventListener('menu-open-change', this._handleMenuOpenChange);
+    this.removeEventListener('menu-dismiss', this._handleMenuDismiss);
+    super.disconnectedCallback();
+  }
+
+  updated(changedProperties: Map<string, unknown>) {
+    if (!changedProperties.has('open')) {
+      return;
     }
 
-    disconnectedCallback() {
-        this.removeEventListener('menu-open-change', this._handleMenuOpenChange);
-        this.removeEventListener('menu-dismiss', this._handleMenuDismiss);
-        super.disconnectedCallback();
+    const reason = this._pendingReason ?? 'programmatic';
+    this._pendingReason = undefined;
+    const menu = this._menu();
+    if (menu && menu.open !== this.open) {
+      if (this.open) {
+        menu.show(
+          reason === 'programmatic' ? 'programmatic' : 'trigger',
+          this._menuTrigger(),
+        );
+      } else {
+        menu.dismiss(reason);
+      }
     }
+    this.dispatchEvent(
+      new CustomEvent('split-button-open-change', {
+        bubbles: true,
+        composed: true,
+        detail: { open: this.open, reason },
+      }),
+    );
+  }
 
-    updated(changedProperties: Map<string, unknown>) {
-        if (!changedProperties.has('open')) {
-            return;
-        }
-
-        const reason = this._pendingReason ?? 'programmatic';
-        this._pendingReason = undefined;
-        const menu = this._menu();
-        if (menu && menu.open !== this.open) {
-            if (this.open) {
-                menu.show(reason === 'programmatic' ? 'programmatic' : 'trigger', this._menuTrigger());
-            } else {
-                menu.dismiss(reason);
-            }
-        }
-        this.dispatchEvent(new CustomEvent('split-button-open-change', {
-            bubbles: true,
-            composed: true,
-            detail: { open: this.open, reason }
-        }));
-    }
-
-    render() {
-        const controls = this._menu()?.id || undefined;
-        return html`
-      <button class="button" type="button" ?disabled=${this.disabled} @click=${this._handleMainClick}>
+  render() {
+    const controls = this._menu()?.id || undefined;
+    return html`
+      <button
+        class="button"
+        type="button"
+        ?disabled=${this.disabled}
+        @click=${this._handleMainClick}
+      >
         <slot></slot>
       </button>
       <button
         class="menu-button ${this.open ? 'active' : ''}"
         type="button"
         ?disabled=${this.disabled}
-        aria-label=${this.menuLabel}
+        aria-label=${ifDefined(this.menuLabel || undefined)}
         aria-haspopup="menu"
         aria-expanded=${String(this.open)}
         aria-controls=${ifDefined(controls || undefined)}
         @click=${this._toggle}
         @keydown=${this._handleKeydown}
       >
-        <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 -960 960 960" width="24" fill="currentColor" aria-hidden="true">
-          <path d="M480-360 280-560h400L480-360Z"/>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          height="24"
+          viewBox="0 -960 960 960"
+          width="24"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path d="M480-360 280-560h400L480-360Z" />
         </svg>
       </button>
       <slot name="menu" @slotchange=${this._handleMenuSlotChange}></slot>
     `;
+  }
+
+  private _handleMainClick = () => {
+    if (this.disabled) {
+      return;
     }
+    this.dispatchEvent(
+      new CustomEvent('split-button-click', {
+        bubbles: true,
+        composed: true,
+        detail: { action: 'main' },
+      }),
+    );
+  };
 
-    private _handleMainClick = () => {
-        if (this.disabled) {
-            return;
-        }
-        this.dispatchEvent(new CustomEvent('split-button-click', {
-            bubbles: true,
-            composed: true,
-            detail: { action: 'main' }
-        }));
-    };
+  private _handleMenuSlotChange = () => {
+    const menu = this._menu();
+    if (!menu) {
+      return;
+    }
+    if (!menu.id) {
+      menu.id = `m3-split-button-menu-${++menuId}`;
+    }
+    if (menu.open !== this.open) {
+      menu.open = this.open;
+    }
+    this.requestUpdate();
+  };
 
-    private _handleMenuSlotChange = () => {
+  private _handleMenuOpenChange = (event: Event) => {
+    if (event.target === this) {
+      return;
+    }
+    const detail = (
+      event as CustomEvent<{ open: boolean; reason: MenuOpenReason }>
+    ).detail;
+    this._pendingReason = detail.reason;
+    this.open = detail.open;
+  };
+
+  private _handleMenuDismiss = (event: Event) => {
+    if (event.target === this) {
+      return;
+    }
+    const detail = (event as CustomEvent<{ reason: MenuOpenReason }>).detail;
+    if (detail.reason !== 'tab') {
+      this.shadowRoot
+        ?.querySelector<HTMLButtonElement>('.menu-button')
+        ?.focus();
+    }
+    this.dispatchEvent(
+      new CustomEvent('split-button-dismiss', {
+        bubbles: true,
+        composed: true,
+        detail,
+      }),
+    );
+  };
+
+  private _toggle = (event: MouseEvent) => {
+    if (!this.disabled) {
+      (event.currentTarget as HTMLButtonElement).focus();
+      this._requestOpen(!this.open, 'trigger');
+    }
+  };
+
+  private _handleKeydown = (event: KeyboardEvent) => {
+    if (this.disabled) {
+      return;
+    }
+    if (event.key === 'Escape' && this.open) {
+      event.preventDefault();
+      this._requestOpen(false, 'escape');
+      return;
+    }
+    if (
+      !this.open &&
+      ['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(event.key)
+    ) {
+      event.preventDefault();
+      this._requestOpen(true, 'trigger');
+      queueMicrotask(() => {
         const menu = this._menu();
-        if (!menu) {
-            return;
+        if (event.key === 'ArrowUp' || event.key === 'End') {
+          menu?.focusLastItem();
+        } else {
+          menu?.focusFirstItem();
         }
-        if (!menu.id) {
-            menu.id = `m3-split-button-menu-${++menuId}`;
-        }
-        if (menu.open !== this.open) {
-            menu.open = this.open;
-        }
-        this.requestUpdate();
-    };
-
-    private _handleMenuOpenChange = (event: Event) => {
-        if (event.target === this) {
-            return;
-        }
-        const detail = (event as CustomEvent<{ open: boolean; reason: MenuOpenReason }>).detail;
-        this._pendingReason = detail.reason;
-        this.open = detail.open;
-    };
-
-    private _handleMenuDismiss = (event: Event) => {
-        if (event.target === this) {
-            return;
-        }
-        const detail = (event as CustomEvent<{ reason: MenuOpenReason }>).detail;
-        if (detail.reason !== 'tab') {
-            this.shadowRoot?.querySelector<HTMLButtonElement>('.menu-button')?.focus();
-        }
-        this.dispatchEvent(new CustomEvent('split-button-dismiss', {
-            bubbles: true,
-            composed: true,
-            detail
-        }));
-    };
-
-    private _toggle = (event: MouseEvent) => {
-        if (!this.disabled) {
-            (event.currentTarget as HTMLButtonElement).focus();
-            this._requestOpen(!this.open, 'trigger');
-        }
-    };
-
-    private _handleKeydown = (event: KeyboardEvent) => {
-        if (this.disabled) {
-            return;
-        }
-        if (event.key === 'Escape' && this.open) {
-            event.preventDefault();
-            this._requestOpen(false, 'escape');
-            return;
-        }
-        if (!this.open && ['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(event.key)) {
-            event.preventDefault();
-            this._requestOpen(true, 'trigger');
-            queueMicrotask(() => {
-                const menu = this._menu();
-                if (event.key === 'ArrowUp' || event.key === 'End') {
-                    menu?.focusLastItem();
-                } else {
-                    menu?.focusFirstItem();
-                }
-            });
-        }
-    };
-
-    private _requestOpen(open: boolean, reason: MenuOpenReason) {
-        if (this.open !== open) {
-            this._pendingReason = reason;
-            this.open = open;
-        }
+      });
     }
+  };
 
-    private _menu(): MenuElement | null {
-        return (this._menus?.find((element) => element.tagName === 'M3-MENU') as MenuElement | undefined) ?? null;
+  private _requestOpen(open: boolean, reason: MenuOpenReason) {
+    if (this.open !== open) {
+      this._pendingReason = reason;
+      this.open = open;
     }
+  }
 
-    private _menuTrigger(): HTMLButtonElement | null {
-        return this.shadowRoot?.querySelector<HTMLButtonElement>('.menu-button') ?? null;
-    }
+  private _menu(): MenuElement | null {
+    return (
+      (this._menus?.find((element) => element.tagName === 'M3-MENU') as
+        MenuElement | undefined) ?? null
+    );
+  }
+
+  private _menuTrigger(): HTMLButtonElement | null {
+    return (
+      this.shadowRoot?.querySelector<HTMLButtonElement>('.menu-button') ?? null
+    );
+  }
 }
 
 declare global {
-    interface HTMLElementTagNameMap {
-        'm3-split-button': M3SplitButton;
-    }
+  interface HTMLElementTagNameMap {
+    'm3-split-button': M3SplitButton;
+  }
 }

--- a/packages/m3-switch/src/m3-switch.ts
+++ b/packages/m3-switch/src/m3-switch.ts
@@ -1,16 +1,16 @@
-import { html } from 'lit';
+import { html, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { FormAssociatedElement } from '@banegasn/m3-form-associated';
 import { m3SwitchStyles } from './m3-switch.styles.js';
 
 /**
  * Material Design 3 Switch Component
- * 
+ *
  * A switch component following Material Design 3 specifications that allows
  * users to toggle between on and off states.
- * 
+ *
  * Emits native `input` and `change` events when the checked state changes.
- * 
+ *
  * @cssprop --md-comp-switch-track-width - Width of the switch track (default: 52px)
  * @cssprop --md-comp-switch-track-height - Height of the switch track (default: 32px)
  * @cssprop --md-comp-switch-thumb-size - Size of the switch thumb (default: 24px)
@@ -82,9 +82,9 @@ export class M3Switch extends FormAssociatedElement {
         class="switch-container"
         role="switch"
         aria-checked=${this.checked}
-        aria-disabled=${this.isFormDisabled}
-        aria-label=${this.ariaLabel || ''}
-        aria-labelledby=${this.ariaLabelledBy || ''}
+        aria-disabled=${this.isFormDisabled ? 'true' : nothing}
+        aria-label=${this.ariaLabel || nothing}
+        aria-labelledby=${this.ariaLabelledBy || nothing}
         tabindex=${this.isFormDisabled ? -1 : 0}
         @click=${this._handleClick}
         @keydown=${this._handleKeyDown}
@@ -94,13 +94,34 @@ export class M3Switch extends FormAssociatedElement {
         @mousedown=${this._handleMouseDown}
         @mouseup=${this._handleMouseUp}
       >
-        <div class="track" ?checked=${this.checked} ?disabled=${this.isFormDisabled}>
-          <div class="thumb" ?checked=${this.checked} ?disabled=${this.isFormDisabled} ?pressed=${this._pressed}>
-            ${this.checked ? html`
-              <svg class="checkmark" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z" fill="currentColor"/>
-              </svg>
-            ` : ''}
+        <div
+          class="track"
+          ?checked=${this.checked}
+          ?disabled=${this.isFormDisabled}
+        >
+          <div
+            class="thumb"
+            ?checked=${this.checked}
+            ?disabled=${this.isFormDisabled}
+            ?pressed=${this._pressed}
+          >
+            ${
+              this.checked
+                ? html`
+                    <svg
+                      class="checkmark"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                  `
+                : ''
+            }
           </div>
         </div>
       </div>
@@ -178,11 +199,17 @@ export class M3Switch extends FormAssociatedElement {
 
   private _syncFormState(): void {
     const disabled = this.isFormDisabled;
-    this.setFormValue(!disabled && this.checked ? this.value ?? 'on' : null, this.checked ? 'checked' : 'unchecked');
+    this.setFormValue(
+      !disabled && this.checked ? (this.value ?? 'on') : null,
+      this.checked ? 'checked' : 'unchecked',
+    );
     this.setFormValidity(
       !disabled && this.required && !this.checked ? { valueMissing: true } : {},
-      !disabled && this.required && !this.checked ? 'Please turn this switch on.' : '',
-      this.shadowRoot?.querySelector<HTMLElement>('.switch-container') ?? undefined,
+      !disabled && this.required && !this.checked
+        ? 'Please turn this switch on.'
+        : '',
+      this.shadowRoot?.querySelector<HTMLElement>('.switch-container') ??
+        undefined,
     );
   }
 
@@ -190,7 +217,9 @@ export class M3Switch extends FormAssociatedElement {
     this.checked = this._defaultChecked;
   }
 
-  protected restoreFormControlState(state: string | File | FormData | null): void {
+  protected restoreFormControlState(
+    state: string | File | FormData | null,
+  ): void {
     if (typeof state === 'string') {
       this.checked = state === 'checked';
     }
@@ -200,14 +229,18 @@ export class M3Switch extends FormAssociatedElement {
    * Focuses the switch
    */
   focus() {
-    (this.shadowRoot?.querySelector('.switch-container') as HTMLElement)?.focus();
+    (
+      this.shadowRoot?.querySelector('.switch-container') as HTMLElement
+    )?.focus();
   }
 
   /**
    * Removes focus from the switch
    */
   blur() {
-    (this.shadowRoot?.querySelector('.switch-container') as HTMLElement)?.blur();
+    (
+      this.shadowRoot?.querySelector('.switch-container') as HTMLElement
+    )?.blur();
   }
 }
 

--- a/test/semantic-attributes.ts
+++ b/test/semantic-attributes.ts
@@ -1,0 +1,18 @@
+import { expect } from '@open-wc/testing';
+
+/**
+ * Browser-test convention for optional semantics: verify that a component
+ * leaves absent attributes out of its rendered DOM, then run axe against the
+ * same element so a visible/slotted label remains a usable accessible name.
+ */
+export async function expectVisibleNameWithoutOptionalAttributes(
+  element: HTMLElement,
+  attributes: string[],
+): Promise<void> {
+  for (const attribute of attributes) {
+    expect(element.hasAttribute(attribute), `${attribute} should be absent`).to
+      .be.false;
+  }
+
+  await expect(element).to.be.accessible();
+}

--- a/vitest.browser.config.ts
+++ b/vitest.browser.config.ts
@@ -30,6 +30,7 @@ const browserPorts: Record<string, number> = {
   'm3-tabs': 63_334,
   'm3-button': 63_335,
   'm3-chip': 63_336,
+  'm3-badge': 63_337,
 };
 
 const port = browserPorts[workspaceName];


### PR DESCRIPTION
Fixes #21

## Summary
- omit unset optional ARIA, role, tabindex, and IDREF attributes with Lit `nothing`/`ifDefined` across affected component templates
- preserve visible and slotted control names; add the reusable browser regression helper and coverage for buttons, chips, cards, and list items
- make unnamed progress and decorative/hidden badges absent from the accessibility tree; retain named determinate and indeterminate progress semantics
- add focused tests for optional menu labels, menu IDREFs, and radio IDREF absence

## Acceptance mapping
- [x] Optional semantic attributes are omitted rather than rendered empty or as optional false states.
- [x] Visible-label buttons, chips, cards, and items have browser accessibility coverage without `aria-label` masking their content.
- [x] IDREF attributes are omitted when unset; existing dialog/menu contracts continue to generate valid targets.
- [x] Decorative and hidden badges are removed from the accessibility tree; named badges expose a status.
- [x] Named determinate/indeterminate progress semantics are correct; unnamed progress is decorative.
- [x] `test/semantic-attributes.ts` establishes the browser regression convention.

## Validation
- `pnpm typecheck`
- `pnpm lint`
- focused browser tests across Chromium, Firefox, and WebKit for button, chip, badge, list, fab-menu, and split-button
- `pnpm test` exercises all component suites successfully but the existing Angular shell test fails under the available Node 26 runtime because `localStorage` is undefined.