### PR TITLE
fix: react to dynamic optional slots

### DIFF
--- a/packages/m3-button/package.json
+++ b/packages/m3-button/package.json
@@ -23,8 +23,9 @@
     "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist",
     "lint": "eslint src --max-warnings 0",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node ../../scripts/no-tests.mjs"
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json",
+    "test": "vitest run --config ../../vitest.browser.config.ts",
+    "test:watch": "vitest --config ../../vitest.browser.config.ts"
   },
   "repository": {
     "type": "git",

--- a/packages/m3-button/src/m3-button.styles.ts
+++ b/packages/m3-button/src/m3-button.styles.ts
@@ -114,6 +114,10 @@ export const m3ButtonStyles = css`
     -webkit-tap-highlight-color: transparent;
   }
 
+  .icon[hidden] {
+    display: none;
+  }
+
   button:focus-visible {
     outline: 2px solid var(--md-sys-color-primary, #6750a4);
     outline-offset: 2px;

--- a/packages/m3-button/src/m3-button.test.ts
+++ b/packages/m3-button/src/m3-button.test.ts
@@ -1,0 +1,56 @@
+import { html, fixture, expect } from '@open-wc/testing';
+import { describe, it } from 'vitest';
+import './m3-button.js';
+import type { M3Button } from './m3-button.js';
+
+async function settleSlotChange(el: M3Button) {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await el.updateComplete;
+}
+
+describe('M3Button icon slot', () => {
+  it('collapses the icon region when initially absent', async () => {
+    const el = await fixture<M3Button>(html`<m3-button>Save</m3-button>`);
+    expect(el.shadowRoot!.querySelector('.icon')!.hasAttribute('hidden')).to.be
+      .true;
+  });
+
+  it('shows initially assigned icon content', async () => {
+    const el = await fixture<M3Button>(
+      html`<m3-button><span slot="icon">+</span>Save</m3-button>`,
+    );
+    await settleSlotChange(el);
+    expect(el.shadowRoot!.querySelector('.icon')!.hasAttribute('hidden')).to.be
+      .false;
+  });
+
+  it('reacts to icon add, remove, reassignment, and reconnect', async () => {
+    const el = await fixture<M3Button>(html`<m3-button>Save</m3-button>`);
+    const icon = document.createElement('span');
+    icon.slot = 'icon';
+    icon.textContent = '+';
+
+    el.append(icon);
+    await settleSlotChange(el);
+    expect(el.shadowRoot!.querySelector('.icon')!.hasAttribute('hidden')).to.be
+      .false;
+
+    icon.slot = '';
+    await settleSlotChange(el);
+    expect(el.shadowRoot!.querySelector('.icon')!.hasAttribute('hidden')).to.be
+      .true;
+
+    el.remove();
+    document.body.append(el);
+    icon.slot = 'icon';
+    await settleSlotChange(el);
+    expect(el.shadowRoot!.querySelector('.icon')!.hasAttribute('hidden')).to.be
+      .false;
+
+    icon.remove();
+    await settleSlotChange(el);
+    expect(el.shadowRoot!.querySelector('.icon')!.hasAttribute('hidden')).to.be
+      .true;
+    el.remove();
+  });
+});

--- a/packages/m3-button/src/m3-button.ts
+++ b/packages/m3-button/src/m3-button.ts
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import { FormAssociatedElement } from '@banegasn/m3-form-associated';
 import { m3ButtonStyles } from './m3-button.styles.js';
 
@@ -119,6 +119,9 @@ export class M3Button extends FormAssociatedElement {
   @property({ type: String, reflect: true })
   value: string | null = null;
 
+  @state()
+  private _hasIcon = false;
+
   render() {
     return html`
       <button
@@ -129,11 +132,9 @@ export class M3Button extends FormAssociatedElement {
         @click=${this._handleClick}
       >
         ${this.loading ? html`<span class="loading-spinner"></span>` : ''}
-        ${this._hasIcon() ? html`
-          <span class="icon">
-            <slot name="icon"></slot>
-          </span>
-        ` : ''}
+        <span class="icon" ?hidden=${!this._hasIcon}>
+          <slot name="icon" @slotchange=${this._handleIconSlotChange}></slot>
+        </span>
         ${!this.iconOnly ? html`
           <span class="label">
             <slot></slot>
@@ -143,8 +144,21 @@ export class M3Button extends FormAssociatedElement {
     `;
   }
 
-  private _hasIcon(): boolean {
-    return this.querySelector('[slot="icon"]') !== null;
+  firstUpdated() {
+    this._hasIcon = this._slotHasContent('icon');
+  }
+
+  private _handleIconSlotChange = () => {
+    queueMicrotask(() => {
+      this._hasIcon = this._slotHasContent('icon');
+    });
+  };
+
+  private _slotHasContent(name: string): boolean {
+    return this.shadowRoot
+      ?.querySelector<HTMLSlotElement>(`slot[name="${name}"]`)
+      ?.assignedNodes({ flatten: true })
+      .some((node) => node.nodeType === Node.ELEMENT_NODE || (node.textContent ?? '').trim().length > 0) ?? false;
   }
 
   private _handleClick(e: MouseEvent) {

--- a/packages/m3-button/tsconfig.test.json
+++ b/packages/m3-button/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.test.json",
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/m3-chip/package.json
+++ b/packages/m3-chip/package.json
@@ -23,8 +23,9 @@
     "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist",
     "lint": "eslint src --max-warnings 0",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node ../../scripts/no-tests.mjs"
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json",
+    "test": "vitest run --config ../../vitest.browser.config.ts",
+    "test:watch": "vitest --config ../../vitest.browser.config.ts"
   },
   "repository": {
     "type": "git",

--- a/packages/m3-chip/src/m3-chip.styles.ts
+++ b/packages/m3-chip/src/m3-chip.styles.ts
@@ -117,6 +117,10 @@ export const m3ChipStyles = css`
     margin-left: -4px;
   }
 
+  .leading-icon[hidden] {
+    display: none;
+  }
+
   .trailing-icon {
     margin-right: -4px;
   }

--- a/packages/m3-chip/src/m3-chip.test.ts
+++ b/packages/m3-chip/src/m3-chip.test.ts
@@ -1,0 +1,62 @@
+import { html, fixture, expect } from '@open-wc/testing';
+import { describe, it } from 'vitest';
+import './m3-chip.js';
+import type { M3Chip } from './m3-chip.js';
+
+async function settleSlotChange(el: M3Chip) {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await el.updateComplete;
+}
+
+describe('M3Chip icon slot', () => {
+  it('collapses the icon region when initially absent', async () => {
+    const el = await fixture<M3Chip>(html`<m3-chip>Tag</m3-chip>`);
+    expect(
+      el.shadowRoot!.querySelector('.leading-icon')!.hasAttribute('hidden'),
+    ).to.be.true;
+  });
+
+  it('shows initially assigned icon content', async () => {
+    const el = await fixture<M3Chip>(
+      html`<m3-chip><span slot="icon">#</span>Tag</m3-chip>`,
+    );
+    await settleSlotChange(el);
+    expect(
+      el.shadowRoot!.querySelector('.leading-icon')!.hasAttribute('hidden'),
+    ).to.be.false;
+  });
+
+  it('reacts to icon add, remove, reassignment, and reconnect', async () => {
+    const el = await fixture<M3Chip>(html`<m3-chip>Tag</m3-chip>`);
+    const icon = document.createElement('span');
+    icon.slot = 'icon';
+    icon.textContent = '#';
+
+    el.append(icon);
+    await settleSlotChange(el);
+    expect(
+      el.shadowRoot!.querySelector('.leading-icon')!.hasAttribute('hidden'),
+    ).to.be.false;
+
+    icon.slot = '';
+    await settleSlotChange(el);
+    expect(
+      el.shadowRoot!.querySelector('.leading-icon')!.hasAttribute('hidden'),
+    ).to.be.true;
+
+    el.remove();
+    document.body.append(el);
+    icon.slot = 'icon';
+    await settleSlotChange(el);
+    expect(
+      el.shadowRoot!.querySelector('.leading-icon')!.hasAttribute('hidden'),
+    ).to.be.false;
+
+    icon.remove();
+    await settleSlotChange(el);
+    expect(
+      el.shadowRoot!.querySelector('.leading-icon')!.hasAttribute('hidden'),
+    ).to.be.true;
+    el.remove();
+  });
+});

--- a/packages/m3-chip/src/m3-chip.ts
+++ b/packages/m3-chip/src/m3-chip.ts
@@ -1,5 +1,5 @@
 import { LitElement, html } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import { m3ChipStyles } from './m3-chip.styles.js';
 
 /**
@@ -39,9 +39,11 @@ export class M3Chip extends LitElement {
   /** ARIA label */
   @property({ type: String, attribute: 'aria-label' }) ariaLabel: string | null = null;
 
+  @state()
+  private _hasIcon = false;
+
   render() {
-    const hasIcon = this.querySelector('[slot="icon"]');
-    const showLeadingIcon = (this.variant === 'filter' && this.selected) || hasIcon;
+    const showLeadingIcon = (this.variant === 'filter' && this.selected) || this._hasIcon;
 
     return html`
       <button
@@ -52,14 +54,13 @@ export class M3Chip extends LitElement {
         aria-label=${this.ariaLabel || ''}
         @click=${this._handleClick}
       >
-        ${showLeadingIcon ? html`
-          <span class="leading-icon">
-            ${this.variant === 'filter' && this.selected
-              ? html`<svg class="checkmark" viewBox="0 0 18 18" width="18" height="18"><path d="M7 13.5L3 9.5l1.4-1.4L7 10.7l7.6-7.6L16 4.5l-9 9z" fill="currentColor"/></svg>`
-              : html`<slot name="icon"></slot>`
-            }
-          </span>
-        ` : ''}
+        <span class="leading-icon" ?hidden=${!showLeadingIcon}>
+          ${this.variant === 'filter' && this.selected
+            ? html`<svg class="checkmark" viewBox="0 0 18 18" width="18" height="18"><path d="M7 13.5L3 9.5l1.4-1.4L7 10.7l7.6-7.6L16 4.5l-9 9z" fill="currentColor"/></svg>`
+            : ''
+          }
+          <slot name="icon" ?hidden=${this.variant === 'filter' && this.selected} @slotchange=${this._handleIconSlotChange}></slot>
+        </span>
 
         <span class="label">
           <slot></slot>
@@ -73,6 +74,23 @@ export class M3Chip extends LitElement {
         <div class="state-layer"></div>
       </button>
     `;
+  }
+
+  firstUpdated() {
+    this._hasIcon = this._slotHasContent('icon');
+  }
+
+  private _handleIconSlotChange = () => {
+    queueMicrotask(() => {
+      this._hasIcon = this._slotHasContent('icon');
+    });
+  };
+
+  private _slotHasContent(name: string): boolean {
+    return this.shadowRoot
+      ?.querySelector<HTMLSlotElement>(`slot[name="${name}"]`)
+      ?.assignedNodes({ flatten: true })
+      .some((node) => node.nodeType === Node.ELEMENT_NODE || (node.textContent ?? '').trim().length > 0) ?? false;
   }
 
   private _handleClick() {

--- a/packages/m3-chip/tsconfig.test.json
+++ b/packages/m3-chip/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.test.json",
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/m3-list/src/m3-list-item.styles.ts
+++ b/packages/m3-list/src/m3-list-item.styles.ts
@@ -77,6 +77,13 @@ export const m3ListItemStyles = css`
     color: var(--md-sys-color-on-surface-variant, #49454f);
   }
 
+  .leading[hidden],
+  .trailing[hidden],
+  .supporting-text[hidden],
+  .tertiary-text[hidden] {
+    display: none;
+  }
+
   /* Trailing content */
   .trailing {
     display: flex;

--- a/packages/m3-list/src/m3-list-item.ts
+++ b/packages/m3-list/src/m3-list-item.ts
@@ -1,6 +1,6 @@
 import { LitElement, html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import { m3ListItemStyles } from './m3-list-item.styles.js';
 
 /**
@@ -75,12 +75,12 @@ export class M3ListItem extends LitElement {
   @property({ type: String })
   value: string | null = null;
 
-  render() {
-    const hasLeading = this.querySelector('[slot="leading"]');
-    const hasTrailing = this.querySelector('[slot="trailing"]');
-    const hasSupporting = this.querySelector('[slot="supporting-text"]');
-    const hasTertiary = this.querySelector('[slot="tertiary-text"]');
+  @state() private _hasLeading = false;
+  @state() private _hasTrailing = false;
+  @state() private _hasSupporting = false;
+  @state() private _hasTertiary = false;
 
+  render() {
     return html`
       <li
         class="item"
@@ -93,23 +93,41 @@ export class M3ListItem extends LitElement {
         @keydown=${this._handleKeydown}
       >
         <div class="state-layer"></div>
-        ${hasLeading ? html`
-          <div class="leading">
-            <slot name="leading"></slot>
-          </div>
-        ` : ''}
+        <div class="leading" ?hidden=${!this._hasLeading}>
+          <slot name="leading" @slotchange=${this._handleSlotChange}></slot>
+        </div>
         <div class="content">
           <span class="headline"><slot></slot></span>
-          ${hasSupporting ? html`<span class="supporting-text"><slot name="supporting-text"></slot></span>` : ''}
-          ${hasTertiary ? html`<span class="tertiary-text"><slot name="tertiary-text"></slot></span>` : ''}
+          <span class="supporting-text" ?hidden=${!this._hasSupporting}><slot name="supporting-text" @slotchange=${this._handleSlotChange}></slot></span>
+          <span class="tertiary-text" ?hidden=${!this._hasTertiary}><slot name="tertiary-text" @slotchange=${this._handleSlotChange}></slot></span>
         </div>
-        ${hasTrailing ? html`
-          <div class="trailing">
-            <slot name="trailing"></slot>
-          </div>
-        ` : ''}
+        <div class="trailing" ?hidden=${!this._hasTrailing}>
+          <slot name="trailing" @slotchange=${this._handleSlotChange}></slot>
+        </div>
       </li>
     `;
+  }
+
+  firstUpdated() {
+    this._syncSlotState();
+  }
+
+  private _handleSlotChange = () => {
+    queueMicrotask(() => this._syncSlotState());
+  };
+
+  private _syncSlotState() {
+    this._hasLeading = this._slotHasContent('leading');
+    this._hasTrailing = this._slotHasContent('trailing');
+    this._hasSupporting = this._slotHasContent('supporting-text');
+    this._hasTertiary = this._slotHasContent('tertiary-text');
+  }
+
+  private _slotHasContent(name: string): boolean {
+    return this.shadowRoot
+      ?.querySelector<HTMLSlotElement>(`slot[name="${name}"]`)
+      ?.assignedNodes({ flatten: true })
+      .some((node) => node.nodeType === Node.ELEMENT_NODE || (node.textContent ?? '').trim().length > 0) ?? false;
   }
 
   private _handleClick() {

--- a/packages/m3-list/src/m3-list.test.ts
+++ b/packages/m3-list/src/m3-list.test.ts
@@ -5,6 +5,11 @@ import './m3-list-item.js';
 import type { M3List } from './m3-list.js';
 import type { M3ListItem } from './m3-list-item.js';
 
+async function settleSlotChange(el: M3ListItem) {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await el.updateComplete;
+}
+
 describe('M3List', () => {
   it('renders a list container', async () => {
     const el = await fixture<M3List>(html`<m3-list></m3-list>`);
@@ -84,6 +89,7 @@ describe('M3ListItem', () => {
     `);
     const leading = el.shadowRoot!.querySelector('.leading');
     expect(leading).to.exist;
+    expect(leading!.hasAttribute('hidden')).to.be.false;
   });
 
   it('supports trailing slot', async () => {
@@ -95,6 +101,42 @@ describe('M3ListItem', () => {
     `);
     const trailing = el.shadowRoot!.querySelector('.trailing');
     expect(trailing).to.exist;
+    expect(trailing!.hasAttribute('hidden')).to.be.false;
+  });
+
+  it('keeps initially absent optional regions collapsed', async () => {
+    const el = await fixture<M3ListItem>(html`<m3-list-item>Headline</m3-list-item>`);
+    for (const selector of ['.leading', '.supporting-text', '.tertiary-text', '.trailing']) {
+      expect(el.shadowRoot!.querySelector(selector)!.hasAttribute('hidden')).to.be.true;
+    }
+  });
+
+  it('reacts to optional content add, remove, reassignment, and reconnect', async () => {
+    const el = await fixture<M3ListItem>(html`<m3-list-item>Headline</m3-list-item>`);
+    const content = document.createElement('span');
+    content.slot = 'leading';
+    content.textContent = 'Icon';
+
+    el.append(content);
+    await settleSlotChange(el);
+    expect(el.shadowRoot!.querySelector('.leading')!.hasAttribute('hidden')).to.be.false;
+
+    content.slot = 'trailing';
+    await settleSlotChange(el);
+    expect(el.shadowRoot!.querySelector('.leading')!.hasAttribute('hidden')).to.be.true;
+    expect(el.shadowRoot!.querySelector('.trailing')!.hasAttribute('hidden')).to.be.false;
+
+    content.slot = 'supporting-text';
+    await settleSlotChange(el);
+    expect(el.shadowRoot!.querySelector('.trailing')!.hasAttribute('hidden')).to.be.true;
+    expect(el.shadowRoot!.querySelector('.supporting-text')!.hasAttribute('hidden')).to.be.false;
+
+    el.remove();
+    document.body.append(el);
+    content.remove();
+    await settleSlotChange(el);
+    expect(el.shadowRoot!.querySelector('.supporting-text')!.hasAttribute('hidden')).to.be.true;
+    el.remove();
   });
 
   it('supports shape variants', async () => {

--- a/packages/m3-snackbar/src/m3-snackbar.styles.ts
+++ b/packages/m3-snackbar/src/m3-snackbar.styles.ts
@@ -40,6 +40,10 @@ export const m3SnackbarStyles = css`
     flex-shrink: 0;
   }
 
+  .action[hidden] {
+    display: none;
+  }
+
   /* Two-line snackbar for longer messages */
   :host([lines="2"]) .snackbar {
     min-height: 68px;

--- a/packages/m3-snackbar/src/m3-snackbar.test.ts
+++ b/packages/m3-snackbar/src/m3-snackbar.test.ts
@@ -3,6 +3,11 @@ import { describe, it } from 'vitest';
 import './m3-snackbar.js';
 import type { M3Snackbar } from './m3-snackbar.js';
 
+async function settleSlotChange(el: M3Snackbar) {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await el.updateComplete;
+}
+
 describe('M3Snackbar', () => {
   it('is hidden by default', async () => {
     const el = await fixture<M3Snackbar>(html`<m3-snackbar></m3-snackbar>`);
@@ -31,6 +36,39 @@ describe('M3Snackbar', () => {
     `);
     const action = el.shadowRoot!.querySelector('.action');
     expect(action).to.exist;
+    await settleSlotChange(el);
+    expect(action!.hasAttribute('hidden')).to.be.false;
+  });
+
+  it('keeps an initially absent action region collapsed', async () => {
+    const el = await fixture<M3Snackbar>(html`<m3-snackbar open>Message</m3-snackbar>`);
+    expect(el.shadowRoot!.querySelector('.action')!.hasAttribute('hidden')).to.be.true;
+  });
+
+  it('reacts to action add, remove, reassignment, and reconnect', async () => {
+    const el = await fixture<M3Snackbar>(html`<m3-snackbar open duration="0">Message</m3-snackbar>`);
+    const action = document.createElement('button');
+    action.slot = 'action';
+    action.textContent = 'Undo';
+
+    el.append(action);
+    await settleSlotChange(el);
+    expect(el.shadowRoot!.querySelector('.action')!.hasAttribute('hidden')).to.be.false;
+
+    action.slot = '';
+    await settleSlotChange(el);
+    expect(el.shadowRoot!.querySelector('.action')!.hasAttribute('hidden')).to.be.true;
+
+    el.remove();
+    document.body.append(el);
+    action.slot = 'action';
+    await settleSlotChange(el);
+    expect(el.shadowRoot!.querySelector('.action')!.hasAttribute('hidden')).to.be.false;
+
+    action.remove();
+    await settleSlotChange(el);
+    expect(el.shadowRoot!.querySelector('.action')!.hasAttribute('hidden')).to.be.true;
+    el.remove();
   });
 
   it('dispatches snackbar-dismiss on dismiss', async () => {

--- a/packages/m3-snackbar/src/m3-snackbar.ts
+++ b/packages/m3-snackbar/src/m3-snackbar.ts
@@ -1,5 +1,5 @@
 import { LitElement, html } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import { m3SnackbarStyles } from './m3-snackbar.styles.js';
 import { motionDuration } from './motion-duration.js';
 
@@ -57,6 +57,9 @@ export class M3Snackbar extends LitElement {
 
   private _dismissTimer: ReturnType<typeof setTimeout> | null = null;
   private _isLeaving = false;
+
+  @state()
+  private _hasAction = false;
 
   updated(changedProperties: Map<string, unknown>) {
     if (changedProperties.has('open')) {
@@ -126,8 +129,6 @@ export class M3Snackbar extends LitElement {
   render() {
     if (!this.open) return html``;
 
-    const hasAction = this.querySelector('[slot="action"]');
-
     return html`
       <div
         class="snackbar ${this._isLeaving ? 'leaving' : ''}"
@@ -138,13 +139,28 @@ export class M3Snackbar extends LitElement {
         <span class="message">
           <slot>${this.message}</slot>
         </span>
-        ${hasAction ? html`
-          <span class="action" @click=${this._handleActionClick}>
-            <slot name="action"></slot>
-          </span>
-        ` : ''}
+        <span class="action" ?hidden=${!this._hasAction} @click=${this._handleActionClick}>
+          <slot name="action" @slotchange=${this._handleActionSlotChange}></slot>
+        </span>
       </div>
     `;
+  }
+
+  firstUpdated() {
+    this._hasAction = this._slotHasContent();
+  }
+
+  private _handleActionSlotChange = () => {
+    queueMicrotask(() => {
+      this._hasAction = this._slotHasContent();
+    });
+  };
+
+  private _slotHasContent(): boolean {
+    return this.shadowRoot
+      ?.querySelector<HTMLSlotElement>('slot[name="action"]')
+      ?.assignedNodes({ flatten: true })
+      .some((node) => node.nodeType === Node.ELEMENT_NODE || (node.textContent ?? '').trim().length > 0) ?? false;
   }
 }
 

--- a/packages/m3-top-app-bar/src/m3-top-app-bar.styles.ts
+++ b/packages/m3-top-app-bar/src/m3-top-app-bar.styles.ts
@@ -38,6 +38,11 @@ export const m3TopAppBarStyles = css`
     margin-right: 8px;
   }
 
+  .navigation-icon[hidden],
+  .actions[hidden] {
+    display: none;
+  }
+
   /* Headline / title */
   .headline {
     flex: 1;

--- a/packages/m3-top-app-bar/src/m3-top-app-bar.test.ts
+++ b/packages/m3-top-app-bar/src/m3-top-app-bar.test.ts
@@ -3,6 +3,11 @@ import { describe, it } from 'vitest';
 import './m3-top-app-bar.js';
 import type { M3TopAppBar } from './m3-top-app-bar.js';
 
+async function settleSlotChange(el: M3TopAppBar) {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await el.updateComplete;
+}
+
 describe('M3TopAppBar', () => {
   it('renders a small top app bar by default', async () => {
     const el = await fixture<M3TopAppBar>(html`<m3-top-app-bar>Title</m3-top-app-bar>`);
@@ -46,6 +51,8 @@ describe('M3TopAppBar', () => {
     `);
     const nav = el.shadowRoot!.querySelector('.navigation-icon');
     expect(nav).to.exist;
+    await settleSlotChange(el);
+    expect(nav!.hasAttribute('hidden')).to.be.false;
   });
 
   it('supports actions slot', async () => {
@@ -57,6 +64,37 @@ describe('M3TopAppBar', () => {
     `);
     const actions = el.shadowRoot!.querySelector('.actions');
     expect(actions).to.exist;
+    await settleSlotChange(el);
+    expect(actions!.hasAttribute('hidden')).to.be.false;
+  });
+
+  it('keeps initially absent navigation and action regions collapsed', async () => {
+    const el = await fixture<M3TopAppBar>(html`<m3-top-app-bar>Title</m3-top-app-bar>`);
+    expect(el.shadowRoot!.querySelector('.navigation-icon')!.hasAttribute('hidden')).to.be.true;
+    expect(el.shadowRoot!.querySelector('.actions')!.hasAttribute('hidden')).to.be.true;
+  });
+
+  it('reacts to navigation and action add, remove, reassignment, and reconnect', async () => {
+    const el = await fixture<M3TopAppBar>(html`<m3-top-app-bar>Title</m3-top-app-bar>`);
+    const control = document.createElement('button');
+    control.slot = 'navigation-icon';
+    control.textContent = 'Menu';
+
+    el.append(control);
+    await settleSlotChange(el);
+    expect(el.shadowRoot!.querySelector('.navigation-icon')!.hasAttribute('hidden')).to.be.false;
+
+    control.slot = 'actions';
+    await settleSlotChange(el);
+    expect(el.shadowRoot!.querySelector('.navigation-icon')!.hasAttribute('hidden')).to.be.true;
+    expect(el.shadowRoot!.querySelector('.actions')!.hasAttribute('hidden')).to.be.false;
+
+    el.remove();
+    document.body.append(el);
+    control.remove();
+    await settleSlotChange(el);
+    expect(el.shadowRoot!.querySelector('.actions')!.hasAttribute('hidden')).to.be.true;
+    el.remove();
   });
 
   it('is accessible', async () => {

--- a/packages/m3-top-app-bar/src/m3-top-app-bar.ts
+++ b/packages/m3-top-app-bar/src/m3-top-app-bar.ts
@@ -1,5 +1,5 @@
 import { LitElement, html } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import { m3TopAppBarStyles } from './m3-top-app-bar.styles.js';
 
 /**
@@ -56,27 +56,43 @@ export class M3TopAppBar extends LitElement {
   @property({ type: String })
   headline = '';
 
-  render() {
-    const hasNav = this.querySelector('[slot="navigation-icon"]');
-    const hasActions = this.querySelector('[slot="actions"]');
+  @state() private _hasNavigationIcon = false;
+  @state() private _hasActions = false;
 
+  render() {
     return html`
       <header class="app-bar" part="app-bar">
-        ${hasNav ? html`
-          <div class="navigation-icon">
-            <slot name="navigation-icon"></slot>
-          </div>
-        ` : ''}
+        <div class="navigation-icon" ?hidden=${!this._hasNavigationIcon}>
+          <slot name="navigation-icon" @slotchange=${this._handleSlotChange}></slot>
+        </div>
         <h1 class="headline">
           <slot>${this.headline}</slot>
         </h1>
-        ${hasActions ? html`
-          <div class="actions">
-            <slot name="actions"></slot>
-          </div>
-        ` : ''}
+        <div class="actions" ?hidden=${!this._hasActions}>
+          <slot name="actions" @slotchange=${this._handleSlotChange}></slot>
+        </div>
       </header>
     `;
+  }
+
+  firstUpdated() {
+    this._syncSlotState();
+  }
+
+  private _handleSlotChange = () => {
+    queueMicrotask(() => this._syncSlotState());
+  };
+
+  private _syncSlotState() {
+    this._hasNavigationIcon = this._slotHasContent('navigation-icon');
+    this._hasActions = this._slotHasContent('actions');
+  }
+
+  private _slotHasContent(name: string): boolean {
+    return this.shadowRoot
+      ?.querySelector<HTMLSlotElement>(`slot[name="${name}"]`)
+      ?.assignedNodes({ flatten: true })
+      .some((node) => node.nodeType === Node.ELEMENT_NODE || (node.textContent ?? '').trim().length > 0) ?? false;
   }
 }
 

--- a/vitest.browser.config.ts
+++ b/vitest.browser.config.ts
@@ -28,6 +28,8 @@ const browserPorts: Record<string, number> = {
   'm3-radio-button': 63_332,
   'm3-tooltip': 63_333,
   'm3-tabs': 63_334,
+  'm3-button': 63_335,
+  'm3-chip': 63_336,
 };
 
 const port = browserPorts[workspaceName];


### PR DESCRIPTION
## Linked issue

Fixes #22

## Summary

- Keep optional icon, supporting text, action, and navigation slots mounted in button, chip, list item, snackbar, and top app bar components.
- Use native slotchange events and hidden wrappers so dynamic additions, removals, and reassignment update layout without MutationObserver instances or manually managed listeners.
- Add browser suites for button and chip and dynamic-slot coverage for every affected family.

## Acceptance criteria

- [x] Optional slotted content added after connection appears immediately.
- [x] Removing content collapses spacing immediately through hidden wrappers.
- [x] Slot reassignment updates the correct region.
- [x] Reconnect coverage verifies dynamic slot changes continue to work; implementation has no observer or external listener lifecycle to leak.
- [x] Initial absent/present and dynamic transitions are covered for button, chip, list item, snackbar, and top app bar.

## Risk and compatibility

- Risk: low. Existing slots and public APIs are unchanged; only their dynamic layout behavior is corrected.
- Semver impact: patch.
- Rollback: revert this commit.

## Verification

Passed with pnpm 11.12.0:

- pnpm lint
- pnpm typecheck
- pnpm tokens:check
- pnpm build
- pnpm smoke:packages
- pnpm smoke:svelte-vite
- pnpm verify:package-licenses
- pnpm audit:prod
- Targeted and repository browser suites in Chromium, Firefox, and WebKit; affected totals: button 9, chip 9, list 51, snackbar 39, top app bar 33.

The repository-wide pnpm test command exercised all affected suites but its unrelated Angular app test fails under the local Node 26 runtime because localStorage is unavailable. CI pins Node 24.18.0; no Angular code was changed.

## Documentation and accessibility

No public API or semantic change. Existing accessibility tests continue to pass; hidden wrappers remove empty regions from layout.

## Release notes

Optional slotted button, chip, list item, snackbar, and top app bar content now updates immediately when it changes at runtime.