### PR TITLE
fix(angular-app): use native submenu links

### DIFF
--- a/apps/angular-app/src/app/app.component.css
+++ b/apps/angular-app/src/app/app.component.css
@@ -57,6 +57,12 @@
   width: var(--components-menu-offset);
 }
 
+.components-menu-link {
+  color: inherit;
+  display: block;
+  text-decoration: none;
+}
+
 m3-navigation-rail {
   opacity: 1;
   transition: opacity var(--md-sys-motion-duration-short3) var(--md-sys-motion-easing-standard-decelerate);

--- a/apps/angular-app/src/app/app.component.html
+++ b/apps/angular-app/src/app/app.component.html
@@ -30,13 +30,15 @@
 
       <m3-menu id="desktop-components-menu" placement="right-start" [offset]="railExpanded() ? 24 : 8" [open]="componentsMenuOpen()" [focusOnOpen]="false"
         (mouseenter)="onDesktopComponentsMouseEnter()" (mouseleave)="onDesktopComponentsMouseLeave()"
-        (menu-dismiss)="onComponentsMenuDismiss($event)" (menu-item-select)="onComponentsMenuItemSelect($event)"
+        (menu-dismiss)="onComponentsMenuDismiss($event)"
         style="--md-comp-menu-max-height: calc(100vh - 400px);">
         @for (item of componentMenuItems; track item.path) {
-        <m3-menu-item [value]="item.path">
-          <span slot="leading-icon" class="material-symbols-outlined">{{ item.icon }}</span>
-          {{ item.label }}
-        </m3-menu-item>
+        <a class="components-menu-link" [href]="item.path.substring(1)">
+          <m3-menu-item [value]="item.path">
+            <span slot="leading-icon" class="material-symbols-outlined">{{ item.icon }}</span>
+            {{ item.label }}
+          </m3-menu-item>
+        </a>
         }
       </m3-menu>
     </div>
@@ -78,13 +80,15 @@
 <div class="mobile-nav-shell">
   <div class="mobile-components-anchor">
     <m3-menu placement="top-center" [offset]="12" [open]="componentsMenuOpen()"
-      (menu-dismiss)="onComponentsMenuDismiss($event)" (menu-item-select)="onComponentsMenuItemSelect($event)"
+      (menu-dismiss)="onComponentsMenuDismiss($event)"
       style="--md-comp-menu-max-height: calc(100dvh - 200px);">
       @for (item of componentMenuItems; track item.path) {
-      <m3-menu-item [value]="item.path">
-        <span slot="leading-icon" class="material-symbols-outlined">{{ item.icon }}</span>
-        {{ item.label }}
-      </m3-menu-item>
+      <a class="components-menu-link" [href]="item.path.substring(1)">
+        <m3-menu-item [value]="item.path">
+          <span slot="leading-icon" class="material-symbols-outlined">{{ item.icon }}</span>
+          {{ item.label }}
+        </m3-menu-item>
+      </a>
       }
     </m3-menu>
   </div>

--- a/apps/angular-app/src/app/app.component.spec.ts
+++ b/apps/angular-app/src/app/app.component.spec.ts
@@ -4,9 +4,9 @@ import {
   ChangeDetectionStrategy,
 } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { provideRouter, Router } from '@angular/router';
+import { provideRouter } from '@angular/router';
 import '@banegasn/m3-button';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { AppComponent } from './app.component';
 
@@ -62,17 +62,13 @@ describe('AppComponent', () => {
     expect(button.textContent?.trim()).toBe('Integrated button');
   });
 
-  it('keeps the Components submenu open across its pointer bridge, navigates selections, and returns focus on Escape', async () => {
+  it('keeps the Components submenu open across its pointer bridge, exposes native links, and returns focus on Escape', async () => {
     await TestBed.configureTestingModule({
       imports: [AppComponent],
       providers: [provideRouter([])],
     }).compileComponents();
 
     const fixture = TestBed.createComponent(AppComponent);
-    const router = TestBed.inject(Router);
-    const navigateByUrl = vi
-      .spyOn(router, 'navigateByUrl')
-      .mockResolvedValue(true);
     fixture.detectChanges();
 
     const trigger = fixture.nativeElement.querySelector(
@@ -100,9 +96,10 @@ describe('AppComponent', () => {
     expect(menu.open).toBe(true);
 
     const firstMenuItem = menu.querySelector('m3-menu-item') as HTMLElement;
+    const firstMenuLink = firstMenuItem.closest('a');
+    expect(firstMenuLink?.getAttribute('href')).toBe('components');
     firstMenuItem.shadowRoot!.querySelector('button')!.click();
     await settle();
-    expect(navigateByUrl).toHaveBeenCalledWith('/components');
     expect(fixture.componentInstance.componentsMenuOpen()).toBe(false);
 
     trigger.dispatchEvent(

--- a/apps/angular-app/src/app/app.component.ts
+++ b/apps/angular-app/src/app/app.component.ts
@@ -288,20 +288,6 @@ export class AppComponent implements OnInit, OnDestroy {
     this.componentsMenuOpen.set(false);
   }
 
-  onComponentsMenuItemSelect(event: Event) {
-    const e = event as CustomEvent<{ value?: string; text?: string }>;
-    const value = e.detail?.value;
-    if (value) {
-      this.navigate(value);
-      return;
-    }
-    const text = e.detail?.text ?? '';
-    const item = this.componentMenuItems.find((i) => i.label === text);
-    if (item) {
-      this.navigate(item.path);
-    }
-  }
-
   onDesktopComponentsMouseEnter() {
     if (this.desktopComponentsCloseTimer !== null) {
       clearTimeout(this.desktopComponentsCloseTimer);


### PR DESCRIPTION
Uses native relative links for Components submenu entries so selection navigates independently of custom-event delivery. Retains menu keyboard support and hover bridge.