### PR TITLE
fix(angular-app): restore native interaction events

### DIFF
--- a/apps/angular-app/e2e/interaction-events.spec.ts
+++ b/apps/angular-app/e2e/interaction-events.spec.ts
@@ -1,0 +1,82 @@
+import { expect, test, type Page } from 'playwright/test';
+
+const consoleErrors = new WeakMap<Page, string[]>();
+
+test.beforeEach(async ({ page }) => {
+  const errors: string[] = [];
+  consoleErrors.set(page, errors);
+  page.on('console', (message) => {
+    if (message.type() === 'error') errors.push(message.text());
+  });
+});
+
+test.afterEach(async ({ page }) => {
+  expect(consoleErrors.get(page)).toEqual([]);
+});
+
+test('shows every snackbar variant from its native button click', async ({
+  page,
+}) => {
+  await page.goto('/snackbar');
+
+  const showButtons = page.getByRole('button', { name: 'Show Snackbar' });
+  const snackbars = page.locator('m3-snackbar');
+
+  for (let index = 0; index < 3; index += 1) {
+    await showButtons.nth(index).click();
+    await expect(snackbars.nth(index)).toHaveAttribute('open', '');
+  }
+});
+
+test('opens menus and reports the selected item', async ({ page }) => {
+  await page.goto('/menu');
+
+  const menu = page.locator('.menu-demo m3-menu').first();
+  await page.getByRole('button', { name: 'Open menu' }).click();
+  await expect(menu).toHaveAttribute('open', '');
+  await menu.getByRole('menuitem', { name: /Profile/ }).click();
+  await expect(page.getByText('Last selection:')).toContainText('Profile');
+  await expect(menu).not.toHaveAttribute('open', '');
+});
+
+test('updates radio, checkbox, and slider demos from native events', async ({
+  page,
+}) => {
+  await page.goto('/radio-buttons');
+  await page.getByRole('radio', { name: 'Dark theme' }).click();
+  await expect(
+    page.getByText('Selected:', { exact: false }).first(),
+  ).toContainText('dark');
+
+  await page.goto('/checkboxes');
+  await page.getByRole('checkbox', { name: 'Accept terms' }).click();
+  await expect(page.getByText('Accepted:')).toContainText('Yes');
+
+  await page.goto('/sliders');
+  const volume = page.getByRole('slider', { name: 'Volume' });
+  await volume.press('ArrowRight');
+  await expect(page.getByText('Volume Value:')).toContainText('51');
+});
+
+test('updates and clears search results through native input events', async ({
+  page,
+}) => {
+  await page.goto('/search-bar');
+
+  await page
+    .getByRole('searchbox', { name: 'Search', exact: true })
+    .fill('alpha');
+  await expect(page.getByText('Result 1 for "alpha"')).toBeVisible();
+  await page.getByRole('button', { name: 'Clear search' }).click();
+  await expect(page.getByText('Result 1 for "alpha"')).not.toBeVisible();
+});
+
+test('starts the button loading demo from a native click', async ({ page }) => {
+  await page.goto('/buttons');
+
+  const loadingDemo = page
+    .locator('m3-button')
+    .filter({ hasText: 'Submit Form' });
+  await loadingDemo.getByRole('button', { name: 'Submit Form' }).click();
+  await expect(loadingDemo).toHaveAttribute('loading', '');
+});

--- a/apps/angular-app/public/cdn-example.html
+++ b/apps/angular-app/public/cdn-example.html
@@ -369,7 +369,7 @@
       const allMenus = document.querySelectorAll('.dropdown-menu');
 
       menuTriggers.forEach((trigger, index) => {
-        trigger.addEventListener('button-click', (e) => {
+        trigger.addEventListener('click', () => {
           // Close other menus first
           allMenus.forEach((menu, i) => {
             if (i !== index) menu.removeAttribute('open');
@@ -396,8 +396,8 @@
       // Handle Task Completion via Radio Buttons
       const radios = document.querySelectorAll('m3-radio-button');
       radios.forEach(radio => {
-        radio.addEventListener('radio-change', (e) => {
-          if (e.detail.checked) {
+        radio.addEventListener('change', () => {
+          if (radio.checked) {
             const taskCard = radio.closest('.task-card');
             taskCard.classList.add('completed');
             // Uncheck after short delay to simulate completion and removal
@@ -414,14 +414,14 @@
       // Handle Fab Actions
       const fabButtons = document.querySelectorAll('m3-fab-menu m3-button');
       fabButtons.forEach(btn => {
-        btn.addEventListener('button-click', (e) => {
+        btn.addEventListener('click', () => {
           alert(`Triggered action: ${btn.getAttribute('aria-label')}`);
         });
       });
 
       // Handle Sync Button (Loading Indicator)
       const syncBtn = document.getElementById('sync-btn');
-      syncBtn.addEventListener('button-click', () => {
+      syncBtn.addEventListener('click', () => {
         if (syncBtn.hasAttribute('loading')) return;
         
         // Disable button and show loading state
@@ -456,8 +456,8 @@
       const searchBar = document.getElementById('task-search');
       const allTaskCards = document.querySelectorAll('.task-card');
 
-      searchBar.addEventListener('search-input', (e) => {
-        const query = e.detail.value.toLowerCase();
+      searchBar.addEventListener('input', () => {
+        const query = searchBar.value.toLowerCase();
         
         allTaskCards.forEach(card => {
           const text = card.querySelector('.task-text').textContent.toLowerCase();
@@ -466,12 +466,6 @@
           } else {
             card.style.display = 'none';
           }
-        });
-      });
-
-      searchBar.addEventListener('search-clear', () => {
-        allTaskCards.forEach(card => {
-          card.style.display = 'flex';
         });
       });
 

--- a/apps/angular-app/src/pages/buttons/button.component.html
+++ b/apps/angular-app/src/pages/buttons/button.component.html
@@ -426,7 +426,7 @@
 
     <div class="interactive-demo">
       <h4>Try it:</h4>
-      <m3-button #button (button-click)="onButtonClick(button)" variant="filled">
+      <m3-button #button (click)="onButtonClick(button)" variant="filled">
         <svg slot="icon" viewBox="0 0 24 24" width="18" height="18">
           <path fill="currentColor" d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z" />
         </svg>

--- a/apps/angular-app/src/pages/checkbox/checkbox.component.html
+++ b/apps/angular-app/src/pages/checkbox/checkbox.component.html
@@ -48,12 +48,13 @@
 
   <section class="demo-section">
     <h2>Interactive Example</h2>
-    <p>Listen to the <code>checkbox-change</code> event to respond to user interaction.</p>
+    <p>Listen to the native <code>change</code> event to respond to user interaction.</p>
     <div class="interactive-demo">
       <div class="demo-row" style="gap: 12px; align-items: center;">
-        <m3-checkbox (checkbox-change)="onCheckboxChange($event, 'terms')"></m3-checkbox>
+        <m3-checkbox aria-label="Accept terms" (change)="onCheckboxChange($event, 'terms')"></m3-checkbox>
         <span style="color: var(--md-sys-color-on-surface)">I accept the terms and conditions</span>
       </div>
+      <p>Accepted: <strong>{{ termsAccepted ? 'Yes' : 'No' }}</strong></p>
       <app-code-block [code]="interactiveExample" language="html" variant="sample"></app-code-block>
     </div>
   </section>

--- a/apps/angular-app/src/pages/checkbox/checkbox.component.ts
+++ b/apps/angular-app/src/pages/checkbox/checkbox.component.ts
@@ -1,7 +1,7 @@
 import { Component, ChangeDetectionStrategy, CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
 import { CodeBlockComponent } from "../../app/components/code-block/code-block.component";
 
-import '@banegasn/m3-checkbox';
+import { M3Checkbox } from '@banegasn/m3-checkbox';
 import '@banegasn/m3-card';
 
 @Component({
@@ -27,11 +27,13 @@ export class CheckboxComponent {
 
   readonly interactiveExample = `<m3-checkbox
   [checked]="termsAccepted"
-  (checkbox-change)="onCheckboxChange($event, 'terms')">
+  (change)="onCheckboxChange($event, 'terms')">
 </m3-checkbox>`;
 
   onCheckboxChange(event: Event, checkboxName: string) {
-    const detail = (event as CustomEvent).detail;
-    console.log(`${checkboxName} checked state is now:`, detail.checked);
+    const target = event.currentTarget ?? event.target;
+    if (!(target instanceof M3Checkbox)) return;
+    if (checkboxName === 'terms') this.termsAccepted = target.checked;
+    console.log(`${checkboxName} checked state is now:`, target.checked);
   }
 }

--- a/apps/angular-app/src/pages/home/home.component.html
+++ b/apps/angular-app/src/pages/home/home.component.html
@@ -12,7 +12,7 @@
     <app-seo-link href="components">
       <m3-button variant="outlined" size="large">Browse components</m3-button>
     </app-seo-link>
-    <m3-button variant="text" size="large" (button-click)="openGitHub()">
+    <m3-button variant="text" size="large" (click)="openGitHub()">
       <span slot="icon" class="material-symbols-outlined">code</span>
       GitHub
     </m3-button>

--- a/apps/angular-app/src/pages/menu/menu.component.html
+++ b/apps/angular-app/src/pages/menu/menu.component.html
@@ -19,7 +19,7 @@
             <div class="menu-demo">
                 <div class="demo-toolbar">
                     <div class="menu-anchor">
-                        <m3-button variant="filled" (button-click)="toggleMenu()">Open menu</m3-button>
+                        <m3-button variant="filled" (click)="toggleMenu()">Open menu</m3-button>
                         <m3-menu [attr.open]="menuOpen ? '' : null" [placement]="examplePlacement"
                             (menu-dismiss)="closeMenu()" (menu-item-select)="handleMenuSelect($event)">
                             <m3-menu-item value="profile">
@@ -37,7 +37,7 @@
                         </m3-menu>
                     </div>
                     <div class="menu-anchor placement-anchor">
-                        <m3-button variant="tonal" (button-click)="togglePlacementMenu()">
+                        <m3-button variant="tonal" (click)="togglePlacementMenu()">
                             Position: {{ examplePlacement }}
                         </m3-button>
                         <m3-menu placement="bottom-start" [attr.open]="placementMenuOpen ? '' : null"

--- a/apps/angular-app/src/pages/quick-start/quick-start.component.html
+++ b/apps/angular-app/src/pages/quick-start/quick-start.component.html
@@ -35,13 +35,13 @@
 
     <section class="page-section">
       <h2>React</h2>
-      <p>React 19+ natively supports Custom Elements. Listen to custom events by prefixing with <code>on</code> — e.g. <code>onbutton-click</code>.</p>
+      <p>React 19+ natively supports Custom Elements. Use the standard <code>onClick</code> handler for button activation.</p>
       <app-code-block language="jsx" variant="block" [code]="reactCode"></app-code-block>
     </section>
 
     <section class="page-section">
       <h2>Vue</h2>
-      <p>Vue has native support for Custom Elements. Use standard Vue directives like <code>&#64;button-click</code> to listen to custom events.</p>
+      <p>Vue has native support for Custom Elements. Use the standard <code>&#64;click</code> directive for button activation.</p>
       <app-code-block language="html" variant="block" [code]="vueCode"></app-code-block>
     </section>
 

--- a/apps/angular-app/src/pages/quick-start/quick-start.component.ts
+++ b/apps/angular-app/src/pages/quick-start/quick-start.component.ts
@@ -41,12 +41,12 @@ export class AppComponent {}`;
 import '@banegasn/m3-button';
 
 function App() {
-  const handleClick = (e) => {
-    console.log('Button clicked', e.detail);
+  const handleClick = (event) => {
+    console.log('Button clicked', event);
   };
 
   return (
-    <m3-button variant="filled" onbutton-click={handleClick}>
+    <m3-button variant="filled" onClick={handleClick}>
       React Button
     </m3-button>
   );
@@ -57,13 +57,13 @@ export default App;`;
   readonly vueCode = `<script setup>
 import '@banegasn/m3-button';
 
-const handleClick = (e) => {
-  console.log('Button clicked', e.detail);
+const handleClick = (event) => {
+  console.log('Button clicked', event);
 };
 </script>
 
 <template>
-  <m3-button variant="filled" @button-click="handleClick">
+  <m3-button variant="filled" @click="handleClick">
     Vue Button
   </m3-button>
 </template>`;

--- a/apps/angular-app/src/pages/radio-buttons/radio-button.component.html
+++ b/apps/angular-app/src/pages/radio-buttons/radio-button.component.html
@@ -50,7 +50,7 @@
             name="theme"
             value="light"
             [checked]="selectedTheme === 'light'"
-            (radio-change)="onRadioChange($event, 'theme')"
+            (change)="onRadioChange($event, 'theme')"
             aria-label="Light theme">
           </m3-radio-button>
           <label>Light</label>
@@ -60,7 +60,7 @@
             name="theme"
             value="dark"
             [checked]="selectedTheme === 'dark'"
-            (radio-change)="onRadioChange($event, 'theme')"
+            (change)="onRadioChange($event, 'theme')"
             aria-label="Dark theme">
           </m3-radio-button>
           <label>Dark</label>
@@ -70,7 +70,7 @@
             name="theme"
             value="auto"
             [checked]="selectedTheme === 'auto'"
-            (radio-change)="onRadioChange($event, 'theme')"
+            (change)="onRadioChange($event, 'theme')"
             aria-label="Auto theme">
           </m3-radio-button>
           <label>Auto</label>
@@ -103,7 +103,7 @@
             value="small"
             size="small"
             [checked]="selectedSize === 'small'"
-            (radio-change)="onRadioChange($event, 'size')"
+            (change)="onRadioChange($event, 'size')"
             aria-label="Small size">
           </m3-radio-button>
         </div>
@@ -118,7 +118,7 @@
             value="medium"
             size="medium"
             [checked]="selectedSize === 'medium'"
-            (radio-change)="onRadioChange($event, 'size')"
+            (change)="onRadioChange($event, 'size')"
             aria-label="Medium size">
           </m3-radio-button>
         </div>
@@ -133,7 +133,7 @@
             value="large"
             size="large"
             [checked]="selectedSize === 'large'"
-            (radio-change)="onRadioChange($event, 'size')"
+            (change)="onRadioChange($event, 'size')"
             aria-label="Large size">
           </m3-radio-button>
         </div>
@@ -262,8 +262,8 @@
         </thead>
         <tbody>
           <tr>
-            <td><code>radio-change</code></td>
-            <td><code>&#123; checked: boolean, name: string | null, value: string | null &#125;</code></td>
+            <td><code>change</code></td>
+            <td>Read <code>checked</code> and <code>value</code> from the radio element</td>
             <td>Fired when the radio button state changes</td>
           </tr>
         </tbody>
@@ -271,4 +271,3 @@
     </div>
   </section>
 </div>
-

--- a/apps/angular-app/src/pages/radio-buttons/radio-button.component.ts
+++ b/apps/angular-app/src/pages/radio-buttons/radio-button.component.ts
@@ -1,7 +1,7 @@
 import { Component, ChangeDetectionStrategy, CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
 import { CodeBlockComponent } from "../../app/components/code-block/code-block.component";
 
-import '@banegasn/m3-radio-button';
+import { M3RadioButton } from '@banegasn/m3-radio-button';
 import '@banegasn/m3-card';
 
 @Component({
@@ -28,34 +28,32 @@ export class RadioButtonComponent {
   name="theme"
   value="light"
   [checked]="selectedTheme === 'light'"
-  (radio-change)="onRadioChange($event, 'theme')">
+  (change)="onRadioChange($event, 'theme')">
 </m3-radio-button>`;
 
   readonly ariaExample = `<m3-radio-button aria-label="Option A"></m3-radio-button>
 <m3-radio-button aria-labelledby="label-id"></m3-radio-button>`;
 
   onRadioChange(event: Event, groupName: string) {
-    const checked = (event as CustomEvent).detail.checked;
-    const value = (event as CustomEvent).detail.value;
+    const target = event.currentTarget ?? event.target;
+    if (!(target instanceof M3RadioButton) || !target.checked) return;
+    const value = target.value ?? '';
+
+    console.log(`${groupName} is now:`, value);
     
-    if (checked) {
-      console.log(`${groupName} is now:`, value);
-      
-      switch (groupName) {
-        case 'theme':
-          this.selectedTheme = value;
-          break;
-        case 'size':
-          this.selectedSize = value;
-          break;
-        case 'color':
-          this.selectedColor = value;
-          break;
-        case 'option':
-          this.selectedOption = value;
-          break;
-      }
+    switch (groupName) {
+      case 'theme':
+        this.selectedTheme = value;
+        break;
+      case 'size':
+        this.selectedSize = value;
+        break;
+      case 'color':
+        this.selectedColor = value;
+        break;
+      case 'option':
+        this.selectedOption = value;
+        break;
     }
   }
 }
-

--- a/apps/angular-app/src/pages/search-bar/search-bar.component.html
+++ b/apps/angular-app/src/pages/search-bar/search-bar.component.html
@@ -15,9 +15,8 @@
                 <m3-search-bar
                     placeholder="Search in your files"
                     [value]="searchValue"
-                    (search-input)="onSearchInput($event)"
-                    (search-submit)="onSearchSubmit($event)"
-                    (search-clear)="onSearchClear()"
+                    (input)="onSearchInput($event)"
+                    (keydown.enter)="onSearchSubmit($event)"
                     aria-label="Search">
                 </m3-search-bar>
             </div>
@@ -32,9 +31,8 @@
                 <m3-search-bar
                     placeholder="Search products..."
                     [value]="searchValue"
-                    (search-input)="onSearchInput($event)"
-                    (search-submit)="onSearchSubmit($event)"
-                    (search-clear)="onSearchClear()"
+                    (input)="onSearchInput($event)"
+                    (keydown.enter)="onSearchSubmit($event)"
                     aria-label="Search products">
                     <span slot="leading" class="material-symbols-outlined">search</span>
                 </m3-search-bar>
@@ -51,17 +49,16 @@
                     #searchBarWithClear
                     placeholder="Search with clear button..."
                     [value]="searchValue"
-                    (search-input)="onSearchInput($event)"
-                    (search-submit)="onSearchSubmit($event)"
-                    (search-clear)="onSearchClear()"
+                    (input)="onSearchInput($event)"
+                    (keydown.enter)="onSearchSubmit($event)"
                     aria-label="Search with clear">
                     <span slot="leading" class="material-symbols-outlined">search</span>
                     @if (searchValue) {
-                        <m3-button icon-only slot="trailing" variant="text" (button-click)="clearSearch(searchBarWithClear)">
+                        <m3-button aria-label="Clear search" icon-only slot="trailing" variant="text" (click)="clearSearch(searchBarWithClear)">
                             <span slot="icon" class="material-symbols-outlined">close</span>
                         </m3-button>
                     }
-                    <m3-button icon-only slot="trailing" variant="text">
+                    <m3-button aria-label="Search options" icon-only slot="trailing" variant="text">
                         <span slot="icon" class="material-symbols-outlined">more_vert</span>
                     </m3-button>
                 </m3-search-bar>
@@ -77,11 +74,10 @@
                 <m3-search-bar
                     placeholder="Search with menu..."
                     [value]="searchValue"
-                    (search-input)="onSearchInput($event)"
-                    (search-submit)="onSearchSubmit($event)"
-                    (search-clear)="onSearchClear()"
+                    (input)="onSearchInput($event)"
+                    (keydown.enter)="onSearchSubmit($event)"
                     aria-label="Search with menu">
-                    <m3-button icon-only slot="leading" variant="text" class="menu-button" size="small">
+                    <m3-button aria-label="Search menu" icon-only slot="leading" variant="text" class="menu-button" size="small">
                         <span slot="icon" class="material-symbols-outlined">menu</span>
                     </m3-button>
                 </m3-search-bar>
@@ -169,13 +165,13 @@
             </div>
             <div class="properties-list">
                 <div class="property-item">
-                    <strong>search-input</strong>: Fired when the input value changes
+                    <strong>input</strong>: Native event fired when the input value changes
                 </div>
                 <div class="property-item">
-                    <strong>search-submit</strong>: Fired when Enter is pressed
+                    <strong>change</strong>: Native event fired when the value is committed or cleared
                 </div>
                 <div class="property-item">
-                    <strong>search-clear</strong>: Fired when the search is cleared (Escape key)
+                    <strong>submit</strong>: Use the owner form's native submit event
                 </div>
             </div>
         </div>

--- a/apps/angular-app/src/pages/search-bar/search-bar.component.ts
+++ b/apps/angular-app/src/pages/search-bar/search-bar.component.ts
@@ -1,7 +1,7 @@
 import { Component, ChangeDetectionStrategy, CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
 import { CodeBlockComponent } from "../../app/components/code-block/code-block.component";
 
-import '@banegasn/m3-search-bar';
+import { M3SearchBar } from '@banegasn/m3-search-bar';
 import '@banegasn/m3-card';
 import '@banegasn/m3-button';
 
@@ -43,7 +43,9 @@ export class SearchBarComponent {
 </m3-search-bar>`;
 
   onSearchInput(event: Event) {
-    const value = (event as CustomEvent).detail.value;
+    const target = event.currentTarget ?? event.target;
+    if (!(target instanceof M3SearchBar)) return;
+    const value = target.value;
     this.searchValue = value;
     console.log('Search input:', value);
     
@@ -60,22 +62,15 @@ export class SearchBarComponent {
   }
 
   onSearchSubmit(event: Event) {
-    const value = (event as CustomEvent).detail.value;
+    const target = event.currentTarget ?? event.target;
+    if (!(target instanceof M3SearchBar)) return;
+    const value = target.value;
     console.log('Search submitted:', value);
     alert(`Searching for: ${value}`);
   }
 
-  onSearchClear() {
-    this.searchValue = '';
-    this.searchResults = [];
-    console.log('Search cleared');
-  }
-
-  clearSearch(searchBar: any) {
-    if (searchBar && typeof searchBar.clear === 'function') {
-      searchBar.clear();
-    }
+  clearSearch(searchBar: M3SearchBar) {
+    searchBar.clear();
   }
 }
-
 

--- a/apps/angular-app/src/pages/slider/slider.component.html
+++ b/apps/angular-app/src/pages/slider/slider.component.html
@@ -31,12 +31,12 @@
 
   <section class="demo-section">
     <h2>Interactive Example</h2>
-    <p>Listen to the <code>slider-change</code> event to respond to user interaction.</p>
+    <p>Listen to the native <code>input</code> event to respond while the value changes.</p>
     <div class="interactive-demo">
       <div class="demo-row" style="width: 100%; max-width: 400px; padding: 24px 0; flex-direction: column; gap: 16px;">
         <div style="width: 100%; display: flex; align-items: center; gap: 16px;">
             <span class="material-symbols-outlined" style="color: var(--md-sys-color-on-surface-variant)">volume_down</span>
-            <m3-slider min="0" max="100" [value]="volume" (slider-change)="onSliderChange($event, 'volume')" style="flex: 1;"></m3-slider>
+            <m3-slider aria-label="Volume" min="0" max="100" [value]="volume" (input)="onSliderChange($event, 'volume')" style="flex: 1;"></m3-slider>
             <span class="material-symbols-outlined" style="color: var(--md-sys-color-on-surface-variant)">volume_up</span>
         </div>
         <div style="color: var(--md-sys-color-on-surface); font-weight: 500;">Volume Value: {{ volume }}</div>

--- a/apps/angular-app/src/pages/slider/slider.component.ts
+++ b/apps/angular-app/src/pages/slider/slider.component.ts
@@ -1,7 +1,7 @@
 import { Component, ChangeDetectionStrategy, CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
 import { CodeBlockComponent } from "../../app/components/code-block/code-block.component";
 
-import '@banegasn/m3-slider';
+import { M3Slider } from '@banegasn/m3-slider';
 import '@banegasn/m3-card';
 
 @Component({
@@ -25,14 +25,13 @@ export class SliderComponent {
   min="0"
   max="100"
   [value]="volume"
-  (slider-change)="onSliderChange($event, 'volume')">
+  (input)="onSliderChange($event, 'volume')">
 </m3-slider>
 <p>Volume: {{volume}}</p>`;
 
   onSliderChange(event: Event, sliderName: string) {
-    const detail = (event as CustomEvent).detail;
-    if (sliderName === 'volume') {
-      this.volume = detail.value;
-    }
+    const target = event.currentTarget ?? event.target;
+    if (sliderName === 'volume' && target instanceof M3Slider)
+      this.volume = target.value;
   }
 }

--- a/apps/angular-app/src/pages/snackbar/snackbar.component.html
+++ b/apps/angular-app/src/pages/snackbar/snackbar.component.html
@@ -8,7 +8,7 @@
     <h2>Basic</h2>
     <div class="interactive-demo">
       <div class="demo-row">
-        <m3-button variant="filled" (button-click)="showBasic.set(true)">Show Snackbar</m3-button>
+        <m3-button variant="filled" (click)="showBasic.set(true)">Show Snackbar</m3-button>
       </div>
       <div class="demo-row snackbar-demo">
         <m3-snackbar [attr.open]="showBasic() ? '' : null" duration="3000" (snackbar-dismiss)="showBasic.set(false)">
@@ -23,7 +23,7 @@
     <h2>With Action</h2>
     <div class="interactive-demo">
       <div class="demo-row">
-        <m3-button variant="filled" (button-click)="showAction.set(true)">Show Snackbar</m3-button>
+        <m3-button variant="filled" (click)="showAction.set(true)">Show Snackbar</m3-button>
       </div>
       <div class="demo-row snackbar-demo">
         <m3-snackbar [attr.open]="showAction() ? '' : null" duration="5000" (snackbar-dismiss)="showAction.set(false)">
@@ -39,7 +39,7 @@
     <h2>Two-Line</h2>
     <div class="interactive-demo">
       <div class="demo-row">
-        <m3-button variant="filled" (button-click)="showTwoLine.set(true)">Show Snackbar</m3-button>
+        <m3-button variant="filled" (click)="showTwoLine.set(true)">Show Snackbar</m3-button>
       </div>
       <div class="demo-row snackbar-demo">
         <m3-snackbar [attr.open]="showTwoLine() ? '' : null" lines="2" duration="6000" (snackbar-dismiss)="showTwoLine.set(false)">


### PR DESCRIPTION
## Summary
- replace removed component-specific form-control events with native browser events across the Angular demos
- restore Snackbar, Menu, Search, Radio, Checkbox, Slider, button actions, Home GitHub action, Quick Start examples, and the CDN example
- add cross-browser Playwright regression coverage while retaining the Settings regression suite

## Validation
- pnpm --filter @apps/angular-app lint
- pnpm --filter @apps/angular-app typecheck
- pnpm --filter @apps/angular-app test (10 passed)
- pnpm --filter @apps/angular-app test:e2e (24 passed across Chromium, Firefox, and WebKit)
- pnpm --filter @apps/angular-app build
- manual in-app browser verification for Snackbar and Settings toggles