### PR TITLE
fix(text-field): reconcile documented contract

### DIFF
--- a/apps/angular-app/src/pages/text-field/text-field.component.html
+++ b/apps/angular-app/src/pages/text-field/text-field.component.html
@@ -8,13 +8,20 @@
 
   <section class="demo-section">
     <h2>Usage</h2>
-    <p>Text fields allow users to enter text into a UI. They typically appear in forms and dialogs.</p>
+    <p>
+      Text fields allow users to enter text into a UI. They typically appear in
+      forms and dialogs.
+    </p>
     <div class="interactive-demo">
       <div class="demo-row">
         <m3-text-field label="Username"></m3-text-field>
         <m3-text-field label="Password" type="password"></m3-text-field>
       </div>
-      <app-code-block [code]="basicExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="basicExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 
@@ -24,21 +31,45 @@
     <div class="interactive-demo">
       <div class="demo-row">
         <m3-text-field label="Disabled" disabled></m3-text-field>
-        <m3-text-field label="Disabled with value" value="Some value" disabled></m3-text-field>
+        <m3-text-field
+          label="Disabled with value"
+          value="Some value"
+          disabled
+        ></m3-text-field>
       </div>
-      <app-code-block [code]="disabledExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="disabledExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 
   <section class="demo-section">
     <h2>Interactive Example</h2>
-    <p>Listen to the <code>textfield-change</code> event to respond to user interaction.</p>
+    <p>
+      Listen to the native <code>input</code> event to respond to each user
+      edit.
+    </p>
     <div class="interactive-demo">
-      <div class="demo-row" style="flex-direction: column; align-items: flex-start; gap: 16px;">
-        <m3-text-field label="Email address" [value]="email" (textfield-change)="onTextFieldChange($event)"></m3-text-field>
-        <div style="color: var(--md-sys-color-on-surface)">You typed: {{ email }}</div>
+      <div
+        class="demo-row"
+        style="flex-direction: column; align-items: flex-start; gap: 16px"
+      >
+        <m3-text-field
+          label="Email address"
+          [value]="email"
+          (input)="onTextFieldInput($event)"
+        ></m3-text-field>
+        <div style="color: var(--md-sys-color-on-surface)">
+          You typed: {{ email }}
+        </div>
       </div>
-      <app-code-block [code]="interactiveExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="interactiveExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 </div>

--- a/apps/angular-app/src/pages/text-field/text-field.component.ts
+++ b/apps/angular-app/src/pages/text-field/text-field.component.ts
@@ -1,5 +1,9 @@
-import { Component, ChangeDetectionStrategy, CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
-import { CodeBlockComponent } from "../../app/components/code-block/code-block.component";
+import {
+  Component,
+  ChangeDetectionStrategy,
+  CUSTOM_ELEMENTS_SCHEMA,
+} from '@angular/core';
+import { CodeBlockComponent } from '../../app/components/code-block/code-block.component';
 
 import '@banegasn/m3-text-field';
 import '@banegasn/m3-card';
@@ -24,12 +28,11 @@ export class TextFieldComponent {
   readonly interactiveExample = `<m3-text-field
   label="Email"
   [value]="email"
-  (textfield-change)="onTextFieldChange($event)">
+  (input)="onTextFieldInput($event)">
 </m3-text-field>
 <p>Email: {{email}}</p>`;
 
-  onTextFieldChange(event: Event) {
-    const detail = (event as CustomEvent).detail;
-    this.email = detail.value;
+  onTextFieldInput(event: Event) {
+    this.email = (event.target as unknown as { value: string }).value;
   }
 }

--- a/packages/m3-text-field/README.md
+++ b/packages/m3-text-field/README.md
@@ -1,171 +1,131 @@
 # @banegasn/m3-text-field
 
-![Preview](images/preview.png)
-
-
-> Material Design 3 Text Field web component — framework-agnostic, built with Lit.
-
-[![npm version](https://img.shields.io/npm/v/@banegasn/m3-text-field.svg)](https://www.npmjs.com/package/@banegasn/m3-text-field)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](../../LICENSE)
-
-An accessible **M3 Text Field** web component following the [Material Design 3 text field specifications](https://m3.material.io/components/text-fields/overview). Supports filled and outlined variants with labels, helper text, error states, and leading/trailing icons. Works in Angular, React, Vue, Svelte, or plain HTML — no build step required.
-
-## Features
-
-- Filled and outlined variants
-- Floating label animation
-- Error and helper text states
-- Leading and trailing icon slots
-- Character counter support
-- Keyboard accessible with proper ARIA attributes
-- Framework-agnostic custom element
+Material Design 3 single-line text field, built with Lit. It is a
+form-associated custom element: its host participates in native `FormData`,
+constraint validation, reset, and browser state restoration.
 
 ## Installation
 
 ```bash
-npm install @banegasn/m3-text-field
-# or
 pnpm add @banegasn/m3-text-field
-# or
-yarn add @banegasn/m3-text-field
 ```
-
-## CDN Usage (no build step)
-
-```html
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <title>M3 Text Field Demo</title>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@banegasn/m3-text-field/+esm"></script>
-  <style>
-    body { font-family: Roboto, sans-serif; padding: 32px; background: #fef7ff; }
-    .demo { display: flex; flex-direction: column; gap: 24px; max-width: 360px; }
-  </style>
-</head>
-<body>
-  <div class="demo">
-    <!-- Filled (default) -->
-    <m3-text-field label="Username" placeholder="Enter username"></m3-text-field>
-
-    <!-- Outlined -->
-    <m3-text-field variant="outlined" label="Email" type="email" placeholder="you@example.com"></m3-text-field>
-
-    <!-- With helper text -->
-    <m3-text-field label="Password" type="password" helper-text="At least 8 characters"></m3-text-field>
-
-    <!-- Error state -->
-    <m3-text-field label="Phone" error error-text="Invalid phone number" value="abc"></m3-text-field>
-
-    <!-- Disabled -->
-    <m3-text-field label="Read only" value="Cannot edit" disabled></m3-text-field>
-  </div>
-
-  <script>
-    document.querySelectorAll('m3-text-field').forEach(field => {
-      field.addEventListener('text-field-input', (e) => {
-        console.log('Input:', e.detail.value);
-      });
-    });
-  </script>
-</body>
-</html>
-```
-
-## npm Usage
 
 ```js
 import '@banegasn/m3-text-field';
 ```
 
+## Usage
+
 ```html
-<m3-text-field label="Name" placeholder="Enter your name"></m3-text-field>
-<m3-text-field variant="outlined" label="Email" type="email"></m3-text-field>
-<m3-text-field label="Password" type="password" helper-text="Min 8 characters"></m3-text-field>
+<form>
+  <m3-text-field
+    name="email"
+    type="email"
+    label="Email address"
+    autocomplete="email"
+    helper-text="We only use this for account messages."
+    required
+  ></m3-text-field>
+</form>
 ```
 
-## With Icons
+Use the host's native events. `input` fires once for every user edit and
+`change` fires once when the input value is committed. Programmatic `value`
+updates do not emit either event.
 
-```html
-<!-- Leading icon -->
-<m3-text-field label="Search" placeholder="Search...">
-  <svg slot="leading-icon" viewBox="0 0 24 24" width="20" height="20">
-    <path fill="currentColor" d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
-  </svg>
-</m3-text-field>
+```js
+const field = document.querySelector('m3-text-field');
+field.addEventListener('input', () => {
+  console.log(field.value);
+});
+field.addEventListener('change', () => {
+  save(field.value);
+});
 ```
 
 ## API
 
-### Properties
+### Properties and attributes
 
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `variant` | `'filled' \| 'outlined'` | `'filled'` | Text field style variant |
-| `label` | `string` | `''` | Floating label text |
-| `placeholder` | `string` | `''` | Placeholder text |
-| `value` | `string` | `''` | Current input value |
-| `type` | `string` | `'text'` | Input type (text, email, password, etc.) |
-| `disabled` | `boolean` | `false` | Disables the field |
-| `required` | `boolean` | `false` | Marks the field as required |
-| `error` | `boolean` | `false` | Shows error state |
-| `error-text` | `string` | `''` | Error message text |
-| `helper-text` | `string` | `''` | Helper text below the field |
-| `maxlength` | `number \| null` | `null` | Maximum character count |
-| `name` | `string \| null` | `null` | Name for form submission |
+Every property below has the named HTML attribute. Camel-case properties use
+the corresponding lower-case attribute shown in the table.
 
-### Events
+| Property          | Attribute          | Type                     | Default    | Description                                                            |
+| ----------------- | ------------------ | ------------------------ | ---------- | ---------------------------------------------------------------------- |
+| `variant`         | `variant`          | `'filled' \| 'outlined'` | `'filled'` | Visual style.                                                          |
+| `label`           | `label`            | `string`                 | `''`       | Visible label. It is associated with the internal input.               |
+| `value`           | `value`            | `string`                 | `''`       | Current value and submitted form value.                                |
+| `type`            | `type`             | `string`                 | `'text'`   | Native input type, such as `email`, `password`, or `tel`.              |
+| `placeholder`     | `placeholder`      | `string`                 | `''`       | Native input placeholder.                                              |
+| `name`            | `name`             | `string \| null`         | `null`     | Name contributed to `FormData`.                                        |
+| `disabled`        | `disabled`         | `boolean`                | `false`    | Disables interaction and form participation.                           |
+| `required`        | `required`         | `boolean`                | `false`    | Enables required-value validation.                                     |
+| `maxLength`       | `maxlength`        | `number \| null`         | `null`     | Native maximum length constraint.                                      |
+| `minLength`       | `minlength`        | `number \| null`         | `null`     | Native minimum length constraint.                                      |
+| `pattern`         | `pattern`          | `string \| null`         | `null`     | Native pattern constraint.                                             |
+| `autocomplete`    | `autocomplete`     | `string \| null`         | `null`     | Native autocomplete hint.                                              |
+| `helperText`      | `helper-text`      | `string`                 | `''`       | Supporting guidance announced with the input.                          |
+| `error`           | `error`            | `boolean`                | `false`    | Applies a custom form-validation error.                                |
+| `errorText`       | `error-text`       | `string`                 | `''`       | Message for the custom error; defaults to `Invalid value.` when empty. |
+| `showCounter`     | `show-counter`     | `boolean`                | `false`    | Displays `value.length/maxLength` when `maxLength` is set.             |
+| `ariaLabel`       | `aria-label`       | `string \| null`         | `null`     | Accessible name override, usually for an unlabeled field.              |
+| `ariaLabelledBy`  | `aria-labelledby`  | `string \| null`         | `null`     | External accessible-name ID reference.                                 |
+| `ariaDescribedBy` | `aria-describedby` | `string \| null`         | `null`     | Additional external description ID reference.                          |
 
-| Event | Description |
-|-------|-------------|
-| `input` | Native event fired on every user edit. |
-| `change` | Native event fired when the value is committed. |
-
-See the [form-associated control migration guide](../../docs/FORM_ASSOCIATED_CONTROLS.md).
+The native host `form` attribute can associate the control with an external
+form. The read-only `form` property returns that owner form. `validity`,
+`validationMessage`, `willValidate`, `checkValidity()`, and `reportValidity()`
+follow the form-associated custom-element platform contract.
 
 ### Slots
 
-| Slot | Description |
-|------|-------------|
-| `leading-icon` | Icon displayed before the input |
-| `trailing-icon` | Icon displayed after the input |
+| Slot            | Description                                               |
+| --------------- | --------------------------------------------------------- |
+| `leading-icon`  | Decorative or interactive content shown before the input. |
+| `trailing-icon` | Decorative or interactive content shown after the input.  |
 
-### CSS Custom Properties
-
-| Property | Default | Description |
-|----------|---------|-------------|
-| `--md-sys-color-primary` | `#6750a4` | Focus indicator and label color |
-| `--md-sys-color-error` | `#ba1a1a` | Error state color |
-| `--md-sys-color-on-surface` | `#1d1b20` | Input text color |
-| `--md-sys-color-surface-container-highest` | `#e6e0e9` | Filled variant background |
-
-## Framework Usage
-
-### Angular
-```typescript
-import '@banegasn/m3-text-field';
-```
 ```html
-<m3-text-field label="Name" [value]="name" (text-field-input)="name = $event.detail.value"></m3-text-field>
+<m3-text-field label="Search" placeholder="Find a project">
+  <svg slot="leading-icon" aria-hidden="true" viewBox="0 0 24 24">...</svg>
+</m3-text-field>
 ```
 
-### React
-```jsx
-import '@banegasn/m3-text-field';
-// <m3-text-field label="Name" value={name} ontext-field-input={(e) => setName(e.detail.value)} />
-```
+### Events
 
-### Vue
-```vue
-<m3-text-field label="Name" :value="name" @text-field-input="name = $event.detail.value" />
-```
+| Event    | When it fires                             |
+| -------- | ----------------------------------------- |
+| `input`  | Once for each user edit.                  |
+| `change` | Once when a user commits an edited value. |
 
-## Resources
+### Methods
 
-- [Material Design 3 Text Fields](https://m3.material.io/components/text-fields/overview)
-- [GitHub Repository](https://github.com/banegasn/components)
+| Method    | Description                                   |
+| --------- | --------------------------------------------- |
+| `focus()` | Focuses the internal native input.            |
+| `blur()`  | Removes focus from the internal native input. |
 
-## License
+## Validation and accessible supporting text
 
-MIT
+`required`, `minLength`, `maxLength`, `pattern`, and the selected native
+`type` participate in the owner form's validation APIs. `error` adds a custom
+error, using `errorText` as its validation message. Disabled fields are omitted
+from `FormData` and validation, including when disabled by a fieldset.
+
+The visible `label` uses a generated `for`/`id` relationship, so activating it
+focuses the input. Helper text and validation errors have a generated stable ID
+and are referenced with `aria-describedby`; an active error also uses
+`aria-errormessage` and `aria-invalid`. Optional ARIA attributes are omitted
+when not supplied.
+
+## Migration from pre-1.1 documentation
+
+This is a clean API correction. The previous README mentioned
+`textfield-input`/`textfield-change` and `text-field-input` events, but those
+aliases are not part of the component contract and are removed. Listen for the
+native host `input` and `change` events instead, then read `field.value`.
+
+`variant`, `helper-text`, `error`, `error-text`, `show-counter`, and the
+`leading-icon`/`trailing-icon` slots are now the only documented presentation
+API. Do not use unlisted aliases. See the repository's
+[form-associated controls guide](../../docs/FORM_ASSOCIATED_CONTROLS.md) for
+browser support and platform fallback behavior.

--- a/packages/m3-text-field/package.json
+++ b/packages/m3-text-field/package.json
@@ -23,8 +23,9 @@
     "postpack": "node ../../scripts/package-license.js clean",
     "clean": "rm -rf dist",
     "lint": "eslint src --max-warnings 0",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node ../../scripts/no-tests.mjs"
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json",
+    "test": "vitest run --config ../../vitest.browser.config.ts",
+    "test:watch": "vitest --config ../../vitest.browser.config.ts"
   },
   "repository": {
     "type": "git",

--- a/packages/m3-text-field/src/m3-text-field.styles.ts
+++ b/packages/m3-text-field/src/m3-text-field.styles.ts
@@ -5,7 +5,6 @@ export const m3TextFieldStyles = css`
     display: inline-flex;
     flex-direction: column;
     min-width: 240px;
-    height: 56px;
     position: relative;
     border-radius: 4px 4px 0 0;
     font-family: inherit;
@@ -15,17 +14,22 @@ export const m3TextFieldStyles = css`
   .field-container {
     position: relative;
     width: 100%;
-    height: 100%;
+    min-height: 56px;
     display: flex;
-    align-items: center;
+    align-items: stretch;
     background-color: var(--md-sys-color-surface-container-highest, #e6e0e9);
     border-radius: inherit;
-    transition: background-color var(--md-sys-motion-duration-short4), box-shadow var(--md-sys-motion-duration-short4);
+    box-sizing: border-box;
     cursor: text;
     overflow: hidden;
   }
 
-  /* Hover state using opacity on state-layer */
+  .field-container.outlined {
+    background-color: transparent;
+    border: 1px solid var(--md-sys-color-outline, #79747e);
+    border-radius: 4px;
+  }
+
   :host(:hover:not([disabled])) {
     --_state-layer-opacity: 0.08;
   }
@@ -35,21 +39,97 @@ export const m3TextFieldStyles = css`
     inset: 0;
     background-color: var(--md-sys-color-on-surface, #1d1b20);
     opacity: var(--_state-layer-opacity);
-    transition: opacity var(--md-sys-motion-duration-short4);
     pointer-events: none;
-    z-index: 0;
   }
 
-  /* Focus indicator */
+  .input-area {
+    position: relative;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .leading-icon,
+  .trailing-icon {
+    display: flex;
+    align-items: center;
+    position: relative;
+    z-index: 1;
+  }
+
+  .leading-icon {
+    padding-left: 12px;
+  }
+  .trailing-icon {
+    padding-right: 12px;
+  }
+  .field-container:not([has-leading-icon]) .leading-icon,
+  .field-container:not([has-trailing-icon]) .trailing-icon {
+    display: none;
+  }
+
+  ::slotted([slot='leading-icon']),
+  ::slotted([slot='trailing-icon']) {
+    color: var(--md-sys-color-on-surface-variant, #49454f);
+    display: block;
+    max-width: 24px;
+    max-height: 24px;
+  }
+
+  .label {
+    position: absolute;
+    left: 16px;
+    top: 50%;
+    color: var(--md-sys-color-on-surface-variant, #49454f);
+    font-size: 1rem;
+    line-height: normal;
+    pointer-events: auto;
+    transform: translateY(-50%);
+    transform-origin: top left;
+    transition:
+      transform var(--md-sys-motion-duration-short4),
+      color var(--md-sys-motion-duration-short4),
+      top var(--md-sys-motion-duration-short4);
+    z-index: 1;
+  }
+
+  .field-container[focused] .label,
+  .field-container[has-value] .label {
+    top: 10px;
+    transform: scale(0.75) translateY(0);
+  }
+
+  .field-container[focused] .label {
+    color: var(--md-sys-color-primary, #6750a4);
+  }
+
+  .input {
+    width: 100%;
+    height: 56px;
+    box-sizing: border-box;
+    padding: 24px 16px 8px;
+    border: 0;
+    outline: 0;
+    background: transparent;
+    color: var(--md-sys-color-on-surface, #1d1b20);
+    font: inherit;
+    caret-color: var(--md-sys-color-primary, #6750a4);
+  }
+
+  .input::placeholder {
+    color: transparent;
+  }
+  .field-container[focused] .input::placeholder {
+    color: var(--md-sys-color-on-surface-variant, #49454f);
+    opacity: 0.5;
+  }
+
   .indicator {
     position: absolute;
+    right: 0;
     bottom: 0;
     left: 0;
-    right: 0;
     height: 1px;
     background-color: var(--md-sys-color-on-surface-variant, #49454f);
-    transition: height var(--md-sys-motion-duration-short4), background-color var(--md-sys-motion-duration-short4);
-    z-index: 3;
   }
 
   .field-container[focused] .indicator {
@@ -57,110 +137,56 @@ export const m3TextFieldStyles = css`
     background-color: var(--md-sys-color-primary, #6750a4);
   }
 
-  /* Label styles */
-  .label-wrapper {
-    position: absolute;
-    left: 16px;
-    top: 50%;
-    transform: translateY(-50%);
-    pointer-events: none;
-    transform-origin: top left;
-    transition: transform var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard), color var(--md-sys-motion-duration-short4), top var(--md-sys-motion-duration-short4);
+  .outlined .indicator {
+    display: none;
+  }
+  .outlined[focused] {
+    border: 2px solid var(--md-sys-color-primary, #6750a4);
+  }
+
+  .field-container[invalid] .indicator {
+    background-color: var(--md-sys-color-error, #ba1a1a);
+  }
+  .field-container[invalid] .label {
+    color: var(--md-sys-color-error, #ba1a1a);
+  }
+  .outlined[invalid] {
+    border-color: var(--md-sys-color-error, #ba1a1a);
+  }
+
+  .supporting-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    min-height: 20px;
+    padding: 4px 16px 0;
     color: var(--md-sys-color-on-surface-variant, #49454f);
-    font-size: 1rem;
-    line-height: normal;
-    z-index: 2;
+    font-size: 0.75rem;
+    line-height: 1rem;
   }
 
-  .field-container[focused] .label-wrapper,
-  .field-container[has-value] .label-wrapper {
-    top: 10px;
-    transform: scale(0.75) translateY(0);
+  .supporting-text {
+    flex: 1;
+  }
+  .counter {
+    white-space: nowrap;
+  }
+  .supporting-row[error] {
+    color: var(--md-sys-color-error, #ba1a1a);
   }
 
-  .field-container[focused] .label-wrapper {
-    color: var(--md-sys-color-primary, #6750a4);
-  }
-
-  /* Input styles */
-  .input {
-    width: 100%;
-    height: 100%;
-    box-sizing: border-box;
-    padding: 24px 16px 8px 16px;
-    border: none;
-    outline: none;
-    background: transparent;
-    color: var(--md-sys-color-on-surface, #1d1b20);
-    font-size: 1rem;
-    font-family: inherit;
-    position: relative;
-    z-index: 1;
-    caret-color: var(--md-sys-color-primary, #6750a4);
-  }
-
-  /* Handle Autofill styles */
-  .input:-webkit-autofill,
-  .input:-webkit-autofill:hover,
-  .input:-webkit-autofill:focus {
-    -webkit-box-shadow: 0 0 0px 1000px var(--md-sys-color-surface-container-highest, #e6e0e9) inset !important;
-    -webkit-text-fill-color: var(--md-sys-color-on-surface, #1d1b20) !important;
-    /* motion-literal-exempt: browser autofill paint workaround, not UI motion. */
-    transition: background-color 5000s ease-in-out 0s;
-  }
-
-  /* Placeholder */
-  .input::placeholder {
-    color: transparent;
-  }
-
-  .field-container[focused] .input::placeholder {
-    color: var(--md-sys-color-on-surface-variant, #49454f);
-    opacity: 0.5;
-  }
-
-  /* Disabled State */
   :host([disabled]) {
     cursor: default;
-    pointer-events: none;
   }
-
   :host([disabled]) .field-container {
-    background-color: var(--md-sys-color-on-surface, #1d1b20);
-    opacity: 0.04;
+    background-color: rgba(
+      var(--md-sys-color-on-surface-rgb, 29, 27, 32),
+      0.04
+    );
   }
-
-  /* Ensure label remains visible but faded in disabled state */
-  :host([disabled]) .label-wrapper {
-    opacity: 1 !important;
-    color: var(--md-sys-color-on-surface, #1d1b20);
-    filter: opacity(0.38); /* Use filter to apply opacity relative to parent's 4% */
-  }
-
-  /* Correction for disabled label invisibility: 
-     Apply 38% opacity directly to the elements, and 4% to container */
+  :host([disabled]) .label,
   :host([disabled]) .input,
-  :host([disabled]) .indicator {
-    opacity: 0.38;
-    color: var(--md-sys-color-on-surface, #1d1b20);
-  }
-
-  /* Re-fix: if container is 0.04, children are effectively invisible.
-     Let's use a different approach for disabled: fixed light/dark color with no container opacity */
-  :host([disabled]) .field-container {
-    background-color: rgba(var(--md-sys-color-on-surface-rgb, 29, 27, 32), 0.04);
-    opacity: 1;
-  }
-  
-  /* Fallback if rgb variable not present */
-  @supports not (color: rgba(var(--foo), 0.1)) {
-    :host([disabled]) .field-container {
-      background-color: #f5f5f5; /* Light fallback */
-    }
-  }
-
-  :host([disabled]) .label-wrapper,
-  :host([disabled]) .input {
+  :host([disabled]) ::slotted(*) {
     color: var(--md-sys-color-on-surface, #1d1b20);
     opacity: 0.38;
   }

--- a/packages/m3-text-field/src/m3-text-field.test.ts
+++ b/packages/m3-text-field/src/m3-text-field.test.ts
@@ -1,0 +1,145 @@
+import { fixture, html, expect } from '@open-wc/testing';
+import { describe, it } from 'vitest';
+import './m3-text-field.js';
+import type { M3TextField } from './m3-text-field.js';
+
+describe('m3-text-field', () => {
+  it('implements the documented variant, slot, supporting-text, and ARIA contract', async () => {
+    const field = await fixture<M3TextField>(html`
+      <m3-text-field
+        variant="outlined"
+        label="Account name"
+        helper-text="Use 3 to 8 letters."
+        show-counter
+        maxlength="8"
+        aria-describedby="account-guidance"
+      >
+        <span slot="leading-icon">@</span>
+        <span slot="trailing-icon">✓</span>
+      </m3-text-field>
+    `);
+    await field.updateComplete;
+
+    const root = field.shadowRoot!;
+    const input = root.querySelector<HTMLInputElement>('input')!;
+    const label = root.querySelector<HTMLLabelElement>('label')!;
+    const supporting = root.querySelector<HTMLElement>('.supporting-row')!;
+    expect(root.querySelector('.field-container')!.className).to.contain(
+      'outlined',
+    );
+    expect(label.htmlFor).to.equal(input.id);
+    expect(input.getAttribute('aria-describedby')).to.equal(
+      `${'account-guidance'} ${supporting.id}`,
+    );
+    expect(input.getAttribute('aria-errormessage')).to.equal(null);
+    expect(input.maxLength).to.equal(8);
+    expect(supporting.textContent).to.contain('Use 3 to 8 letters.');
+    expect(supporting.textContent).to.contain('0/8');
+    expect(
+      root
+        .querySelector<HTMLSlotElement>('slot[name="leading-icon"]')!
+        .assignedElements(),
+    ).to.have.length(1);
+    expect(
+      root
+        .querySelector<HTMLSlotElement>('slot[name="trailing-icon"]')!
+        .assignedElements(),
+    ).to.have.length(1);
+  });
+
+  it('associates its visible label with the input and preserves optional ARIA absence', async () => {
+    const field = await fixture<M3TextField>(
+      html`<m3-text-field label="Email"></m3-text-field>`,
+    );
+    await field.updateComplete;
+    const root = field.shadowRoot!;
+    const input = root.querySelector<HTMLInputElement>('input')!;
+    root.querySelector<HTMLLabelElement>('label')!.click();
+
+    expect(root.activeElement).to.equal(input);
+    expect(input.hasAttribute('aria-label')).to.equal(false);
+    expect(input.hasAttribute('aria-labelledby')).to.equal(false);
+    expect(input.hasAttribute('aria-describedby')).to.equal(false);
+    await expect(field).to.be.accessible();
+  });
+
+  it('contributes native constraint validity and custom errors to its owner form', async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form>
+        <m3-text-field
+          name="username"
+          required
+          pattern="[A-Za-z]+"
+          maxlength="8"
+        ></m3-text-field>
+      </form>
+    `);
+    const field = form.querySelector<M3TextField>('m3-text-field')!;
+    await field.updateComplete;
+
+    expect(field.validity.valueMissing).to.equal(true);
+    expect(form.checkValidity()).to.equal(false);
+
+    const input = field.shadowRoot!.querySelector<HTMLInputElement>('input')!;
+    input.value = '123';
+    input.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+    await field.updateComplete;
+    expect(field.validity.patternMismatch).to.equal(true);
+    expect(
+      field.shadowRoot!.querySelector('.supporting-row')!.textContent,
+    ).to.not.equal('');
+
+    field.error = true;
+    field.errorText = 'That username is reserved.';
+    await field.updateComplete;
+    expect(field.validity.customError).to.equal(true);
+    expect(field.validationMessage).to.equal('That username is reserved.');
+    expect(
+      field
+        .shadowRoot!.querySelector<HTMLInputElement>('input')!
+        .getAttribute('aria-errormessage'),
+    ).to.match(/supporting$/);
+
+    field.error = false;
+    input.value = 'Ada';
+    input.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+    await field.updateComplete;
+    expect(field.validity.valid).to.equal(true);
+    expect(new FormData(form).get('username')).to.equal('Ada');
+  });
+
+  it('emits exactly one native input/change pair and no removed custom aliases', async () => {
+    const field = await fixture<M3TextField>(
+      html`<m3-text-field></m3-text-field>`,
+    );
+    await field.updateComplete;
+    const input = field.shadowRoot!.querySelector<HTMLInputElement>('input')!;
+    let inputs = 0;
+    let changes = 0;
+    let legacyInputs = 0;
+    let legacyChanges = 0;
+    field.addEventListener('input', () => {
+      inputs += 1;
+    });
+    field.addEventListener('change', () => {
+      changes += 1;
+    });
+    field.addEventListener('textfield-input', () => {
+      legacyInputs += 1;
+    });
+    field.addEventListener('textfield-change', () => {
+      legacyChanges += 1;
+    });
+
+    input.value = 'Grace';
+    input.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+    input.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
+    await field.updateComplete;
+
+    expect(field.value).to.equal('Grace');
+    expect(inputs).to.equal(1);
+    expect(changes).to.equal(1);
+    expect(legacyInputs).to.equal(0);
+    expect(legacyChanges).to.equal(0);
+  });
+});

--- a/packages/m3-text-field/src/m3-text-field.test.ts
+++ b/packages/m3-text-field/src/m3-text-field.test.ts
@@ -4,6 +4,22 @@ import './m3-text-field.js';
 import type { M3TextField } from './m3-text-field.js';
 
 describe('m3-text-field', () => {
+  it('renders an initial required error after synchronizing form validity', async () => {
+    const field = await fixture<M3TextField>(html`
+      <m3-text-field label="Email" required></m3-text-field>
+    `);
+    await field.updateComplete;
+    await field.updateComplete;
+
+    const input = field.shadowRoot!.querySelector<HTMLInputElement>('input')!;
+    expect(field.validity.valueMissing).to.equal(true);
+    expect(input.getAttribute('aria-invalid')).to.equal('true');
+    expect(input.getAttribute('aria-errormessage')).to.match(/supporting$/);
+    expect(
+      field.shadowRoot!.querySelector('.supporting-row')!.textContent,
+    ).to.not.equal('');
+  });
+
   it('implements the documented variant, slot, supporting-text, and ARIA contract', async () => {
     const field = await fixture<M3TextField>(html`
       <m3-text-field
@@ -106,6 +122,57 @@ describe('m3-text-field', () => {
     await field.updateComplete;
     expect(field.validity.valid).to.equal(true);
     expect(new FormData(form).get('username')).to.equal('Ada');
+  });
+
+  it('updates rendered validity when required and pattern constraints change', async () => {
+    const field = await fixture<M3TextField>(html`
+      <m3-text-field label="Username" value="123"></m3-text-field>
+    `);
+    await field.updateComplete;
+    const input = field.shadowRoot!.querySelector<HTMLInputElement>('input')!;
+
+    field.required = true;
+    field.value = '';
+    await field.updateComplete;
+    await field.updateComplete;
+    expect(input.getAttribute('aria-invalid')).to.equal('true');
+
+    field.required = false;
+    field.value = '123';
+    field.pattern = '[A-Za-z]+';
+    await field.updateComplete;
+    await field.updateComplete;
+    expect(field.validity.patternMismatch).to.equal(true);
+    expect(input.getAttribute('aria-invalid')).to.equal('true');
+
+    field.pattern = null;
+    await field.updateComplete;
+    await field.updateComplete;
+    expect(field.validity.valid).to.equal(true);
+    expect(input.hasAttribute('aria-invalid')).to.equal(false);
+    expect(field.shadowRoot!.querySelector('.supporting-row')).to.equal(null);
+  });
+
+  it('clears rendered errors and ARIA error references when disabled', async () => {
+    const field = await fixture<M3TextField>(html`
+      <m3-text-field
+        label="Email"
+        error
+        error-text="Use a work address."
+      ></m3-text-field>
+    `);
+    await field.updateComplete;
+    await field.updateComplete;
+    const input = field.shadowRoot!.querySelector<HTMLInputElement>('input')!;
+    expect(input.getAttribute('aria-invalid')).to.equal('true');
+
+    field.disabled = true;
+    await field.updateComplete;
+    await field.updateComplete;
+    expect(field.validity.valid).to.equal(true);
+    expect(input.hasAttribute('aria-invalid')).to.equal(false);
+    expect(input.hasAttribute('aria-errormessage')).to.equal(false);
+    expect(field.shadowRoot!.querySelector('.supporting-row')).to.equal(null);
   });
 
   it('emits exactly one native input/change pair and no removed custom aliases', async () => {

--- a/packages/m3-text-field/src/m3-text-field.ts
+++ b/packages/m3-text-field/src/m3-text-field.ts
@@ -52,14 +52,16 @@ export class M3TextField extends FormAssociatedElement {
   @state() private _focused = false;
   @state() private _hasLeadingIcon = false;
   @state() private _hasTrailingIcon = false;
+  @state() private _invalid = false;
+  @state() private _validationMessage = '';
   @query('input') private _input!: HTMLInputElement;
 
   private readonly _id = `m3-text-field-${(M3TextField._nextId += 1)}`;
   private _defaultValue = '';
 
   render() {
-    const invalid = this._isInvalid();
-    const supportingText = invalid ? this._errorMessage() : this.helperText;
+    const invalid = this._invalid;
+    const supportingText = invalid ? this._validationMessage : this.helperText;
     const describedBy = [
       this.ariaDescribedBy,
       supportingText ? `${this._id}-supporting` : null,
@@ -126,12 +128,12 @@ export class M3TextField extends FormAssociatedElement {
               >
                 <span class="supporting-text">${supportingText}</span>
                 ${
-                this._showsCounter()
-                  ? html`<span class="counter"
-                      >${this.value.length}/${this.maxLength}</span
-                    >`
-                  : nothing
-              }
+                  this._showsCounter()
+                    ? html`<span class="counter"
+                        >${this.value.length}/${this.maxLength}</span
+                      >`
+                    : nothing
+                }
               </div>
             `
           : nothing
@@ -179,10 +181,6 @@ export class M3TextField extends FormAssociatedElement {
     return this.showCounter && this.maxLength !== null && this.maxLength >= 0;
   }
 
-  private _isInvalid(): boolean {
-    return this.error || Boolean(this._input && !this._input.validity.valid);
-  }
-
   private _errorMessage(): string {
     if (this.error) return this.errorText || 'Invalid value.';
     return this._input?.validationMessage || 'Invalid value.';
@@ -190,12 +188,15 @@ export class M3TextField extends FormAssociatedElement {
 
   private _syncFormState(): void {
     const input = this._input;
-    const flags =
-      !this.isFormDisabled && input ? validityFlags(input.validity) : {};
-    if (this.error && !this.isFormDisabled) flags.customError = true;
+    const disabled = this.isFormDisabled;
+    const flags = !disabled && input ? validityFlags(input.validity) : {};
+    if (this.error && !disabled) flags.customError = true;
     const invalid = Object.keys(flags).length > 0;
-    this.setFormValue(this.isFormDisabled ? null : this.value, this.value);
-    this.setFormValidity(flags, invalid ? this._errorMessage() : '', input);
+    const message = invalid ? this._errorMessage() : '';
+    this.setFormValue(disabled ? null : this.value, this.value);
+    this.setFormValidity(flags, message, input);
+    if (this._invalid !== invalid) this._invalid = invalid;
+    if (this._validationMessage !== message) this._validationMessage = message;
   }
 
   protected resetFormControl(): void {

--- a/packages/m3-text-field/src/m3-text-field.ts
+++ b/packages/m3-text-field/src/m3-text-field.ts
@@ -1,53 +1,141 @@
-import { html } from 'lit';
+import { html, nothing } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { customElement, property, state, query } from 'lit/decorators.js';
-import { FormAssociatedElement, validityFlags } from '@banegasn/m3-form-associated';
+import { customElement, property, query, state } from 'lit/decorators.js';
+import {
+  FormAssociatedElement,
+  validityFlags,
+} from '@banegasn/m3-form-associated';
 import { m3TextFieldStyles } from './m3-text-field.styles.js';
 
+type TextFieldVariant = 'filled' | 'outlined';
+
+/**
+ * A form-associated Material 3 single-line text field.
+ *
+ * User edits emit one native-like `input` event; committed edits emit one
+ * native-like `change` event. Setting `value` programmatically is silent,
+ * matching a native input.
+ */
 @customElement('m3-text-field')
 export class M3TextField extends FormAssociatedElement {
   static styles = m3TextFieldStyles;
   static readonly formAssociated = true;
+  private static _nextId = 0;
 
   @property({ type: String }) type = 'text';
   @property({ type: String }) label = '';
   @property({ type: String, reflect: true }) value = '';
   @property({ type: String }) placeholder = '';
+  @property({ type: String, reflect: true }) variant: TextFieldVariant =
+    'filled';
   @property({ type: Boolean, reflect: true }) disabled = false;
   @property({ type: String, reflect: true }) name: string | null = null;
   @property({ type: Boolean, reflect: true }) required = false;
-  @property({ type: Number, attribute: 'maxlength' }) maxLength: number | null = null;
-  @property({ type: Number, attribute: 'minlength' }) minLength: number | null = null;
+  @property({ type: Number, attribute: 'maxlength' }) maxLength: number | null =
+    null;
+  @property({ type: Number, attribute: 'minlength' }) minLength: number | null =
+    null;
   @property({ type: String }) pattern: string | null = null;
-  
+  @property({ type: String, attribute: 'autocomplete' }) autocomplete:
+    string | null = null;
+  @property({ type: String, attribute: 'helper-text' }) helperText = '';
+  @property({ type: Boolean, reflect: true }) error = false;
+  @property({ type: String, attribute: 'error-text' }) errorText = '';
+  @property({ type: Boolean, attribute: 'show-counter' }) showCounter = false;
+  @property({ type: String, attribute: 'aria-label' }) ariaLabel:
+    string | null = null;
+  @property({ type: String, attribute: 'aria-labelledby' }) ariaLabelledBy:
+    string | null = null;
+  @property({ type: String, attribute: 'aria-describedby' }) ariaDescribedBy:
+    string | null = null;
+
   @state() private _focused = false;
-  @query('input') inputEl!: HTMLInputElement;
+  @state() private _hasLeadingIcon = false;
+  @state() private _hasTrailingIcon = false;
+  @query('input') private _input!: HTMLInputElement;
+
+  private readonly _id = `m3-text-field-${(M3TextField._nextId += 1)}`;
   private _defaultValue = '';
 
   render() {
+    const invalid = this._isInvalid();
+    const supportingText = invalid ? this._errorMessage() : this.helperText;
+    const describedBy = [
+      this.ariaDescribedBy,
+      supportingText ? `${this._id}-supporting` : null,
+    ]
+      .filter((id): id is string => Boolean(id))
+      .join(' ');
+
     return html`
-      <div class="field-container" ?focused=${this._focused} ?has-value=${!!this.value}>
+      <div
+        class="field-container ${this.variant}"
+        ?focused=${this._focused}
+        ?has-value=${!!this.value}
+        ?invalid=${invalid}
+        ?has-leading-icon=${this._hasLeadingIcon}
+        ?has-trailing-icon=${this._hasTrailingIcon}
+      >
         <div class="state-layer"></div>
-        <div class="label-wrapper">
-          ${this.label ? html`<label class="label">${this.label}</label>` : ''}
+        <div class="leading-icon">
+          <slot
+            name="leading-icon"
+            @slotchange=${this._handleSlotChange}
+          ></slot>
         </div>
-        <input
-          class="input"
-          type=${this.type}
-          .value=${this.value}
-          ?disabled=${this.isFormDisabled}
-          ?required=${this.required}
-          placeholder=${this.placeholder}
-          maxlength=${ifDefined(this.maxLength ?? undefined)}
-          minlength=${ifDefined(this.minLength ?? undefined)}
-          pattern=${ifDefined(this.pattern ?? undefined)}
-          @focus=${this._handleFocus}
-          @blur=${this._handleBlur}
-          @input=${this._handleInput}
-          @change=${this._handleChange}
-        />
+        <div class="input-area">
+          ${this.label ? html`<label class="label" for="${this._id}-input">${this.label}</label>` : nothing}
+          <input
+            id="${this._id}-input"
+            class="input"
+            type=${this.type}
+            .value=${this.value}
+            ?disabled=${this.isFormDisabled}
+            ?required=${this.required}
+            placeholder=${this.placeholder}
+            aria-label=${this.ariaLabel || nothing}
+            aria-labelledby=${this.ariaLabelledBy || nothing}
+            aria-describedby=${describedBy || nothing}
+            aria-errormessage=${invalid ? `${this._id}-supporting` : nothing}
+            aria-invalid=${invalid ? 'true' : nothing}
+            maxlength=${ifDefined(this.maxLength ?? undefined)}
+            minlength=${ifDefined(this.minLength ?? undefined)}
+            pattern=${ifDefined(this.pattern ?? undefined)}
+            autocomplete=${ifDefined(this.autocomplete ?? undefined)}
+            @focus=${this._handleFocus}
+            @blur=${this._handleBlur}
+            @input=${this._handleInput}
+            @change=${this._handleChange}
+          />
+        </div>
+        <div class="trailing-icon">
+          <slot
+            name="trailing-icon"
+            @slotchange=${this._handleSlotChange}
+          ></slot>
+        </div>
         <div class="indicator"></div>
       </div>
+      ${
+        supportingText || this._showsCounter()
+          ? html`
+              <div
+                class="supporting-row"
+                id="${this._id}-supporting"
+                ?error=${invalid}
+              >
+                <span class="supporting-text">${supportingText}</span>
+                ${
+                this._showsCounter()
+                  ? html`<span class="counter"
+                      >${this.value.length}/${this.maxLength}</span
+                    >`
+                  : nothing
+              }
+              </div>
+            `
+          : nothing
+      }
     `;
   }
 
@@ -60,55 +148,74 @@ export class M3TextField extends FormAssociatedElement {
     this._syncFormState();
   }
 
-  private _handleFocus() {
+  private _handleFocus(): void {
     this._focused = true;
   }
 
-  private _handleBlur() {
+  private _handleBlur(): void {
     this._focused = false;
   }
 
-  private _handleInput(e: Event) {
-    e.stopPropagation();
-    const target = e.target as HTMLInputElement;
-    this.value = target.value;
+  private _handleSlotChange(event: Event): void {
+    const slot = event.target as HTMLSlotElement;
+    const hasContent = slot.assignedElements({ flatten: true }).length > 0;
+    if (slot.name === 'leading-icon') this._hasLeadingIcon = hasContent;
+    else this._hasTrailingIcon = hasContent;
+  }
+
+  private _handleInput(event: Event): void {
+    event.stopPropagation();
+    this.value = (event.target as HTMLInputElement).value;
     this.emitInput();
   }
 
-  private _handleChange(e: Event) {
-    e.stopPropagation();
-    const target = e.target as HTMLInputElement;
-    this.value = target.value;
+  private _handleChange(event: Event): void {
+    event.stopPropagation();
+    this.value = (event.target as HTMLInputElement).value;
     this.emitChange();
   }
 
+  private _showsCounter(): boolean {
+    return this.showCounter && this.maxLength !== null && this.maxLength >= 0;
+  }
+
+  private _isInvalid(): boolean {
+    return this.error || Boolean(this._input && !this._input.validity.valid);
+  }
+
+  private _errorMessage(): string {
+    if (this.error) return this.errorText || 'Invalid value.';
+    return this._input?.validationMessage || 'Invalid value.';
+  }
+
   private _syncFormState(): void {
-    const input = this.inputEl;
-    const flags = !this.isFormDisabled && input ? validityFlags(input.validity) : {};
-    if (this.value) delete flags.valueMissing;
-    else if (this.required && !this.isFormDisabled) flags.valueMissing = true;
+    const input = this._input;
+    const flags =
+      !this.isFormDisabled && input ? validityFlags(input.validity) : {};
+    if (this.error && !this.isFormDisabled) flags.customError = true;
     const invalid = Object.keys(flags).length > 0;
     this.setFormValue(this.isFormDisabled ? null : this.value, this.value);
-    this.setFormValidity(
-      flags,
-      invalid ? input.validationMessage : '',
-      input,
-    );
+    this.setFormValidity(flags, invalid ? this._errorMessage() : '', input);
   }
 
   protected resetFormControl(): void {
     this.value = this._defaultValue;
   }
 
-  protected restoreFormControlState(state: string | File | FormData | null): void {
+  protected restoreFormControlState(
+    state: string | File | FormData | null,
+  ): void {
     if (typeof state === 'string') this.value = state;
   }
 
-  focus() {
-    this.inputEl?.focus();
+  focus(): void {
+    this._input?.focus();
+  }
+
+  blur(): void {
+    this._input?.blur();
   }
 }
-
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/m3-text-field/tsconfig.test.json
+++ b/packages/m3-text-field/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.test.json",
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/vitest.browser.config.ts
+++ b/vitest.browser.config.ts
@@ -33,6 +33,7 @@ const browserPorts: Record<string, number> = {
   'm3-badge': 63_337,
   'm3-navigation-bar': 63_338,
   'm3-navigation-rail': 63_339,
+  'm3-text-field': 63_340,
 };
 
 const browserCoverageThresholds: Record<


### PR DESCRIPTION
Fixes #23

## Summary
- establish one typed text-field API for filled/outlined variants, labels, helper/error text, counters, slots, validation, and host methods
- connect generated label, helper, and error IDs to the native input; make required, min/max length, pattern, and custom errors participate in form validation
- standardize on exactly-once native host `input`/`change` events, update the Angular demo, and document the clean-break migration from undocumented aliases
- add browser tests and package test/typecheck wiring

## Acceptance mapping
- [x] Every documented property, attribute, slot, event, method, and variant is implemented and typed, with public removals documented.
- [x] Label activation focuses the input; label/help/error relationships use generated IDs and ARIA IDREFs.
- [x] Required, minlength, maxlength, pattern, and custom-error validity participate through `ElementInternals`.
- [x] Native-like host `input` and `change` events fire once; removed custom aliases do not fire.
- [x] README and Angular demo use the canonical contract; browser tests cover Chromium, Firefox, and WebKit.

## Validation
- `pnpm build` (passes; existing Angular bundle/style budget warnings)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm --filter @banegasn/m3-text-field test` (12 tests across Chromium, Firefox, and WebKit)