### PR TITLE
fix(angular-app): restore settings switch actions

### DIFF
--- a/apps/angular-app/e2e/settings-dialog.spec.ts
+++ b/apps/angular-app/e2e/settings-dialog.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from 'playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/home');
+  await page.evaluate(() => {
+    localStorage.setItem('theme', 'light');
+    localStorage.setItem('rtl', 'false');
+    localStorage.setItem('motion', 'system');
+  });
+  await page.reload();
+  await page.getByRole('button', { name: 'Settings', exact: true }).click();
+});
+
+test('applies theme, motion, and direction from the settings switches', async ({
+  page,
+}) => {
+  const consoleErrors: string[] = [];
+  page.on('console', (message) => {
+    if (message.type() === 'error') consoleErrors.push(message.text());
+  });
+
+  const root = page.locator('html');
+  const darkMode = page.getByRole('switch', { name: 'Enable dark mode' });
+  const reducedMotion = page.getByRole('switch', {
+    name: 'Enable reduced motion verification',
+  });
+  const rtl = page.getByRole('switch', { name: 'Enable RTL layout' });
+
+  await darkMode.click();
+  await expect(root).toHaveAttribute('theme', 'dark');
+
+  await reducedMotion.click();
+  await expect(root).toHaveAttribute('data-motion', 'reduced');
+
+  await rtl.click();
+  await expect(root).toHaveAttribute('dir', 'rtl');
+
+  await expect
+    .poll(() =>
+      page.evaluate(() => ({
+        theme: localStorage.getItem('theme'),
+        motion: localStorage.getItem('motion'),
+        rtl: localStorage.getItem('rtl'),
+      })),
+    )
+    .toEqual({ theme: 'dark', motion: 'reduced', rtl: 'true' });
+
+  await darkMode.click();
+  await reducedMotion.click();
+  await rtl.click();
+  await expect(root).toHaveAttribute('theme', 'light');
+  await expect(root).not.toHaveAttribute('data-motion');
+  await expect(root).not.toHaveAttribute('dir');
+  expect(consoleErrors).toEqual([]);
+});

--- a/apps/angular-app/src/app/app.component.ts
+++ b/apps/angular-app/src/app/app.component.ts
@@ -11,6 +11,7 @@ import {
   effect,
   PLATFORM_ID,
   ChangeDetectionStrategy,
+  ChangeDetectorRef,
 } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 import { RouterOutlet, Router, NavigationEnd } from '@angular/router';
@@ -47,6 +48,7 @@ export class AppComponent implements OnInit, OnDestroy {
   #ngZone = inject(NgZone);
   #destroyRef = inject(DestroyRef);
   #platformId = inject(PLATFORM_ID);
+  #changeDetectorRef = inject(ChangeDetectorRef);
   title = 'Multi-Framework Components Demo';
   currentTheme = 'light';
   currentRoute = signal('/');
@@ -135,6 +137,7 @@ export class AppComponent implements OnInit, OnDestroy {
     if (typeof window !== 'undefined') {
       window.addEventListener('theme-changed', ((event: CustomEvent) => {
         this.currentTheme = event.detail;
+        this.#changeDetectorRef.markForCheck();
       }) as EventListener);
     }
 

--- a/apps/angular-app/src/app/components/settings/settings.component.html
+++ b/apps/angular-app/src/app/components/settings/settings.component.html
@@ -8,7 +8,7 @@
     <div class="setting-control">
       <m3-switch
         [checked]="darkModeEnabled"
-        (switch-change)="onDarkModeChange($event)"
+        (change)="onDarkModeChange($event)"
         aria-label="Enable dark mode">
       </m3-switch>
     </div>
@@ -45,7 +45,7 @@
     <div class="setting-control">
       <m3-switch
         [checked]="reducedMotionEnabled"
-        (switch-change)="onReducedMotionChange($event)"
+        (change)="onReducedMotionChange($event)"
         aria-label="Enable reduced motion verification">
       </m3-switch>
     </div>
@@ -61,7 +61,7 @@
     <div class="setting-control">
       <m3-switch
         [checked]="isRTL"
-        (switch-change)="onRTLChange($event)"
+        (change)="onRTLChange($event)"
         aria-label="Enable RTL layout">
       </m3-switch>
     </div>

--- a/apps/angular-app/src/app/components/settings/settings.component.spec.ts
+++ b/apps/angular-app/src/app/components/settings/settings.component.spec.ts
@@ -1,22 +1,74 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { M3Switch } from '@banegasn/m3-switch';
 import { SettingsComponent } from './settings.component';
 
-describe('SettingsComponent motion verification', () => {
-  it('activates and clears the demo reduced-motion token mode', async () => {
+describe('SettingsComponent', () => {
+  beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [SettingsComponent],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
     }).compileComponents();
 
+    document.documentElement.setAttribute('theme', 'light');
+    document.documentElement.removeAttribute('dir');
+    document.documentElement.removeAttribute('data-motion');
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    document.documentElement.setAttribute('theme', 'light');
+    document.documentElement.removeAttribute('dir');
+    document.documentElement.removeAttribute('data-motion');
+    localStorage.clear();
+  });
+
+  function changeSwitch(element: M3Switch, checked: boolean) {
+    element.checked = checked;
+    element.dispatchEvent(new Event('change', { bubbles: true }));
+  }
+
+  it('applies dark mode and RTL from native switch change events', () => {
     const fixture = TestBed.createComponent(SettingsComponent);
     fixture.detectChanges();
 
-    fixture.componentInstance.onReducedMotionChange(new CustomEvent('switch-change', { detail: { checked: true } }));
-    expect(document.documentElement.getAttribute('data-motion')).to.equal('reduced');
+    const switches = fixture.nativeElement.querySelectorAll(
+      'm3-switch',
+    ) as NodeListOf<M3Switch>;
+    const darkModeSwitch = switches[0];
+    const rtlSwitch = switches[2];
 
-    fixture.componentInstance.onReducedMotionChange(new CustomEvent('switch-change', { detail: { checked: false } }));
-    expect(document.documentElement.hasAttribute('data-motion')).to.equal(false);
+    changeSwitch(darkModeSwitch, true);
+    expect(document.documentElement.getAttribute('theme')).to.equal('dark');
+    expect(localStorage.getItem('theme')).to.equal('dark');
+
+    changeSwitch(rtlSwitch, true);
+    expect(document.documentElement.getAttribute('dir')).to.equal('rtl');
+    expect(localStorage.getItem('rtl')).to.equal('true');
+
+    changeSwitch(darkModeSwitch, false);
+    changeSwitch(rtlSwitch, false);
+    expect(document.documentElement.getAttribute('theme')).to.equal('light');
+    expect(document.documentElement.hasAttribute('dir')).to.equal(false);
+  });
+
+  it('activates and clears the demo reduced-motion token mode', () => {
+    const fixture = TestBed.createComponent(SettingsComponent);
+    fixture.detectChanges();
+
+    const motionSwitch = fixture.nativeElement.querySelectorAll(
+      'm3-switch',
+    )[1] as M3Switch;
+
+    changeSwitch(motionSwitch, true);
+    expect(document.documentElement.getAttribute('data-motion')).to.equal(
+      'reduced',
+    );
+
+    changeSwitch(motionSwitch, false);
+    expect(document.documentElement.hasAttribute('data-motion')).to.equal(
+      false,
+    );
   });
 });

--- a/apps/angular-app/src/app/components/settings/settings.component.ts
+++ b/apps/angular-app/src/app/components/settings/settings.component.ts
@@ -7,7 +7,7 @@ import {
   ChangeDetectionStrategy,
 } from '@angular/core';
 import { DialogRef } from '../../services/dialog.service';
-import '@banegasn/m3-switch';
+import { M3Switch } from '@banegasn/m3-switch';
 
 @Component({
   selector: 'app-settings',
@@ -72,14 +72,14 @@ export class SettingsComponent implements OnInit {
   }
 
   onDarkModeChange(event: Event) {
-    this.darkModeEnabled = (event as CustomEvent).detail.checked;
+    this.darkModeEnabled = this.#getSwitchChecked(event);
     this.#applyTheme(
       this.#buildTheme(this.activePalette, this.darkModeEnabled),
     );
   }
 
   onRTLChange(event: Event) {
-    this.isRTL = (event as CustomEvent).detail.checked;
+    this.isRTL = this.#getSwitchChecked(event);
     if (this.isRTL) {
       this.#document.documentElement.setAttribute('dir', 'rtl');
     } else {
@@ -90,7 +90,7 @@ export class SettingsComponent implements OnInit {
   }
 
   onReducedMotionChange(event: Event) {
-    this.reducedMotionEnabled = (event as CustomEvent).detail.checked;
+    this.reducedMotionEnabled = this.#getSwitchChecked(event);
     if (this.reducedMotionEnabled) {
       this.#document.documentElement.setAttribute('data-motion', 'reduced');
     } else {
@@ -99,5 +99,10 @@ export class SettingsComponent implements OnInit {
     if (typeof localStorage !== 'undefined') {
       localStorage.setItem('motion', this.reducedMotionEnabled ? 'reduced' : 'system');
     }
+  }
+
+  #getSwitchChecked(event: Event): boolean {
+    const switchElement = event.currentTarget ?? event.target;
+    return switchElement instanceof M3Switch && switchElement.checked;
   }
 }

--- a/apps/angular-app/src/pages/switches/switch.component.html
+++ b/apps/angular-app/src/pages/switches/switch.component.html
@@ -72,7 +72,7 @@
           </div>
           <m3-switch 
             [checked]="notificationsEnabled"
-            (switch-change)="onSwitchChange($event, 'notifications')"
+            (change)="onSwitchChange($event, 'notifications')"
             aria-label="Enable notifications">
           </m3-switch>
         </div>
@@ -83,7 +83,7 @@
           </div>
           <m3-switch 
             [checked]="darkModeEnabled"
-            (switch-change)="onSwitchChange($event, 'darkMode')"
+            (change)="onSwitchChange($event, 'darkMode')"
             aria-label="Enable dark mode">
           </m3-switch>
         </div>
@@ -94,7 +94,7 @@
           </div>
           <m3-switch 
             [checked]="autoSaveEnabled"
-            (switch-change)="onSwitchChange($event, 'autoSave')"
+            (change)="onSwitchChange($event, 'autoSave')"
             aria-label="Enable auto-save">
           </m3-switch>
         </div>
@@ -105,7 +105,7 @@
           </div>
           <m3-switch 
             [checked]="locationEnabled"
-            (switch-change)="onSwitchChange($event, 'location')"
+            (change)="onSwitchChange($event, 'location')"
             aria-label="Enable location services">
           </m3-switch>
         </div>
@@ -208,8 +208,8 @@
         </thead>
         <tbody>
           <tr>
-            <td><code>switch-change</code></td>
-            <td><code>&#123; checked: boolean, name: string | null, value: string | null &#125;</code></td>
+            <td><code>change</code></td>
+            <td>Read <code>checked</code> from the switch element</td>
             <td>Fired when the switch state changes</td>
           </tr>
         </tbody>

--- a/apps/angular-app/src/pages/switches/switch.component.ts
+++ b/apps/angular-app/src/pages/switches/switch.component.ts
@@ -1,7 +1,7 @@
 import { Component, ChangeDetectionStrategy, CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
 import { CodeBlockComponent } from "../../app/components/code-block/code-block.component";
 
-import '@banegasn/m3-switch';
+import { M3Switch } from '@banegasn/m3-switch';
 import '@banegasn/m3-card';
 
 @Component({
@@ -26,14 +26,15 @@ export class SwitchComponent {
 
   readonly interactiveExample = `<m3-switch
   [checked]="notificationsEnabled"
-  (switch-change)="onSwitchChange($event, 'notifications')">
+  (change)="onSwitchChange($event, 'notifications')">
 </m3-switch>`;
 
   readonly ariaExample = `<m3-switch aria-label="Enable Wi-Fi"></m3-switch>
 <m3-switch aria-labelledby="wifi-label"></m3-switch>`;
 
   onSwitchChange(event: Event, switchName: string) {
-    const checked = (event as CustomEvent).detail.checked;
+    const switchElement = event.currentTarget ?? event.target;
+    const checked = switchElement instanceof M3Switch && switchElement.checked;
     console.log(`${switchName} is now:`, checked);
     
     // Update the corresponding property
@@ -53,4 +54,3 @@ export class SwitchComponent {
     }
   }
 }
-


### PR DESCRIPTION
## Summary
- listen to the native `change` contract emitted by `m3-switch`
- restore dark mode, reduced-motion, and RTL updates in the Settings dialog
- update the interactive switch documentation and synchronize the app theme icon safely
- add Angular and cross-browser Playwright regression coverage

## Validation
- Angular unit tests: 10/10
- Playwright: 9/9 across Chromium, Firefox, and WebKit
- lint and typecheck
- production build