### PR TITLE
fix(forms): synchronize disabled state before render

### DIFF
--- a/apps/angular-app/e2e/interaction-events.spec.ts
+++ b/apps/angular-app/e2e/interaction-events.spec.ts
@@ -71,6 +71,22 @@ test('updates and clears search results through native input events', async ({
   await expect(page.getByText('Result 1 for "alpha"')).not.toBeVisible();
 });
 
+test('renders the disabled search bar before any user interaction', async ({
+  page,
+}) => {
+  await page.goto('/search-bar');
+
+  const disabledSearch = page.getByRole('searchbox', {
+    name: 'Disabled search',
+  });
+  await expect(disabledSearch).toBeDisabled();
+  await expect(
+    page.locator(
+      'm3-search-bar[aria-label="Disabled search"] .search-bar',
+    ),
+  ).toHaveCSS('opacity', '0.38');
+});
+
 test('starts the button loading demo from a native click', async ({ page }) => {
   await page.goto('/buttons');
 

--- a/packages/m3-checkbox/src/m3-form-associated.test.ts
+++ b/packages/m3-checkbox/src/m3-form-associated.test.ts
@@ -57,6 +57,88 @@ describe('form-associated controls', () => {
     expect(new FormData(container.querySelector<HTMLFormElement>('#disabled-owner')!).has('skip')).to.equal(false);
   });
 
+  it('renders programmatic disabled state before another interaction for every control', async () => {
+    const container = await fixture<HTMLDivElement>(html`
+      <div>
+        <m3-button>Save</m3-button>
+        <m3-checkbox aria-label="Terms"></m3-checkbox>
+        <m3-radio-button aria-label="Theme"></m3-radio-button>
+        <m3-search-bar aria-label="Search"></m3-search-bar>
+        <m3-slider aria-label="Volume"></m3-slider>
+        <m3-switch aria-label="Alerts"></m3-switch>
+        <m3-text-field label="Name"></m3-text-field>
+      </div>
+    `);
+    const button = container.querySelector<M3Button>('m3-button')!;
+    const checkbox = container.querySelector<M3Checkbox>('m3-checkbox')!;
+    const radio = container.querySelector<M3RadioButton>('m3-radio-button')!;
+    const search = container.querySelector<M3SearchBar>('m3-search-bar')!;
+    const slider = container.querySelector<M3Slider>('m3-slider')!;
+    const controlSwitch = container.querySelector<M3Switch>('m3-switch')!;
+    const text = container.querySelector<M3TextField>('m3-text-field')!;
+    const controls = [
+      button,
+      checkbox,
+      radio,
+      search,
+      slider,
+      controlSwitch,
+      text,
+    ];
+
+    await Promise.all(controls.map((control) => control.updateComplete));
+    controls.forEach((control) => {
+      control.disabled = true;
+    });
+    await Promise.all(controls.map((control) => control.updateComplete));
+
+    expect(button.shadowRoot!.querySelector('button')!.disabled).to.equal(true);
+    expect(
+      checkbox.shadowRoot!
+        .querySelector('[role="checkbox"]')!
+        .getAttribute('aria-disabled'),
+    ).to.equal('true');
+    expect(
+      radio.shadowRoot!
+        .querySelector('[role="radio"]')!
+        .getAttribute('aria-disabled'),
+    ).to.equal('true');
+    expect(search.shadowRoot!.querySelector('input')!.disabled).to.equal(true);
+    expect(slider.shadowRoot!.querySelector('input')!.disabled).to.equal(true);
+    expect(
+      controlSwitch.shadowRoot!
+        .querySelector('[role="switch"]')!
+        .getAttribute('aria-disabled'),
+    ).to.equal('true');
+    expect(text.shadowRoot!.querySelector('input')!.disabled).to.equal(true);
+
+    controls.forEach((control) => {
+      control.disabled = false;
+    });
+    await Promise.all(controls.map((control) => control.updateComplete));
+    await Promise.all(controls.map((control) => control.updateComplete));
+
+    expect(button.shadowRoot!.querySelector('button')!.disabled).to.equal(false);
+    expect(
+      checkbox.shadowRoot!
+        .querySelector('[role="checkbox"]')!
+        .hasAttribute('aria-disabled'),
+    ).to.equal(false);
+    expect(
+      radio.shadowRoot!
+        .querySelector('[role="radio"]')!
+        .hasAttribute('aria-disabled'),
+    ).to.equal(false);
+    expect(search.shadowRoot!.querySelector('input')!.disabled).to.equal(false);
+    expect(slider.shadowRoot!.querySelector('input')!.disabled).to.equal(false);
+    expect(
+      controlSwitch.shadowRoot!
+        .querySelector('[role="switch"]')!
+        .hasAttribute('aria-disabled'),
+    ).to.equal(false);
+    expect(text.shadowRoot!.querySelector('input')!.disabled).to.equal(false);
+  });
+
   it('enforces required fields through native form validity', async () => {
     const form = await fixture<HTMLFormElement>(html`
       <form><m3-text-field name="email" required></m3-text-field></form>

--- a/packages/m3-form-associated/src/form-associated-element.ts
+++ b/packages/m3-form-associated/src/form-associated-element.ts
@@ -1,4 +1,4 @@
-import { LitElement } from 'lit';
+import { LitElement, type PropertyValues } from 'lit';
 
 /** A value that ElementInternals can contribute to FormData. */
 export type FormAssociatedValue = File | FormData | string | null;
@@ -31,11 +31,14 @@ export function validityFlags(validity: ValidityState): FormValidityFlags {
 export abstract class FormAssociatedElement extends LitElement {
   static readonly formAssociated = true;
 
+  /** Direct disabled state owned by each concrete form control. */
+  abstract disabled: boolean;
+
   private readonly _internals = typeof this.attachInternals === 'function'
     ? this.attachInternals()
     : undefined;
 
-  private _fieldsetDisabled = false;
+  private _formDisabled = false;
 
   /** The form owner, including an owner selected with the host `form` attribute. */
   get form(): HTMLFormElement | null {
@@ -66,11 +69,20 @@ export abstract class FormAssociatedElement extends LitElement {
 
   /** True when this control is disabled directly or through a disabled fieldset. */
   protected get formDisabled(): boolean {
-    return this._fieldsetDisabled;
+    return this._formDisabled;
   }
 
   protected get isFormDisabled(): boolean {
-    return this._fieldsetDisabled || this.hasAttribute('disabled');
+    return this._formDisabled || this.disabled;
+  }
+
+  protected willUpdate(changedProperties: PropertyValues<this>): void {
+    if (changedProperties.has('disabled')) {
+      // Lit normally reflects after render. Form-associated controls need the
+      // browser disabled callback before render so their internal control and
+      // visual state cannot lag one update behind a property binding.
+      this.toggleAttribute('disabled', this.disabled);
+    }
   }
 
   checkValidity(): boolean {
@@ -119,8 +131,10 @@ export abstract class FormAssociatedElement extends LitElement {
   }
 
   formDisabledCallback(disabled: boolean): void {
-    this._fieldsetDisabled = disabled;
-    this.requestUpdate();
+    if (this._formDisabled !== disabled) {
+      this._formDisabled = disabled;
+      this.requestUpdate();
+    }
   }
 
   formResetCallback(): void {


### PR DESCRIPTION
## Summary
- synchronize the shared form-associated disabled state before Lit renders reflected properties
- fix Angular property bindings whose internal controls and disabled visuals lagged until another interaction
- cover button, checkbox, radio, search bar, slider, switch, and text field in one cross-browser regression
- assert the Angular disabled Search Bar is disabled and visually attenuated on first paint

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build
- 27/27 Angular Playwright tests across Chromium, Firefox, and WebKit
- 27/27 shared form-associated package tests across Chromium, Firefox, and WebKit
- manual local in-app browser visual verification