### PR TITLE
fix(angular-app): resolve submenu selection by item label

### DIFF
--- a/apps/angular-app/src/app/app.component.html
+++ b/apps/angular-app/src/app/app.component.html
@@ -30,7 +30,7 @@
 
       <m3-menu id="desktop-components-menu" placement="right-start" [offset]="railExpanded() ? 24 : 8" [open]="componentsMenuOpen()" [focusOnOpen]="false"
         (mouseenter)="onDesktopComponentsMouseEnter()" (mouseleave)="onDesktopComponentsMouseLeave()"
-        (menu-dismiss)="onComponentsMenuDismiss($event)"
+        (menu-dismiss)="onComponentsMenuDismiss($event)" (menu-item-select)="onComponentsMenuItemSelect($event)"
         style="--md-comp-menu-max-height: calc(100vh - 400px);">
         @for (item of componentMenuItems; track item.path) {
         <a class="components-menu-link" [href]="item.path.substring(1)">
@@ -80,7 +80,7 @@
 <div class="mobile-nav-shell">
   <div class="mobile-components-anchor">
     <m3-menu placement="top-center" [offset]="12" [open]="componentsMenuOpen()"
-      (menu-dismiss)="onComponentsMenuDismiss($event)"
+      (menu-dismiss)="onComponentsMenuDismiss($event)" (menu-item-select)="onComponentsMenuItemSelect($event)"
       style="--md-comp-menu-max-height: calc(100dvh - 200px);">
       @for (item of componentMenuItems; track item.path) {
       <a class="components-menu-link" [href]="item.path.substring(1)">

--- a/apps/angular-app/src/app/app.component.spec.ts
+++ b/apps/angular-app/src/app/app.component.spec.ts
@@ -4,9 +4,9 @@ import {
   ChangeDetectionStrategy,
 } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { provideRouter } from '@angular/router';
+import { provideRouter, Router } from '@angular/router';
 import '@banegasn/m3-button';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { AppComponent } from './app.component';
 
@@ -62,13 +62,17 @@ describe('AppComponent', () => {
     expect(button.textContent?.trim()).toBe('Integrated button');
   });
 
-  it('keeps the Components submenu open across its pointer bridge, exposes native links, and returns focus on Escape', async () => {
+  it('keeps the Components submenu open across its pointer bridge, routes selections, and returns focus on Escape', async () => {
     await TestBed.configureTestingModule({
       imports: [AppComponent],
       providers: [provideRouter([])],
     }).compileComponents();
 
     const fixture = TestBed.createComponent(AppComponent);
+    const router = TestBed.inject(Router);
+    const navigateByUrl = vi
+      .spyOn(router, 'navigateByUrl')
+      .mockResolvedValue(true);
     fixture.detectChanges();
 
     const trigger = fixture.nativeElement.querySelector(
@@ -100,6 +104,7 @@ describe('AppComponent', () => {
     expect(firstMenuLink?.getAttribute('href')).toBe('components');
     firstMenuItem.shadowRoot!.querySelector('button')!.click();
     await settle();
+    expect(navigateByUrl).toHaveBeenCalledWith('/components');
     expect(fixture.componentInstance.componentsMenuOpen()).toBe(false);
 
     trigger.dispatchEvent(

--- a/apps/angular-app/src/app/app.component.ts
+++ b/apps/angular-app/src/app/app.component.ts
@@ -288,6 +288,20 @@ export class AppComponent implements OnInit, OnDestroy {
     this.componentsMenuOpen.set(false);
   }
 
+  onComponentsMenuItemSelect(event: Event) {
+    const detail = (event as CustomEvent<{ value?: string; text?: string }>)
+      .detail;
+    const item = this.componentMenuItems.find(
+      (menuItem) =>
+        menuItem.path === detail?.value ||
+        menuItem.label === detail?.value ||
+        menuItem.label === detail?.text,
+    );
+    if (item) {
+      this.navigate(item.path);
+    }
+  }
+
   onDesktopComponentsMouseEnter() {
     if (this.desktopComponentsCloseTimer !== null) {
       clearTimeout(this.desktopComponentsCloseTimer);


### PR DESCRIPTION
Maps menu selection values and labels back to the known component paths before routing, preventing label values such as Buttons from falling through to /home.