### PR TITLE
fix(dialog): synchronize initial focus with modal activation

### DIFF
--- a/packages/m3-dialog/src/m3-dialog.test.ts
+++ b/packages/m3-dialog/src/m3-dialog.test.ts
@@ -8,12 +8,8 @@ import type {
   M3DialogCloseReason,
 } from './m3-dialog.js';
 
-const nextFrame = () =>
-  new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
-
 async function settleDialog(dialog: M3Dialog) {
   await dialog.updateComplete;
-  await nextFrame();
 }
 
 describe('M3Dialog modal contract', () => {

--- a/packages/m3-dialog/src/m3-dialog.ts
+++ b/packages/m3-dialog/src/m3-dialog.ts
@@ -217,11 +217,9 @@ export class M3Dialog extends LitElement {
 
     void this.updateComplete.then(() => {
       this.showNativeModal();
-      requestAnimationFrame(() => {
-        if (this.open && M3Dialog.topDialog === this) {
-          this.focusInitial();
-        }
-      });
+      if (this.open && M3Dialog.topDialog === this) {
+        this.focusInitial();
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- focus the initial dialog target immediately after the rendered native modal opens
- make the dialog test settle on Lit's deterministic update lifecycle rather than a browser animation frame

## Validation
- Node v24.18.0 / pnpm 11.12.0
- pnpm --filter @banegasn/m3-dialog test (20 consecutive all-browser runs)
- pnpm lint and pnpm typecheck
- pnpm test: dialog passed; suite is blocked by an unrelated existing WebKit m3-menu Tab-focus assertion
- navigation coverage ratchets, tokens, build, production audit, package smoke, Svelte Vite smoke, and license verification