### PR TITLE
fix(angular-app): make components submenu selectable

### DIFF
--- a/apps/angular-app/src/app/app.component.html
+++ b/apps/angular-app/src/app/app.component.html
@@ -17,7 +17,7 @@
 
     <div class="desktop-components-trigger" [style.--components-menu-offset.px]="railExpanded() ? 24 : 8"
       (mouseenter)="onDesktopComponentsMouseEnter()" (mouseleave)="onDesktopComponentsMouseLeave()"
-      (menu-item-select)="onComponentsMenuItemSelect($event)">
+      >
       <m3-navigation-rail-item #desktopComponentsTrigger id="desktop-components-trigger" label="Components"
         [active]="isComponentsRoute()" aria-haspopup="menu" [attr.aria-expanded]="componentsMenuOpen()"
         (click)="onDesktopComponentsTriggerClick($event)"
@@ -30,7 +30,8 @@
 
       <m3-menu id="desktop-components-menu" placement="right-start" [offset]="railExpanded() ? 24 : 8" [open]="componentsMenuOpen()" [focusOnOpen]="false"
         (mouseenter)="onDesktopComponentsMouseEnter()" (mouseleave)="onDesktopComponentsMouseLeave()"
-        (menu-dismiss)="onComponentsMenuDismiss($event)" style="--md-comp-menu-max-height: calc(100vh - 400px);">
+        (menu-dismiss)="onComponentsMenuDismiss($event)" (menu-item-select)="onComponentsMenuItemSelect($event)"
+        style="--md-comp-menu-max-height: calc(100vh - 400px);">
         @for (item of componentMenuItems; track item.path) {
         <m3-menu-item [value]="item.path">
           <span slot="leading-icon" class="material-symbols-outlined">{{ item.icon }}</span>
@@ -74,10 +75,11 @@
   </div>
 </div>
 
-<div class="mobile-nav-shell" (menu-item-select)="onComponentsMenuItemSelect($event)">
+<div class="mobile-nav-shell">
   <div class="mobile-components-anchor">
     <m3-menu placement="top-center" [offset]="12" [open]="componentsMenuOpen()"
-      (menu-dismiss)="onComponentsMenuDismiss($event)" style="--md-comp-menu-max-height: calc(100dvh - 200px);">
+      (menu-dismiss)="onComponentsMenuDismiss($event)" (menu-item-select)="onComponentsMenuItemSelect($event)"
+      style="--md-comp-menu-max-height: calc(100dvh - 200px);">
       @for (item of componentMenuItems; track item.path) {
       <m3-menu-item [value]="item.path">
         <span slot="leading-icon" class="material-symbols-outlined">{{ item.icon }}</span>

--- a/apps/angular-app/src/app/app.component.ts
+++ b/apps/angular-app/src/app/app.component.ts
@@ -73,10 +73,6 @@ export class AppComponent implements OnInit, OnDestroy {
   private mobileComponentsLongPressFired = false;
   private desktopComponentsCloseTimer: ReturnType<typeof setTimeout> | null =
     null;
-  private boundMenuClick = (event: Event) =>
-    this.handleComponentsMenuClick(event);
-  private boundMenuItemSelect = (event: Event) =>
-    this.handleMenuItemSelectCapture(event);
 
   onRailToggle(event: Event) {
     const e = event as CustomEvent<{ expanded: boolean }>;
@@ -141,15 +137,6 @@ export class AppComponent implements OnInit, OnDestroy {
       }) as EventListener);
     }
 
-    // Capture menu-item-select at document so we handle it before the menu (menu stays open until we close it)
-    this.#document.addEventListener(
-      'menu-item-select',
-      this.boundMenuItemSelect,
-      true,
-    );
-    // Fallback: click on menu item
-    this.#document.addEventListener('click', this.boundMenuClick, true);
-
     // Track route changes for navigation bar active state
     this.currentRoute.set(this.#router.url);
     this.#router.events
@@ -165,12 +152,6 @@ export class AppComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.#document.removeEventListener(
-      'menu-item-select',
-      this.boundMenuItemSelect,
-      true,
-    );
-    this.#document.removeEventListener('click', this.boundMenuClick, true);
     if (this.desktopComponentsCloseTimer !== null) {
       clearTimeout(this.desktopComponentsCloseTimer);
     }
@@ -178,7 +159,6 @@ export class AppComponent implements OnInit, OnDestroy {
       clearTimeout(this.mobileComponentsLongPressTimer);
     }
   }
-
   initializeTheme() {
     let savedTheme = null;
     if (typeof localStorage !== 'undefined') {
@@ -308,54 +288,16 @@ export class AppComponent implements OnInit, OnDestroy {
     this.componentsMenuOpen.set(false);
   }
 
-  private isFromAppComponentsMenu(path: unknown[]): boolean {
-    return path.some(
-      (n) =>
-        n instanceof Element &&
-        ((n as Element).closest?.('.desktop-components-trigger') ||
-          (n as Element).closest?.('.mobile-nav-shell')),
-    );
-  }
-
-  handleComponentsMenuClick(event: Event) {
-    const path = event.composedPath?.() ?? [];
-    if (!this.isFromAppComponentsMenu(path)) return;
-
-    const menuItem = path.find(
-      (n): n is HTMLElement =>
-        n instanceof HTMLElement && n.tagName === 'M3-MENU-ITEM',
-    );
-    if (!menuItem) return;
-
-    const value =
-      (menuItem as unknown as { value?: string }).value ??
-      menuItem.getAttribute('value') ??
-      '';
-    if (value) this.navigate(value);
-  }
-
   onComponentsMenuItemSelect(event: Event) {
-    this.handleMenuItemSelectCapture(event);
-  }
-
-  handleMenuItemSelectCapture(event: Event) {
-    const path = event.composedPath?.() ?? [];
-    const fromOurMenu = this.isFromAppComponentsMenu(path);
-    if (!fromOurMenu) return;
-
     const e = event as CustomEvent<{ value?: string; text?: string }>;
     const value = e.detail?.value;
     if (value) {
-      event.stopPropagation();
-      event.preventDefault();
       this.navigate(value);
       return;
     }
     const text = e.detail?.text ?? '';
     const item = this.componentMenuItems.find((i) => i.label === text);
     if (item) {
-      event.stopPropagation();
-      event.preventDefault();
       this.navigate(item.path);
     }
   }


### PR DESCRIPTION
Fixes Components submenu navigation by handling selections directly on the menu and keeping items as direct menu children.