### PR TITLE
fix(dialog): synchronize native modal activation

### DIFF
--- a/packages/m3-dialog/src/m3-dialog.test.ts
+++ b/packages/m3-dialog/src/m3-dialog.test.ts
@@ -229,12 +229,18 @@ describe('M3Dialog modal contract', () => {
 
     first.open = true;
     await settleDialog(first);
+    expect(
+      first.shadowRoot!.querySelector<HTMLDialogElement>('.dialog')!.open,
+    ).to.equal(true);
     expect(background.inert).to.equal(true);
     expect(insideBackground.inert).to.equal(true);
     expect(document.body.style.overflow).to.equal('hidden');
 
     second.open = true;
     await settleDialog(second);
+    expect(
+      second.shadowRoot!.querySelector<HTMLDialogElement>('.dialog')!.open,
+    ).to.equal(true);
     document.dispatchEvent(
       new KeyboardEvent('keydown', {
         key: 'Escape',
@@ -252,6 +258,39 @@ describe('M3Dialog modal contract', () => {
     expect(insideBackground.inert).to.equal(false);
     expect(document.body.style.overflow).to.equal('');
     background.remove();
+  });
+
+  it('restores native modal containment when an open dialog reconnects', async () => {
+    const wrapper = await fixture<HTMLDivElement>(html`
+      <div>
+        <button id="background">Background</button>
+        <m3-dialog open><button>Dismiss</button></m3-dialog>
+      </div>
+    `);
+    const background = wrapper.querySelector<HTMLButtonElement>('#background')!;
+    const dialog = wrapper.querySelector<M3Dialog>('m3-dialog')!;
+    const surface =
+      dialog.shadowRoot!.querySelector<HTMLDialogElement>('.dialog')!;
+    await settleDialog(dialog);
+
+    expect(surface.open).to.equal(true);
+    expect(background.inert).to.equal(true);
+
+    dialog.remove();
+    expect(surface.open).to.equal(false);
+    expect(background.inert).to.equal(false);
+
+    wrapper.append(dialog);
+    await settleDialog(dialog);
+
+    expect(dialog.open).to.equal(true);
+    expect(surface.open).to.equal(true);
+    expect(surface.getAttribute('aria-modal')).to.equal('true');
+    expect(background.inert).to.equal(true);
+    const bounds = surface.getBoundingClientRect();
+    expect(document.elementFromPoint(bounds.x + 8, bounds.y + 8)).to.equal(
+      dialog,
+    );
   });
 
   it('puts the most recently opened dialog above an earlier DOM sibling across stacking contexts', async () => {

--- a/packages/m3-dialog/src/m3-dialog.test.ts
+++ b/packages/m3-dialog/src/m3-dialog.test.ts
@@ -241,6 +241,12 @@ describe('M3Dialog modal contract', () => {
     expect(
       second.shadowRoot!.querySelector<HTMLDialogElement>('.dialog')!.open,
     ).to.equal(true);
+    const secondSurface =
+      second.shadowRoot!.querySelector<HTMLDialogElement>('.dialog')!;
+    const secondBounds = secondSurface.getBoundingClientRect();
+    expect(
+      document.elementFromPoint(secondBounds.x + 8, secondBounds.y + 8),
+    ).to.equal(second);
     document.dispatchEvent(
       new KeyboardEvent('keydown', {
         key: 'Escape',
@@ -251,6 +257,13 @@ describe('M3Dialog modal contract', () => {
     await second.updateComplete;
     expect(second.open).to.equal(false);
     expect(first.open).to.equal(true);
+    const firstSurface =
+      first.shadowRoot!.querySelector<HTMLDialogElement>('.dialog')!;
+    expect(firstSurface.open).to.equal(true);
+    const firstBounds = firstSurface.getBoundingClientRect();
+    expect(
+      document.elementFromPoint(firstBounds.x + 8, firstBounds.y + 8),
+    ).to.equal(first);
 
     first.close();
     await first.updateComplete;

--- a/packages/m3-dialog/src/m3-dialog.ts
+++ b/packages/m3-dialog/src/m3-dialog.ts
@@ -99,12 +99,17 @@ export class M3Dialog extends LitElement {
   private readonly descriptionId = `m3-dialog-description-${this.instanceId}`;
   private opener: HTMLElement | null = null;
   private closeReason: M3DialogCloseReason = 'programmatic';
+  private modalActivationComplete = Promise.resolve();
+  private modalActivationPending = false;
 
   connectedCallback() {
     super.connectedCallback();
 
     if (this.open) {
       this.activate();
+      if (this.dialogElement) {
+        this.activateNativeModal();
+      }
     }
   }
 
@@ -150,9 +155,23 @@ export class M3Dialog extends LitElement {
 
     if (this.open) {
       this.activate();
+      this.activateNativeModal();
     } else if (changedProperties.get('open') === true) {
       this.deactivate();
     }
+  }
+
+  protected firstUpdated() {
+    if (this.open) {
+      this.activate();
+      this.activateNativeModal();
+    }
+  }
+
+  protected override async getUpdateComplete(): Promise<boolean> {
+    const completed = await super.getUpdateComplete();
+    await this.modalActivationComplete;
+    return completed;
   }
 
   /** Opens the dialog and returns after Lit has rendered the open state. */
@@ -207,17 +226,42 @@ export class M3Dialog extends LitElement {
     M3Dialog.openDialogs.push(this);
 
     M3Dialog.updatePageContainment();
-    this.dispatchEvent(
-      new CustomEvent('dialog-open', {
-        bubbles: true,
-        composed: true,
-        detail: { opener: this.opener },
-      }),
-    );
+  }
+
+  private activateNativeModal() {
+    if (this.modalActivationPending) {
+      return;
+    }
+
+    this.modalActivationPending = true;
+    this.modalActivationComplete = new Promise((resolve) => {
+      queueMicrotask(() => {
+        this.modalActivationPending = false;
+
+        if (
+          this.open &&
+          M3Dialog.openDialogs.includes(this) &&
+          this.showNativeModal()
+        ) {
+          this.dispatchEvent(
+            new CustomEvent('dialog-open', {
+              bubbles: true,
+              composed: true,
+              detail: { opener: this.opener },
+            }),
+          );
+        }
+
+        resolve();
+      });
+    });
 
     void this.updateComplete.then(() => {
-      this.showNativeModal();
-      if (this.open && M3Dialog.topDialog === this) {
+      if (
+        this.open &&
+        this.dialogElement?.open &&
+        M3Dialog.topDialog === this
+      ) {
         this.focusInitial();
       }
     });
@@ -309,12 +353,16 @@ export class M3Dialog extends LitElement {
    * The native modal dialog top layer is ordered by showModal() calls, not DOM
    * order or ancestor stacking contexts. Calling it from the modal stack makes
    * the most recently opened component the visual and pointer-event topmost.
+   * It runs after containment has restored the active dialog from inertness.
    */
-  private showNativeModal() {
+  private showNativeModal(): boolean {
     const dialog = this.dialogElement;
     if (dialog && !dialog.open) {
       dialog.showModal();
+      return true;
     }
+
+    return false;
   }
 
   private closeNativeModal() {

--- a/packages/m3-dialog/src/m3-dialog.ts
+++ b/packages/m3-dialog/src/m3-dialog.ts
@@ -99,8 +99,7 @@ export class M3Dialog extends LitElement {
   private readonly descriptionId = `m3-dialog-description-${this.instanceId}`;
   private opener: HTMLElement | null = null;
   private closeReason: M3DialogCloseReason = 'programmatic';
-  private modalActivationComplete = Promise.resolve();
-  private modalActivationPending = false;
+  private initialFocusComplete = Promise.resolve();
 
   connectedCallback() {
     super.connectedCallback();
@@ -170,7 +169,7 @@ export class M3Dialog extends LitElement {
 
   protected override async getUpdateComplete(): Promise<boolean> {
     const completed = await super.getUpdateComplete();
-    await this.modalActivationComplete;
+    await this.initialFocusComplete;
     return completed;
   }
 
@@ -229,41 +228,33 @@ export class M3Dialog extends LitElement {
   }
 
   private activateNativeModal() {
-    if (this.modalActivationPending) {
+    if (
+      !this.open ||
+      !M3Dialog.openDialogs.includes(this) ||
+      !this.showNativeModal()
+    ) {
       return;
     }
 
-    this.modalActivationPending = true;
-    this.modalActivationComplete = new Promise((resolve) => {
-      queueMicrotask(() => {
-        this.modalActivationPending = false;
+    this.dispatchEvent(
+      new CustomEvent('dialog-open', {
+        bubbles: true,
+        composed: true,
+        detail: { opener: this.opener },
+      }),
+    );
 
+    this.initialFocusComplete = new Promise((resolve) => {
+      requestAnimationFrame(() => {
         if (
           this.open &&
-          M3Dialog.openDialogs.includes(this) &&
-          this.showNativeModal()
+          this.dialogElement?.open &&
+          M3Dialog.topDialog === this
         ) {
-          this.dispatchEvent(
-            new CustomEvent('dialog-open', {
-              bubbles: true,
-              composed: true,
-              detail: { opener: this.opener },
-            }),
-          );
+          this.focusInitial();
         }
-
         resolve();
       });
-    });
-
-    void this.updateComplete.then(() => {
-      if (
-        this.open &&
-        this.dialogElement?.open &&
-        M3Dialog.topDialog === this
-      ) {
-        this.focusInitial();
-      }
     });
   }
 


### PR DESCRIPTION
## Summary\n- activate the native dialog top-layer state during Lit's post-render open update\n- retain deferred initial focus for slotted component rendering\n- verify stacked dialogs are natively open after their open update\n\n## Verification\n-  (Chromium, Firefox, WebKit)\n- \n- 