### PR TITLE
test: cover navigation browser contracts

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -82,6 +82,11 @@ jobs:
       - name: Test
         run: pnpm test
 
+      - name: Navigation browser coverage ratchet
+        run: |
+          pnpm --filter @banegasn/m3-navigation-bar test:coverage
+          pnpm --filter @banegasn/m3-navigation-rail test:coverage
+
       - name: Token and motion guard
         run: pnpm tokens:check
 

--- a/README.md
+++ b/README.md
@@ -163,12 +163,14 @@ pnpm dev
 ### Pull-request quality gate
 
 Every pull request to `main` runs the immutable, least-privilege `Quality`
- workflow. Its required status check is **`quality`**. It verifies the
-pinned Node 24.18.0/pnpm 11.12.0 install, linting, type checks, Chromium
-Vitest and Angular tests, generated token and motion files, build output,
+workflow. Its required status check is **`quality`**. It verifies the
+pinned Node 24.18.0/pnpm 11.12.0 install, linting, type checks, Chromium,
+Firefox, and WebKit Vitest and Angular tests, generated token and motion files, build output,
 production dependency audit, packed-package imports (including the Svelte Vite
 consumer), and package licenses. It keeps only dependency and Turbo caches—no
-test artifacts or coverage archives are retained.
+test artifacts or coverage archives are retained. The navigation browser
+contract batch prints its Istanbul coverage summary in the quality log and
+ratchets both covered packages at 100% across the supported browser matrix.
 
 Configure `main` branch protection to require **`quality`** before
 merging, require the branch to be up to date, and restrict bypasses to
@@ -239,9 +241,13 @@ pnpm test
 pnpm build
 ```
 
-`pnpm test` runs the existing browser suites with Playwright. Workspaces that
-do not have tests yet print an explicit temporary status instead of being
-silently skipped; adding their behavioral coverage is tracked in issue #12.
+`pnpm test` runs the existing browser suites with Playwright across Chromium,
+Firefox, and WebKit. Workspaces that do not have tests yet print an explicit
+temporary status instead of being silently skipped; each focused contract batch
+removes that status only for the packages it covers. The first navigation batch
+for issue #12 adds executable layout, event, and cleanup contracts for the
+navigation bar and navigation rail; the remaining public packages stay tracked
+for later focused batches rather than being counted as covered.
 
 Formatting uses the shared Prettier policy:
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@eslint/js": "10.0.1",
     "@open-wc/testing": "5.0.0",
     "@vitest/browser-playwright": "4.1.10",
+    "@vitest/coverage-istanbul": "4.1.10",
     "chai-a11y-axe": "1.5.0",
     "eslint": "10.7.0",
     "eslint-plugin-svelte": "3.20.0",

--- a/packages/m3-navigation-bar/package.json
+++ b/packages/m3-navigation-bar/package.json
@@ -23,8 +23,9 @@
     "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist",
     "lint": "eslint src --max-warnings 0",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node ../../scripts/no-tests.mjs"
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json",
+    "test": "vitest run --config ../../vitest.browser.config.ts",
+    "test:coverage": "vitest run --config ../../vitest.browser.config.ts --coverage"
   },
   "repository": {
     "type": "git",

--- a/packages/m3-navigation-bar/src/m3-navigation-bar.test.ts
+++ b/packages/m3-navigation-bar/src/m3-navigation-bar.test.ts
@@ -1,0 +1,143 @@
+import { expect, fixture, html } from '@open-wc/testing';
+import { describe, it } from 'vitest';
+import {
+  captureCustomEvents,
+  settleLitElement,
+} from '../../../test/lit-browser-contracts.js';
+import './navigation-bar.js';
+import './navigation-bar-item.js';
+import type { M3NavigationBar } from './navigation-bar.js';
+import type { M3NavigationBarItem } from './navigation-bar-item.js';
+
+type ItemClickDetail = { label: string };
+
+describe('M3NavigationBar browser contract', () => {
+  it('exposes a labelled navigation landmark and propagates its layout to slotted items', async () => {
+    const bar = await fixture<M3NavigationBar>(html`
+      <m3-navigation-bar layout="horizontal">
+        <m3-navigation-bar-item label="Home"></m3-navigation-bar-item>
+        <m3-navigation-bar-item label="Search"></m3-navigation-bar-item>
+      </m3-navigation-bar>
+    `);
+    await settleLitElement(bar);
+
+    const navigation = bar.shadowRoot!.querySelector('nav')!;
+    const items = [
+      ...bar.querySelectorAll<M3NavigationBarItem>('m3-navigation-bar-item'),
+    ];
+    expect(navigation.getAttribute('role')).to.equal('navigation');
+    expect(navigation.getAttribute('aria-label')).to.equal('Main navigation');
+    expect(items.map((item) => item.layout)).to.deep.equal([
+      'horizontal',
+      'horizontal',
+    ]);
+    expect(bar).to.be.accessible();
+  });
+
+  it('emits one composed item-click payload from a nested item', async () => {
+    const bar = await fixture<M3NavigationBar>(html`
+      <m3-navigation-bar>
+        <m3-navigation-bar-item label="Inbox"></m3-navigation-bar-item>
+      </m3-navigation-bar>
+    `);
+    const events = captureCustomEvents<ItemClickDetail>(bar, 'item-click');
+
+    try {
+      bar
+        .querySelector<M3NavigationBarItem>('m3-navigation-bar-item')!
+        .shadowRoot!.querySelector<HTMLButtonElement>('button')!
+        .click();
+
+      expect(events.events).to.have.length(1);
+      expect(events.events[0]!.detail).to.deep.equal({ label: 'Inbox' });
+      expect(events.events[0]!.bubbles).to.equal(true);
+      expect(events.events[0]!.composed).to.equal(true);
+    } finally {
+      events.dispose();
+    }
+  });
+
+  it('renders active compact and large badges while retaining the fallback item label', async () => {
+    const root = await fixture<HTMLDivElement>(html`
+      <div>
+        <m3-navigation-bar-item
+          label="Inbox"
+          badge="3"
+          active
+        ></m3-navigation-bar-item>
+        <m3-navigation-bar-item
+          label="Updates"
+          largeBadge="New"
+        ></m3-navigation-bar-item>
+        <m3-navigation-bar-item></m3-navigation-bar-item>
+      </div>
+    `);
+    const [inbox, updates, unnamed] = [
+      ...root.querySelectorAll<M3NavigationBarItem>('m3-navigation-bar-item'),
+    ];
+
+    expect(
+      inbox.shadowRoot!.querySelector('button')!.classList.contains('active'),
+    ).to.equal(true);
+    expect(inbox.shadowRoot!.querySelector('.badge')!.textContent).to.equal(
+      '3',
+    );
+    expect(
+      updates.shadowRoot!.querySelector('.badge-large')!.textContent,
+    ).to.equal('New');
+    expect(
+      updates.shadowRoot!.querySelector('.badge-large-label')!.textContent,
+    ).to.equal('New');
+    expect(
+      unnamed.shadowRoot!.querySelector('button')!.getAttribute('aria-label'),
+    ).to.equal('Navigation item');
+  });
+
+  it('updates auto-layout on resize, removes the resize listener while detached, and restores it on reconnect', async () => {
+    const ownWidth = Object.getOwnPropertyDescriptor(window, 'innerWidth');
+    const setWidth = (width: number) =>
+      Object.defineProperty(window, 'innerWidth', {
+        configurable: true,
+        value: width,
+      });
+    setWidth(480);
+
+    try {
+      const container = await fixture<HTMLDivElement>(html`
+        <div>
+          <m3-navigation-bar auto-layout>
+            <m3-navigation-bar-item label="Home"></m3-navigation-bar-item>
+          </m3-navigation-bar>
+        </div>
+      `);
+      const bar =
+        container.querySelector<M3NavigationBar>('m3-navigation-bar')!;
+      const item = bar.querySelector<M3NavigationBarItem>(
+        'm3-navigation-bar-item',
+      )!;
+      await settleLitElement(bar);
+      expect(item.layout).to.equal('vertical');
+
+      setWidth(800);
+      window.dispatchEvent(new Event('resize'));
+      await settleLitElement(bar);
+      expect(item.layout).to.equal('horizontal');
+
+      bar.remove();
+      setWidth(480);
+      window.dispatchEvent(new Event('resize'));
+      await settleLitElement(item);
+      expect(item.layout).to.equal('horizontal');
+
+      container.append(bar);
+      await settleLitElement(bar);
+      expect(item.layout).to.equal('vertical');
+    } finally {
+      if (ownWidth) {
+        Object.defineProperty(window, 'innerWidth', ownWidth);
+      } else {
+        delete (window as { innerWidth?: number }).innerWidth;
+      }
+    }
+  });
+});

--- a/packages/m3-navigation-bar/src/m3-navigation-bar.test.ts
+++ b/packages/m3-navigation-bar/src/m3-navigation-bar.test.ts
@@ -52,6 +52,7 @@ describe('M3NavigationBar browser contract', () => {
       expect(events.events[0]!.detail).to.deep.equal({ label: 'Inbox' });
       expect(events.events[0]!.bubbles).to.equal(true);
       expect(events.events[0]!.composed).to.equal(true);
+      expect(events.events[0]!.cancelable).to.equal(false);
     } finally {
       events.dispose();
     }

--- a/packages/m3-navigation-bar/tsconfig.test.json
+++ b/packages/m3-navigation-bar/tsconfig.test.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.test.json",
+  "compilerOptions": { "rootDir": "../.." },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/m3-navigation-rail/package.json
+++ b/packages/m3-navigation-rail/package.json
@@ -23,8 +23,9 @@
     "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist",
     "lint": "eslint src --max-warnings 0",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node ../../scripts/no-tests.mjs"
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json",
+    "test": "vitest run --config ../../vitest.browser.config.ts",
+    "test:coverage": "vitest run --config ../../vitest.browser.config.ts --coverage"
   },
   "repository": {
     "type": "git",

--- a/packages/m3-navigation-rail/src/m3-navigation-rail.test.ts
+++ b/packages/m3-navigation-rail/src/m3-navigation-rail.test.ts
@@ -1,0 +1,125 @@
+import { expect, fixture, html } from '@open-wc/testing';
+import { describe, it } from 'vitest';
+import {
+  captureCustomEvents,
+  settleLitElement,
+} from '../../../test/lit-browser-contracts.js';
+import './navigation-rail.js';
+import './navigation-rail-item.js';
+import './navigation-rail-toggle.js';
+import type { M3NavigationRail } from './navigation-rail.js';
+import type { M3NavigationRailItem } from './navigation-rail-item.js';
+import type { M3NavigationRailToggle } from './navigation-rail-toggle.js';
+
+type MenuToggleDetail = { expanded: boolean };
+type ItemClickDetail = { label: string };
+
+describe('M3NavigationRail browser contract', () => {
+  it('propagates a toggle state to every item and reports the new state once', async () => {
+    const rail = await fixture<M3NavigationRail>(html`
+      <m3-navigation-rail>
+        <m3-navigation-rail-toggle></m3-navigation-rail-toggle>
+        <m3-navigation-rail-item label="Home"></m3-navigation-rail-item>
+        <m3-navigation-rail-item
+          slot="bottom"
+          label="Settings"
+        ></m3-navigation-rail-item>
+      </m3-navigation-rail>
+    `);
+    const events = captureCustomEvents<MenuToggleDetail>(rail, 'menu-toggle');
+
+    try {
+      const toggle = rail.querySelector<M3NavigationRailToggle>(
+        'm3-navigation-rail-toggle',
+      )!;
+      const items = [
+        ...rail.querySelectorAll<M3NavigationRailItem>(
+          'm3-navigation-rail-item',
+        ),
+      ];
+      toggle.shadowRoot!.querySelector<HTMLButtonElement>('button')!.click();
+      await settleLitElement(rail);
+
+      expect(rail.expanded).to.equal(true);
+      expect(toggle.expanded).to.equal(true);
+      expect(items.map((item) => item.expanded)).to.deep.equal([true, true]);
+      expect(events.events).to.have.length(1);
+      expect(events.events[0]!.detail).to.deep.equal({ expanded: true });
+      expect(events.events[0]!.bubbles).to.equal(true);
+      expect(events.events[0]!.composed).to.equal(true);
+    } finally {
+      events.dispose();
+    }
+  });
+
+  it('renders assigned bottom navigation separately after the slot settles', async () => {
+    const rail = await fixture<M3NavigationRail>(html`
+      <m3-navigation-rail>
+        <m3-navigation-rail-item label="Home"></m3-navigation-rail-item>
+        <m3-navigation-rail-item
+          slot="bottom"
+          label="Settings"
+        ></m3-navigation-rail-item>
+      </m3-navigation-rail>
+    `);
+    await settleLitElement(rail);
+
+    const bottom = rail.shadowRoot!.querySelector('.bottom-items');
+    expect(bottom).to.exist;
+    expect(bottom!.querySelector('slot')!.name).to.equal('bottom');
+    expect(rail).to.be.accessible();
+  });
+
+  it('keeps item badges in the documented location and bubbles their click details', async () => {
+    const rail = await fixture<M3NavigationRail>(html`
+      <m3-navigation-rail>
+        <m3-navigation-rail-item
+          label="Inbox"
+          badge="3"
+          active
+        ></m3-navigation-rail-item>
+      </m3-navigation-rail>
+    `);
+    const item = rail.querySelector<M3NavigationRailItem>(
+      'm3-navigation-rail-item',
+    )!;
+    const events = captureCustomEvents<ItemClickDetail>(rail, 'item-click');
+
+    try {
+      await settleLitElement(item);
+      expect(item.shadowRoot!.querySelector('.badge')!.textContent).to.equal(
+        '3',
+      );
+      expect(item.shadowRoot!.querySelector('.badge-expanded')).to.not.exist;
+      expect(
+        item.shadowRoot!.querySelector('button')!.getAttribute('aria-current'),
+      ).to.equal('page');
+
+      item.shadowRoot!.querySelector<HTMLButtonElement>('button')!.click();
+      expect(events.events).to.have.length(1);
+      expect(events.events[0]!.detail).to.deep.equal({ label: 'Inbox' });
+
+      rail.expanded = true;
+      await settleLitElement(rail);
+      expect(item.shadowRoot!.querySelector('.badge')).to.not.exist;
+      expect(
+        item.shadowRoot!.querySelector('.badge-expanded')!.textContent,
+      ).to.equal('3');
+    } finally {
+      events.dispose();
+    }
+  });
+
+  it('uses the fallback label and does not render a badge when none is supplied', async () => {
+    const item = await fixture<M3NavigationRailItem>(html`
+      <m3-navigation-rail-item></m3-navigation-rail-item>
+    `);
+    await settleLitElement(item);
+
+    const button = item.shadowRoot!.querySelector('button')!;
+    expect(button.getAttribute('aria-label')).to.equal('Navigation item');
+    expect(item.shadowRoot!.querySelector('.label')).to.not.exist;
+    expect(item.shadowRoot!.querySelector('.badge')).to.not.exist;
+    expect(item.shadowRoot!.querySelector('.badge-expanded')).to.not.exist;
+  });
+});

--- a/packages/m3-navigation-rail/src/m3-navigation-rail.test.ts
+++ b/packages/m3-navigation-rail/src/m3-navigation-rail.test.ts
@@ -32,21 +32,34 @@ describe('M3NavigationRail browser contract', () => {
       const toggle = rail.querySelector<M3NavigationRailToggle>(
         'm3-navigation-rail-toggle',
       )!;
+      const toggleEvents = captureCustomEvents<undefined>(
+        toggle,
+        'toggle-click',
+      );
       const items = [
         ...rail.querySelectorAll<M3NavigationRailItem>(
           'm3-navigation-rail-item',
         ),
       ];
-      toggle.shadowRoot!.querySelector<HTMLButtonElement>('button')!.click();
-      await settleLitElement(rail);
+      try {
+        toggle.shadowRoot!.querySelector<HTMLButtonElement>('button')!.click();
+        await settleLitElement(rail);
 
-      expect(rail.expanded).to.equal(true);
-      expect(toggle.expanded).to.equal(true);
-      expect(items.map((item) => item.expanded)).to.deep.equal([true, true]);
-      expect(events.events).to.have.length(1);
-      expect(events.events[0]!.detail).to.deep.equal({ expanded: true });
-      expect(events.events[0]!.bubbles).to.equal(true);
-      expect(events.events[0]!.composed).to.equal(true);
+        expect(rail.expanded).to.equal(true);
+        expect(toggle.expanded).to.equal(true);
+        expect(items.map((item) => item.expanded)).to.deep.equal([true, true]);
+        expect(events.events).to.have.length(1);
+        expect(events.events[0]!.detail).to.deep.equal({ expanded: true });
+        expect(events.events[0]!.bubbles).to.equal(true);
+        expect(events.events[0]!.composed).to.equal(true);
+        expect(events.events[0]!.cancelable).to.equal(false);
+        expect(toggleEvents.events).to.have.length(1);
+        expect(toggleEvents.events[0]!.bubbles).to.equal(true);
+        expect(toggleEvents.events[0]!.composed).to.equal(true);
+        expect(toggleEvents.events[0]!.cancelable).to.equal(false);
+      } finally {
+        toggleEvents.dispose();
+      }
     } finally {
       events.dispose();
     }
@@ -98,6 +111,9 @@ describe('M3NavigationRail browser contract', () => {
       item.shadowRoot!.querySelector<HTMLButtonElement>('button')!.click();
       expect(events.events).to.have.length(1);
       expect(events.events[0]!.detail).to.deep.equal({ label: 'Inbox' });
+      expect(events.events[0]!.bubbles).to.equal(true);
+      expect(events.events[0]!.composed).to.equal(true);
+      expect(events.events[0]!.cancelable).to.equal(false);
 
       rail.expanded = true;
       await settleLitElement(rail);

--- a/packages/m3-navigation-rail/tsconfig.test.json
+++ b/packages/m3-navigation-rail/tsconfig.test.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.test.json",
+  "compilerOptions": { "rootDir": "../.." },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@vitest/browser-playwright':
         specifier: 4.1.10
         version: 4.1.10(playwright@1.62.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(less@4.4.0)(sass@1.99.0)(terser@5.43.1))(vitest@4.1.10)
+      '@vitest/coverage-istanbul':
+        specifier: 4.1.10
+        version: 4.1.10(vitest@4.1.10)
       chai-a11y-axe:
         specifier: 1.5.0
         version: 1.5.0
@@ -46,7 +49,7 @@ importers:
         version: 8.63.0(eslint@10.7.0(jiti@1.21.7))(typescript@5.9.3)
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(jsdom@30.0.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(less@4.4.0)(sass@1.99.0)(terser@5.43.1))
+        version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(jsdom@30.0.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(less@4.4.0)(sass@1.99.0)(terser@5.43.1))
 
   apps/angular-app:
     dependencies:
@@ -185,7 +188,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(jsdom@30.0.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(less@4.4.0)(sass@1.99.0)(terser@5.43.1))
+        version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(jsdom@30.0.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(less@4.4.0)(sass@1.99.0)(terser@5.43.1))
       xhr2:
         specifier: ^0.2.1
         version: 0.2.1
@@ -2445,6 +2448,11 @@ packages:
     peerDependencies:
       vitest: 4.1.10
 
+  '@vitest/coverage-istanbul@4.1.10':
+    resolution: {integrity: sha512-AyNJ5pQRFqCX7pwB9PSTmoVKPaZ4H5IEVJfJsT+q1DYkXvZMEFYgJlyk5sfStmt9rVYRyYYRRsuBeImCOc39ww==}
+    peerDependencies:
+      vitest: 4.1.10
+
   '@vitest/expect@4.1.10':
     resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
 
@@ -3706,6 +3714,9 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.3:
+    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
 
   make-dir@2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
@@ -5048,7 +5059,7 @@ snapshots:
       less: 4.4.0
       lmdb: 3.5.4
       postcss: 8.5.6
-      vitest: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(jsdom@30.0.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(less@4.4.0)(sass@1.99.0)(terser@5.43.1))
+      vitest: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(jsdom@30.0.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(less@4.4.0)(sass@1.99.0)(terser@5.43.1))
     transitivePeerDependencies:
       - '@types/node'
       - chokidar
@@ -5715,8 +5726,7 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
-  '@istanbuljs/schema@0.1.3':
-    optional: true
+  '@istanbuljs/schema@0.1.3': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -6591,7 +6601,7 @@ snapshots:
       '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(less@4.4.0)(sass@1.99.0)(terser@5.43.1))
       playwright: 1.62.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(jsdom@30.0.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(less@4.4.0)(sass@1.99.0)(terser@5.43.1))
+      vitest: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(jsdom@30.0.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(less@4.4.0)(sass@1.99.0)(terser@5.43.1))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -6607,13 +6617,29 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(jsdom@30.0.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(less@4.4.0)(sass@1.99.0)(terser@5.43.1))
+      vitest: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(jsdom@30.0.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(less@4.4.0)(sass@1.99.0)(terser@5.43.1))
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
+
+  '@vitest/coverage-istanbul@4.1.10(vitest@4.1.10)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@istanbuljs/schema': 0.1.3
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.3
+      obug: 2.1.3
+      tinyrainbow: 3.1.0
+      vitest: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(jsdom@30.0.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(less@4.4.0)(sass@1.99.0)(terser@5.43.1))
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -8038,6 +8064,12 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  magicast@0.5.3:
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      source-map-js: 1.2.1
+
   make-dir@2.1.0:
     dependencies:
       pify: 4.0.1
@@ -9083,7 +9115,7 @@ snapshots:
     optionalDependencies:
       vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(less@4.4.0)(sass@1.99.0)(terser@5.43.1)
 
-  vitest@4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(jsdom@30.0.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(less@4.4.0)(sass@1.99.0)(terser@5.43.1)):
+  vitest@4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(jsdom@30.0.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(less@4.4.0)(sass@1.99.0)(terser@5.43.1)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(less@4.4.0)(sass@1.99.0)(terser@5.43.1))
@@ -9108,6 +9140,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.13.3
       '@vitest/browser-playwright': 4.1.10(playwright@1.62.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(less@4.4.0)(sass@1.99.0)(terser@5.43.1))(vitest@4.1.10)
+      '@vitest/coverage-istanbul': 4.1.10(vitest@4.1.10)
       jsdom: 30.0.0
     transitivePeerDependencies:
       - msw

--- a/test/lit-browser-contracts.ts
+++ b/test/lit-browser-contracts.ts
@@ -1,0 +1,27 @@
+/**
+ * Wait for Lit to finish its update, then let the browser apply the rendered
+ * DOM. Browser suites use this instead of arbitrary timer delays.
+ */
+export async function settleLitElement(element: {
+  updateComplete: Promise<unknown>;
+}) {
+  await element.updateComplete;
+  await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+  await element.updateComplete;
+}
+
+/**
+ * Collect typed custom events and make listener teardown explicit in tests.
+ * The component contracts can therefore assert both event payloads and the
+ * cleanup that keeps a detached fixture from retaining test listeners.
+ */
+export function captureCustomEvents<Detail>(target: EventTarget, type: string) {
+  const events: CustomEvent<Detail>[] = [];
+  const listener = (event: Event) => events.push(event as CustomEvent<Detail>);
+  target.addEventListener(type, listener);
+
+  return {
+    events,
+    dispose: () => target.removeEventListener(type, listener),
+  };
+}

--- a/test/open-wc-vitest.ts
+++ b/test/open-wc-vitest.ts
@@ -10,3 +10,4 @@ import { chaiA11yAxe } from 'chai-a11y-axe';
 chai.use(chaiA11yAxe);
 
 export * from '@open-wc/testing/pure';
+export * from './lit-browser-contracts.js';

--- a/vitest.browser.config.ts
+++ b/vitest.browser.config.ts
@@ -31,6 +31,29 @@ const browserPorts: Record<string, number> = {
   'm3-button': 63_335,
   'm3-chip': 63_336,
   'm3-badge': 63_337,
+  'm3-navigation-bar': 63_338,
+  'm3-navigation-rail': 63_339,
+};
+
+const browserCoverageThresholds: Record<
+  string,
+  { branches: number; functions: number; lines: number; statements: number }
+> = {
+  // This first issue #12 batch ratchets the two newly covered navigation
+  // packages. Future batches add their own baseline only after browser tests
+  // exercise every included production source file.
+  'm3-navigation-bar': {
+    branches: 100,
+    functions: 100,
+    lines: 100,
+    statements: 100,
+  },
+  'm3-navigation-rail': {
+    branches: 100,
+    functions: 100,
+    lines: 100,
+    statements: 100,
+  },
 };
 
 const port = browserPorts[workspaceName];
@@ -54,6 +77,15 @@ export default defineConfig({
     globals: false,
     passWithNoTests: false,
     setupFiles: [path.join(configDirectory, 'test/vitest-browser-setup.ts')],
+    // Istanbul instruments browser bundles in every Playwright engine. V8
+    // coverage would restrict this contract lane to Chromium.
+    coverage: {
+      provider: 'istanbul',
+      reporter: ['text', 'json-summary'],
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.test.ts', 'src/index.ts'],
+      thresholds: browserCoverageThresholds[workspaceName],
+    },
     browser: {
       enabled: true,
       headless: true,


### PR DESCRIPTION
## Summary

Partially addresses #12.

This is the first focused browser-contract batch. It deliberately covers only the public navigation family:

- @banegasn/m3-navigation-bar
- @banegasn/m3-navigation-rail

It adds reusable Lit browser-contract helpers; deterministic layout, event, slot, accessibility, reconnect-cleanup coverage; and an Istanbul browser-coverage ratchet. The two packages run in Chromium, Firefox, and WebKit and are ratcheted at 100% statements, branches, functions, and lines. CI prints the summaries without retaining coverage artifacts.

## Follow-up plan

Continue #12 in focused public component-family batches (for example, button/chip/badge or input controls), adding a package to the ratchet only after all of that package production source is exercised in the three-browser matrix. Do not treat the remaining packages that still use the explicit temporary no-test status as covered.

## Validation

- pnpm lint
- pnpm typecheck
- pnpm --filter @banegasn/m3-navigation-bar test:coverage
- pnpm --filter @banegasn/m3-navigation-rail test:coverage
- pnpm tokens:check
- pnpm build
- pnpm audit:prod
- pnpm smoke:packages
- pnpm smoke:svelte-vite
- pnpm verify:package-licenses

pnpm test is otherwise clean for this batch but currently fails on the pre-existing WebKit-only m3-menu test synchronously hides and escapes the menu when a real Tab key moves focus: WebKit leaves document.activeElement on body instead of the expected next button. This PR does not modify the already-merged menu contract.