### PR TITLE
fix(angular-demo): prevent closed dialog interception

### DIFF
--- a/apps/angular-app/src/pages/dialog/dialog.component.html
+++ b/apps/angular-app/src/pages/dialog/dialog.component.html
@@ -14,23 +14,25 @@
     <div class="interactive-demo">
       <div class="demo-row">
         <m3-button (click)="openDialog()">Open Dialog</m3-button>
-        <m3-dialog
-          #dialog
-          [open]="dialogOpen"
-          headline="Confirm Action"
-          (dialog-close)="closeDialog($event)"
-        >
-          <p>Are you sure you want to proceed with this action?</p>
-          <m3-button
-            slot="actions"
-            variant="text"
-            (click)="closeFromAction(dialog)"
-            >Cancel</m3-button
+        @if (dialogOpen) {
+          <m3-dialog
+            #dialog
+            open
+            headline="Confirm Action"
+            (dialog-close)="closeDialog($event)"
           >
-          <m3-button slot="actions" (click)="closeFromAction(dialog)"
-            >Confirm</m3-button
-          >
-        </m3-dialog>
+            <p>Are you sure you want to proceed with this action?</p>
+            <m3-button
+              slot="actions"
+              variant="text"
+              (click)="closeFromAction(dialog)"
+              >Cancel</m3-button
+            >
+            <m3-button slot="actions" (click)="closeFromAction(dialog)"
+              >Confirm</m3-button
+            >
+          </m3-dialog>
+        }
       </div>
       <p class="demo-note">
         Last close reason: <code>{{ lastCloseReason }}</code

--- a/apps/angular-app/src/pages/dialog/dialog.component.spec.ts
+++ b/apps/angular-app/src/pages/dialog/dialog.component.spec.ts
@@ -1,9 +1,33 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { DialogComponent } from './dialog.component';
 
+type DemoDialog = HTMLElement & {
+  close(reason: 'action' | 'escape'): boolean;
+  open: boolean;
+  updateComplete: Promise<boolean>;
+};
+
 describe('DialogComponent', () => {
+  const nativeDialog = HTMLDialogElement.prototype;
+  const showModal = nativeDialog.showModal;
+  const close = nativeDialog.close;
+
+  beforeAll(() => {
+    nativeDialog.showModal = function showModal() {
+      this.setAttribute('open', '');
+    };
+    nativeDialog.close = function close() {
+      this.removeAttribute('open');
+    };
+  });
+
+  afterAll(() => {
+    nativeDialog.showModal = showModal;
+    nativeDialog.close = close;
+  });
+
   async function createFixture(): Promise<ComponentFixture<DialogComponent>> {
     await TestBed.configureTestingModule({
       imports: [DialogComponent],
@@ -16,34 +40,69 @@ describe('DialogComponent', () => {
     return fixture;
   }
 
+  async function openDemo(
+    fixture: ComponentFixture<DialogComponent>,
+  ): Promise<DemoDialog> {
+    const opener = fixture.nativeElement.querySelector(
+      'm3-button',
+    ) as HTMLElement;
+    opener.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await fixture.whenStable();
+
+    const dialog = fixture.nativeElement.querySelector(
+      'm3-dialog',
+    ) as DemoDialog;
+    await dialog.updateComplete;
+
+    return dialog;
+  }
+
   it('does not render a dialog until the user opens the demo', async () => {
     const fixture = await createFixture();
 
     expect(fixture.nativeElement.querySelector('m3-dialog')).toBeNull();
   });
 
-  it('keeps the Angular state in sync when the dialog closes', async () => {
+  it('opens from the rendered opener and closes from Cancel', async () => {
     const fixture = await createFixture();
-    fixture.componentInstance.dialogOpen = true;
+    const dialog = await openDemo(fixture);
 
-    fixture.componentInstance.closeDialog(
-      new CustomEvent('dialog-close', {
-        detail: { reason: 'escape' },
-      }),
-    );
+    expect(dialog.open).toBe(true);
+
+    dialog
+      .querySelectorAll('m3-button')[0]
+      .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await dialog.updateComplete;
+    await fixture.whenStable();
+
+    expect(fixture.nativeElement.querySelector('m3-dialog')).toBeNull();
+    expect(fixture.componentInstance.lastCloseReason).toBe('action');
+  });
+
+  it('closes from the rendered Confirm action', async () => {
+    const fixture = await createFixture();
+    const dialog = await openDemo(fixture);
+
+    dialog
+      .querySelectorAll('m3-button')[1]
+      .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await dialog.updateComplete;
+    await fixture.whenStable();
+
+    expect(fixture.nativeElement.querySelector('m3-dialog')).toBeNull();
+    expect(fixture.componentInstance.lastCloseReason).toBe('action');
+  });
+
+  it('handles an Escape close event from the rendered dialog', async () => {
+    const fixture = await createFixture();
+    const dialog = await openDemo(fixture);
+
+    expect(dialog.close('escape')).toBe(true);
+    await dialog.updateComplete;
+    await fixture.whenStable();
 
     expect(fixture.componentInstance.dialogOpen).toBe(false);
     expect(fixture.componentInstance.lastCloseReason).toBe('escape');
-  });
-
-  it('uses the dialog close API for action buttons', () => {
-    const close = vi.fn();
-    const dialog = { close } as unknown as HTMLElement;
-
-    TestBed.createComponent(DialogComponent).componentInstance.closeFromAction(
-      dialog,
-    );
-
-    expect(close).toHaveBeenCalledWith('action');
+    expect(fixture.nativeElement.querySelector('m3-dialog')).toBeNull();
   });
 });

--- a/apps/angular-app/src/pages/dialog/dialog.component.spec.ts
+++ b/apps/angular-app/src/pages/dialog/dialog.component.spec.ts
@@ -1,0 +1,49 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import { DialogComponent } from './dialog.component';
+
+describe('DialogComponent', () => {
+  async function createFixture(): Promise<ComponentFixture<DialogComponent>> {
+    await TestBed.configureTestingModule({
+      imports: [DialogComponent],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(DialogComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    return fixture;
+  }
+
+  it('does not render a dialog until the user opens the demo', async () => {
+    const fixture = await createFixture();
+
+    expect(fixture.nativeElement.querySelector('m3-dialog')).toBeNull();
+  });
+
+  it('keeps the Angular state in sync when the dialog closes', async () => {
+    const fixture = await createFixture();
+    fixture.componentInstance.dialogOpen = true;
+
+    fixture.componentInstance.closeDialog(
+      new CustomEvent('dialog-close', {
+        detail: { reason: 'escape' },
+      }),
+    );
+
+    expect(fixture.componentInstance.dialogOpen).toBe(false);
+    expect(fixture.componentInstance.lastCloseReason).toBe('escape');
+  });
+
+  it('uses the dialog close API for action buttons', () => {
+    const close = vi.fn();
+    const dialog = { close } as unknown as HTMLElement;
+
+    TestBed.createComponent(DialogComponent).componentInstance.closeFromAction(
+      dialog,
+    );
+
+    expect(close).toHaveBeenCalledWith('action');
+  });
+});


### PR DESCRIPTION
## Summary
- render the Angular dialog demo only after its opener is activated
- retain the m3-dialog close API and close-event state synchronization
- cover the initial closed state and close handlers

## Verification
- `pnpm --filter @apps/angular-app lint`
- `pnpm --filter @apps/angular-app test`
- `pnpm --filter @apps/angular-app typecheck`
- `pnpm --filter @apps/angular-app build` (existing budget warnings only)
- Playwright against `/dialog`: initial no dialog; action and Escape both close it