### PR TITLE
fix(tooltip): dismiss plain tooltips on leave

### DIFF
--- a/packages/m3-tooltip/src/m3-tooltip.test.ts
+++ b/packages/m3-tooltip/src/m3-tooltip.test.ts
@@ -28,7 +28,7 @@ describe('M3Tooltip public interaction contract', () => {
     expect(surface(tooltip).hasAttribute('visible')).to.equal(true);
 
     trigger.dispatchEvent(new MouseEvent('mouseleave', { relatedTarget: document.body }));
-    await settle(tooltip);
+    await tooltip.updateComplete;
     expect(surface(tooltip).hasAttribute('visible')).to.equal(false);
 
     trigger.focus();

--- a/packages/m3-tooltip/src/m3-tooltip.ts
+++ b/packages/m3-tooltip/src/m3-tooltip.ts
@@ -173,10 +173,17 @@ export class M3Tooltip extends LitElement {
   private _scheduleHide() {
     this._clearShowTimeout();
     if (!this._visible || this._hideTimeout !== null) return;
+    // Plain tooltips are not interactive, so they must dismiss as soon as the
+    // trigger is left. Only rich tooltips need a grace period for a pointer
+    // moving from the trigger into their interactive content.
+    if (this.variant !== 'rich') {
+      this._hideNow();
+      return;
+    }
     this._hideTimeout = setTimeout(() => {
       this._hideTimeout = null;
       this._hideNow();
-    }, this.variant === 'rich' ? RICH_HIDE_DELAY : 0);
+    }, RICH_HIDE_DELAY);
   }
 
   private _showNow() {


### PR DESCRIPTION
## Summary
- Dismiss plain tooltips immediately when their trigger is left.
- Retain the rich-tooltip grace period for pointer travel to interactive content.
- Synchronize the plain-tooltip browser contract with the immediate dismissal lifecycle.

## Validation
- m3-tooltip tests: Chromium, Firefox, and WebKit — 21 tests per engine.
- Lint and typecheck.
- Coverage ratchets, tokens, build, production audit, package smoke, Svelte smoke, and license verification.

The full pnpm test lane is blocked by an unrelated baseline WebKit failure in m3-menu: its real Tab key test expects #after but receives document.body. The focused menu run reproduces it on unchanged main code.