### PR TITLE
feat(docs): unify and polish component pages

### DIFF
--- a/apps/angular-app/e2e/docs-layout.spec.ts
+++ b/apps/angular-app/e2e/docs-layout.spec.ts
@@ -1,0 +1,107 @@
+import { expect, test } from 'playwright/test';
+
+const documentationRoutes = [
+  '/quick-start',
+  '/components',
+  '/buttons',
+  '/cards',
+  '/navigation-rail',
+  '/navigation-bar',
+  '/switches',
+  '/radio-buttons',
+  '/checkboxes',
+  '/sliders',
+  '/text-fields',
+  '/chips',
+  '/dialog',
+  '/tooltip',
+  '/badge',
+  '/divider',
+  '/list',
+  '/progress',
+  '/tabs',
+  '/search-bar',
+  '/split-button',
+  '/menu',
+  '/loading-indicator',
+  '/fab-menu',
+  '/icon-button',
+  '/top-app-bar',
+  '/snackbar',
+  '/contact',
+] as const;
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('theme', 'light');
+    localStorage.setItem('rtl', 'false');
+    localStorage.setItem('railExpanded', 'true');
+  });
+});
+
+test('every documentation route uses the shared page layout', async ({
+  page,
+}) => {
+  test.setTimeout(60_000);
+
+  for (const route of documentationRoutes) {
+    await page.goto(route);
+
+    await expect(page.locator('app-page-header')).toHaveCount(1);
+    await expect(page.locator('#route-page-title')).toBeVisible();
+    await expect(page.locator('.route-content .docs-page')).toBeVisible();
+    await expect(page.locator('.docs-page .page-header')).toHaveCount(0);
+
+    const hasHorizontalOverflow = await page.evaluate(
+      () =>
+        document.documentElement.scrollWidth >
+        document.documentElement.clientWidth + 1,
+    );
+    expect(
+      hasHorizontalOverflow,
+      `${route} should not overflow horizontally`,
+    ).toBe(false);
+  }
+});
+
+test('home keeps its focused hero while using the shared app shell', async ({
+  page,
+}) => {
+  await page.goto('/home');
+
+  await expect(
+    page.getByRole('heading', {
+      level: 1,
+      name: 'Build expressive UIs. Use any framework.',
+    }),
+  ).toBeVisible();
+  await expect(page.locator('app-page-header')).toHaveCount(0);
+  await expect(page.locator('.hero-preview')).toBeVisible();
+});
+
+test('representative pages remain polished and overflow-free on mobile', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+
+  for (const route of [
+    '/home',
+    '/components',
+    '/buttons',
+    '/quick-start',
+    '/contact',
+  ]) {
+    await page.goto(route);
+    await expect(page.locator('.mobile-nav-shell')).toBeVisible();
+    await expect(page.locator('.desktop-nav-shell')).toBeHidden();
+
+    const hasHorizontalOverflow = await page.evaluate(
+      () =>
+        document.documentElement.scrollWidth >
+        document.documentElement.clientWidth + 1,
+    );
+    expect(hasHorizontalOverflow, `${route} should fit a 390px viewport`).toBe(
+      false,
+    );
+  }
+});

--- a/apps/angular-app/src/app/app.component.css
+++ b/apps/angular-app/src/app/app.component.css
@@ -7,6 +7,16 @@
 .app-container {
   flex: 1;
   overflow: auto;
+  background: linear-gradient(
+    180deg,
+    color-mix(
+        in srgb,
+        var(--md-sys-color-primary-container) 18%,
+        var(--md-sys-color-surface-container-low)
+      )
+      0,
+    var(--md-sys-color-surface-container-low) 440px
+  );
   scrollbar-width: thin;
   scrollbar-color: var(--md-sys-color-outline) transparent;
 }
@@ -30,9 +40,19 @@
 }
 
 .app-content {
-  padding: clamp(16px, 3vw, 32px);
-  max-width: 1100px;
+  width: 100%;
+  max-width: 1240px;
   margin: 0 auto;
+  padding: clamp(20px, 4vw, 52px) clamp(16px, 4vw, 48px) clamp(48px, 8vw, 96px);
+}
+
+.route-content {
+  min-width: 0;
+}
+
+.route-content--home {
+  max-width: 1160px;
+  margin-inline: auto;
 }
 
 /* Navigation Rail - Desktop/Tablet */
@@ -81,17 +101,18 @@
 
 m3-navigation-rail {
   opacity: 1;
-  transition: opacity var(--md-sys-motion-duration-short3) var(--md-sys-motion-easing-standard-decelerate);
+  transition: opacity var(--md-sys-motion-duration-short3)
+    var(--md-sys-motion-easing-standard-decelerate);
 }
 
 m3-navigation-rail:not(:defined) {
   opacity: 0;
 }
 
-
 m3-navigation-bar {
   opacity: 1;
-  transition: opacity var(--md-sys-motion-duration-short3) var(--md-sys-motion-easing-standard-decelerate);
+  transition: opacity var(--md-sys-motion-duration-short3)
+    var(--md-sys-motion-easing-standard-decelerate);
 }
 
 m3-navigation-bar:not(:defined) {
@@ -100,7 +121,8 @@ m3-navigation-bar:not(:defined) {
 
 m3-menu {
   opacity: 1;
-  transition: opacity var(--md-sys-motion-duration-short3) var(--md-sys-motion-easing-standard-decelerate);
+  transition: opacity var(--md-sys-motion-duration-short3)
+    var(--md-sys-motion-easing-standard-decelerate);
 }
 
 m3-menu:not(:defined) {
@@ -143,7 +165,7 @@ m3-menu:not(:defined) {
   }
 
   .app-content {
-    padding: 16px;
+    padding: 16px 14px 32px;
     max-width: 100%;
   }
 }

--- a/apps/angular-app/src/app/app.component.html
+++ b/apps/angular-app/src/app/app.component.html
@@ -1,120 +1,211 @@
 <!-- Navigation Rail for Desktop/Tablet (hidden on mobile) -->
 <div class="desktop-nav-shell">
-  <m3-navigation-rail class="desktop-nav" [attr.expanded]="railExpanded() ? '' : null" (menu-toggle)="onRailToggle($event)">
+  <m3-navigation-rail
+    class="desktop-nav"
+    [attr.expanded]="railExpanded() ? '' : null"
+    (menu-toggle)="onRailToggle($event)"
+  >
     <m3-navigation-rail-toggle></m3-navigation-rail-toggle>
 
     <app-seo-link href="home">
-      <m3-navigation-rail-item label="Home" [active]="currentRoute() === '/home'">
+      <m3-navigation-rail-item
+        label="Home"
+        [active]="currentRoute() === '/home'"
+      >
         <span slot="icon" class="material-symbols-outlined">home</span>
       </m3-navigation-rail-item>
     </app-seo-link>
 
     <app-seo-link href="quick-start">
-      <m3-navigation-rail-item label="Quick Start" [active]="currentRoute() === '/quick-start'">
+      <m3-navigation-rail-item
+        label="Quick Start"
+        [active]="currentRoute() === '/quick-start'"
+      >
         <span slot="icon" class="material-symbols-outlined">rocket_launch</span>
       </m3-navigation-rail-item>
     </app-seo-link>
 
-    <div class="desktop-components-trigger" [style.--components-menu-offset.px]="railExpanded() ? 24 : 8"
-      (mouseenter)="onDesktopComponentsMouseEnter()" (mouseleave)="onDesktopComponentsMouseLeave()"
-      >
-      <m3-navigation-rail-item #desktopComponentsTrigger id="desktop-components-trigger" label="Components"
-        [active]="isComponentsRoute()" aria-haspopup="menu" [attr.aria-expanded]="desktopComponentsMenuOpen()"
+    <div
+      class="desktop-components-trigger"
+      [style.--components-menu-offset.px]="railExpanded() ? 24 : 8"
+      (mouseenter)="onDesktopComponentsMouseEnter()"
+      (mouseleave)="onDesktopComponentsMouseLeave()"
+    >
+      <m3-navigation-rail-item
+        #desktopComponentsTrigger
+        id="desktop-components-trigger"
+        label="Components"
+        [active]="isComponentsRoute()"
+        aria-haspopup="menu"
+        [attr.aria-expanded]="desktopComponentsMenuOpen()"
         (click)="onDesktopComponentsTriggerClick($event)"
-        (keydown)="onDesktopComponentsTriggerKeydown($event)">
+        (keydown)="onDesktopComponentsTriggerKeydown($event)"
+      >
         <span slot="icon" class="material-symbols-outlined">browse</span>
       </m3-navigation-rail-item>
 
-      <div class="desktop-components-menu-bridge" aria-hidden="true"
-        (mouseenter)="onDesktopComponentsMouseEnter()"></div>
+      <div
+        class="desktop-components-menu-bridge"
+        aria-hidden="true"
+        (mouseenter)="onDesktopComponentsMouseEnter()"
+      ></div>
 
-      <m3-menu id="desktop-components-menu" placement="right-start" [offset]="railExpanded() ? 24 : 8" [open]="desktopComponentsMenuOpen()" [focusOnOpen]="false"
-        (mouseenter)="onDesktopComponentsMouseEnter()" (mouseleave)="onDesktopComponentsMouseLeave()"
+      <m3-menu
+        id="desktop-components-menu"
+        placement="right-start"
+        [offset]="railExpanded() ? 24 : 8"
+        [open]="desktopComponentsMenuOpen()"
+        [focusOnOpen]="false"
+        (mouseenter)="onDesktopComponentsMouseEnter()"
+        (mouseleave)="onDesktopComponentsMouseLeave()"
         (menu-dismiss)="onDesktopComponentsMenuDismiss($event)"
-        style="--md-comp-menu-max-height: calc(100vh - 400px);">
+        style="--md-comp-menu-max-height: calc(100vh - 400px)"
+      >
         @for (item of componentMenuItems; track item.path) {
-        <a class="components-menu-link" role="menuitem" tabindex="-1" [attr.href]="item.path"
-          (click)="onComponentsMenuLinkClick($event, item.path)">
-          <span class="material-symbols-outlined">{{ item.icon }}</span>
-          {{ item.label }}
-        </a>
+          <a
+            class="components-menu-link"
+            role="menuitem"
+            tabindex="-1"
+            [attr.href]="item.path"
+            (click)="onComponentsMenuLinkClick($event, item.path)"
+          >
+            <span class="material-symbols-outlined">{{ item.icon }}</span>
+            {{ item.label }}
+          </a>
         }
       </m3-menu>
     </div>
 
     <app-seo-link href="contact">
-      <m3-navigation-rail-item label="Contact" [active]="currentRoute() === '/contact'">
+      <m3-navigation-rail-item
+        label="Contact"
+        [active]="currentRoute() === '/contact'"
+      >
         <span slot="icon" class="material-symbols-outlined">person</span>
       </m3-navigation-rail-item>
     </app-seo-link>
 
-    <m3-navigation-rail-item label="Theme" slot="bottom" (item-click)="toggleTheme()">
-      @if(!isDarkTheme()) {
-      <span slot="icon" class="material-symbols-outlined">dark_mode</span>
+    <m3-navigation-rail-item
+      label="Theme"
+      slot="bottom"
+      (item-click)="toggleTheme()"
+    >
+      @if (!isDarkTheme()) {
+        <span slot="icon" class="material-symbols-outlined">dark_mode</span>
       } @else {
-      <span slot="icon" class="material-symbols-outlined">light_mode</span>
+        <span slot="icon" class="material-symbols-outlined">light_mode</span>
       }
     </m3-navigation-rail-item>
 
-    <m3-navigation-rail-item label="Settings" slot="bottom" (item-click)="openSettings()">
+    <m3-navigation-rail-item
+      label="Settings"
+      slot="bottom"
+      (item-click)="openSettings()"
+    >
       <span slot="icon" class="material-symbols-outlined">settings</span>
     </m3-navigation-rail-item>
 
-    <m3-navigation-rail-item label="GitHub" slot="bottom" (item-click)="openGitHub()">
-      <svg slot="icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
-        fill="currentColor">
+    <m3-navigation-rail-item
+      label="GitHub"
+      slot="bottom"
+      (item-click)="openGitHub()"
+    >
+      <svg
+        slot="icon"
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+      >
         <path
-          d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+          d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"
+        />
       </svg>
     </m3-navigation-rail-item>
   </m3-navigation-rail>
 </div>
 
 <div class="app-container">
-  <div class="app-content">
-    <router-outlet></router-outlet>
-  </div>
+  <main class="app-content" id="main-content">
+    @if (pageMeta(); as meta) {
+      <app-page-header
+        [title]="meta.title"
+        [description]="meta.description"
+        [eyebrow]="meta.eyebrow"
+        [icon]="meta.icon"
+      />
+    }
+    <div class="route-content" [class.route-content--home]="!pageMeta()">
+      <router-outlet></router-outlet>
+    </div>
+  </main>
 </div>
 
 <div class="mobile-nav-shell">
   <div class="mobile-components-anchor">
-    <m3-menu placement="top-center" [offset]="12" [open]="mobileComponentsMenuOpen()"
+    <m3-menu
+      placement="top-center"
+      [offset]="12"
+      [open]="mobileComponentsMenuOpen()"
       (menu-dismiss)="onMobileComponentsMenuDismiss($event)"
-      style="--md-comp-menu-max-height: calc(100dvh - 200px);">
+      style="--md-comp-menu-max-height: calc(100dvh - 200px)"
+    >
       @for (item of componentMenuItems; track item.path) {
-      <a class="components-menu-link" role="menuitem" tabindex="-1" [attr.href]="item.path"
-        (click)="onComponentsMenuLinkClick($event, item.path)">
-        <span class="material-symbols-outlined">{{ item.icon }}</span>
-        {{ item.label }}
-      </a>
+        <a
+          class="components-menu-link"
+          role="menuitem"
+          tabindex="-1"
+          [attr.href]="item.path"
+          (click)="onComponentsMenuLinkClick($event, item.path)"
+        >
+          <span class="material-symbols-outlined">{{ item.icon }}</span>
+          {{ item.label }}
+        </a>
       }
     </m3-menu>
   </div>
 
   <m3-navigation-bar class="mobile-nav" auto-layout>
     <app-seo-link href="home">
-      <m3-navigation-bar-item label="Home" [active]="currentRoute() === '/home'">
+      <m3-navigation-bar-item
+        label="Home"
+        [active]="currentRoute() === '/home'"
+      >
         <span slot="icon" class="material-symbols-outlined">home</span>
       </m3-navigation-bar-item>
     </app-seo-link>
 
     <app-seo-link href="quick-start">
-      <m3-navigation-bar-item label="Quick Start" [active]="currentRoute() === '/quick-start'">
+      <m3-navigation-bar-item
+        label="Quick Start"
+        [active]="currentRoute() === '/quick-start'"
+      >
         <span slot="icon" class="material-symbols-outlined">rocket_launch</span>
       </m3-navigation-bar-item>
     </app-seo-link>
 
     <app-seo-link href="components">
-      <m3-navigation-bar-item id="mobile-components-trigger" label="Components" [active]="isComponentsRoute()"
-        aria-haspopup="menu" [attr.aria-expanded]="mobileComponentsMenuOpen()"
-        (pointerdown)="onMobileComponentsPointerDown($event)" (pointerup)="onMobileComponentsPointerUp($event)"
-        (pointercancel)="onMobileComponentsPointerCancel($event)" (contextmenu)="onMobileComponentsContextMenu($event)">
+      <m3-navigation-bar-item
+        id="mobile-components-trigger"
+        label="Components"
+        [active]="isComponentsRoute()"
+        aria-haspopup="menu"
+        [attr.aria-expanded]="mobileComponentsMenuOpen()"
+        (pointerdown)="onMobileComponentsPointerDown($event)"
+        (pointerup)="onMobileComponentsPointerUp($event)"
+        (pointercancel)="onMobileComponentsPointerCancel($event)"
+        (contextmenu)="onMobileComponentsContextMenu($event)"
+      >
         <span slot="icon" class="material-symbols-outlined">browse</span>
       </m3-navigation-bar-item>
     </app-seo-link>
 
     <app-seo-link href="contact">
-      <m3-navigation-bar-item label="Contact" [active]="currentRoute() === '/contact'">
+      <m3-navigation-bar-item
+        label="Contact"
+        [active]="currentRoute() === '/contact'"
+      >
         <span slot="icon" class="material-symbols-outlined">person</span>
       </m3-navigation-bar-item>
     </app-seo-link>

--- a/apps/angular-app/src/app/app.component.ts
+++ b/apps/angular-app/src/app/app.component.ts
@@ -27,6 +27,14 @@ import { DialogService } from './services/dialog.service';
 import { SettingsComponent } from './components/settings/settings.component';
 
 import { SeoLinkComponent } from './components/seo-link/seo-link.component';
+import { PageHeaderComponent } from './components/page-header/page-header.component';
+
+interface PageMeta {
+  title: string;
+  description: string;
+  eyebrow: string;
+  icon: string;
+}
 
 type ComponentsMenuElement = HTMLElement & {
   open: boolean;
@@ -35,7 +43,7 @@ type ComponentsMenuElement = HTMLElement & {
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet, SeoLinkComponent],
+  imports: [RouterOutlet, SeoLinkComponent, PageHeaderComponent],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
   templateUrl: './app.component.html',
   changeDetection: ChangeDetectionStrategy.Eager,
@@ -52,6 +60,7 @@ export class AppComponent implements OnInit, OnDestroy {
   title = 'Multi-Framework Components Demo';
   currentTheme = 'light';
   currentRoute = signal('/');
+  pageMeta = signal<PageMeta | null>(null);
   desktopComponentsMenuOpen = signal(false);
   mobileComponentsMenuOpen = signal(false);
   railExpanded = signal(true);
@@ -142,17 +151,44 @@ export class AppComponent implements OnInit, OnDestroy {
     }
 
     // Track route changes for navigation bar active state
-    this.currentRoute.set(this.#router.url);
+    this.syncRouteState(this.#router.url);
     this.#router.events
       .pipe(
         filter((event) => event instanceof NavigationEnd),
         takeUntilDestroyed(this.#destroyRef),
       )
       .subscribe((event: any) => {
-        this.currentRoute.set(event.url);
+        this.syncRouteState(event.urlAfterRedirects);
         this.closeComponentsMenu();
         this.scrollToTop();
       });
+  }
+
+  private syncRouteState(url: string) {
+    const path = url.split(/[?#]/, 1)[0];
+    this.currentRoute.set(path);
+
+    let snapshot = this.#router.routerState.snapshot.root;
+    while (snapshot.firstChild) snapshot = snapshot.firstChild;
+
+    const title = snapshot.routeConfig?.title;
+    const description = snapshot.data['description'];
+    if (typeof title !== 'string' || typeof description !== 'string') {
+      this.pageMeta.set(null);
+      return;
+    }
+
+    const contextualMeta: Record<string, Pick<PageMeta, 'eyebrow' | 'icon'>> = {
+      '/quick-start': { eyebrow: 'Getting started', icon: 'rocket_launch' },
+      '/components': { eyebrow: 'Component library', icon: 'widgets' },
+      '/contact': { eyebrow: 'Community', icon: 'forum' },
+    };
+    const context = contextualMeta[path] ?? {
+      eyebrow: 'Component reference',
+      icon: 'deployed_code',
+    };
+
+    this.pageMeta.set({ title, description, ...context });
   }
 
   ngOnDestroy() {

--- a/apps/angular-app/src/app/app.routes.ts
+++ b/apps/angular-app/src/app/app.routes.ts
@@ -30,241 +30,261 @@ import { ProgressComponent } from '../pages/progress/progress.component';
 import { TabsComponent } from '../pages/tabs/tabs.component';
 
 export const routes: Routes = [
-    { path: '', redirectTo: 'home', pathMatch: 'full' },
-    {
-        path: 'home',
-        component: HomeComponent
+  { path: '', redirectTo: 'home', pathMatch: 'full' },
+  {
+    path: 'home',
+    component: HomeComponent,
+  },
+  {
+    path: 'quick-start',
+    component: QuickStartComponent,
+    title: 'Quick Start',
+    data: {
+      description:
+        'Learn how to quickly install and integrate the Material 3 Expressive web components into your Angular, React, Vue, or Vanilla JS project.',
     },
-    {
-        path: 'quick-start',
-        component: QuickStartComponent,
-        title: 'Quick Start',
-        data: {
-            description: 'Learn how to quickly install and integrate the Material 3 Expressive web components into your Angular, React, Vue, or Vanilla JS project.'
-        }
+  },
+  {
+    path: 'components',
+    component: ComponentsComponent,
+    title: 'Components',
+    data: {
+      description:
+        'Browse the complete collection of Material 3 Expressive web components available for your web applications.',
     },
-    {
-        path: 'components',
-        component: ComponentsComponent,
-        title: 'Components',
-        data: {
-            description: 'Browse the complete collection of Material 3 Expressive web components available for your web applications.'
-        }
+  },
+  {
+    path: 'buttons',
+    component: ButtonComponent,
+    title: 'Buttons',
+    data: {
+      description:
+        'Material 3 Expressive Button components, including elevated, filled, tonal, outlined, and text variants.',
     },
-    {
-        path: 'buttons',
-        component: ButtonComponent,
-        title: 'Buttons',
-        data: {
-            description: 'Material 3 Expressive Button components, including elevated, filled, tonal, outlined, and text variants.'
-        }
+  },
+  {
+    path: 'cards',
+    component: CardsComponent,
+    title: 'Cards',
+    data: {
+      description:
+        'Material 3 Expressive Card components for grouping related content and actions.',
     },
-    {
-        path: 'cards',
-        component: CardsComponent,
-        title: 'Cards',
-        data: {
-            description: 'Material 3 Expressive Card components for grouping related content and actions.'
-        }
+  },
+  {
+    path: 'navigation-rail',
+    component: NavigationRailComponent,
+    title: 'Navigation Rail',
+    data: {
+      description:
+        'Material 3 Expressive Navigation Rail component for ergonomic side navigation.',
     },
-    {
-        path: 'navigation-rail',
-        component: NavigationRailComponent,
-        title: 'Navigation Rail',
-        data: {
-            description: 'Material 3 Expressive Navigation Rail component for ergonomic side navigation.'
-        }
+  },
+  {
+    path: 'navigation-bar',
+    component: NavigationBarComponent,
+    title: 'Navigation Bar',
+    data: {
+      description:
+        'Material 3 Expressive Navigation Bar component for bottom navigation on mobile devices.',
     },
-    {
-        path: 'navigation-bar',
-        component: NavigationBarComponent,
-        title: 'Navigation Bar',
-        data: {
-            description: 'Material 3 Expressive Navigation Bar component for bottom navigation on mobile devices.'
-        }
+  },
+  {
+    path: 'switches',
+    component: SwitchComponent,
+    title: 'Switches',
+    data: {
+      description:
+        'Material 3 Expressive Switch components for toggling the state of a single setting.',
     },
-    {
-        path: 'switches',
-        component: SwitchComponent,
-        title: 'Switches',
-        data: {
-            description: 'Material 3 Expressive Switch components for toggling the state of a single setting.'
-        }
+  },
+  {
+    path: 'radio-buttons',
+    component: RadioButtonComponent,
+    title: 'Radio Buttons',
+    data: {
+      description:
+        'Material 3 Expressive Radio Button components for selecting a single option from a list.',
     },
-    {
-        path: 'radio-buttons',
-        component: RadioButtonComponent,
-        title: 'Radio Buttons',
-        data: {
-            description: 'Material 3 Expressive Radio Button components for selecting a single option from a list.'
-        }
+  },
+  {
+    path: 'checkboxes',
+    component: CheckboxComponent,
+    title: 'Checkboxes',
+    data: {
+      description:
+        'Material 3 Expressive Checkbox components for selecting multiple options.',
     },
-    {
-        path: 'checkboxes',
-        component: CheckboxComponent,
-        title: 'Checkboxes',
-        data: {
-            description: 'Material 3 Expressive Checkbox components for selecting multiple options.'
-        }
+  },
+  {
+    path: 'sliders',
+    component: SliderComponent,
+    title: 'Sliders',
+    data: {
+      description:
+        'Material 3 Expressive Slider components for selecting from a range of values.',
     },
-    {
-        path: 'sliders',
-        component: SliderComponent,
-        title: 'Sliders',
-        data: {
-            description: 'Material 3 Expressive Slider components for selecting from a range of values.'
-        }
+  },
+  {
+    path: 'text-fields',
+    component: TextFieldComponent,
+    title: 'Text Fields',
+    data: {
+      description:
+        'Material 3 Expressive Text Field components for entering text.',
     },
-    {
-        path: 'text-fields',
-        component: TextFieldComponent,
-        title: 'Text Fields',
-        data: {
-            description: 'Material 3 Expressive Text Field components for entering text.'
-        }
+  },
+  {
+    path: 'chips',
+    component: ChipsComponent,
+    title: 'Chips',
+    data: {
+      description:
+        'Material 3 Expressive Chip components for entering information, making selections, filtering content, or triggering actions.',
     },
-    {
-        path: 'chips',
-        component: ChipsComponent,
-        title: 'Chips',
-        data: {
-            description: 'Material 3 Expressive Chip components for entering information, making selections, filtering content, or triggering actions.'
-        }
+  },
+  {
+    path: 'dialog',
+    component: DialogComponent,
+    title: 'Dialog',
+    data: {
+      description:
+        'Material 3 Expressive Dialog component for important prompts in a user flow.',
     },
-    {
-        path: 'dialog',
-        component: DialogComponent,
-        title: 'Dialog',
-        data: {
-            description: 'Material 3 Expressive Dialog component for important prompts in a user flow.'
-        }
+  },
+  {
+    path: 'tooltip',
+    component: TooltipComponent,
+    title: 'Tooltip',
+    data: {
+      description:
+        'Material 3 Expressive Tooltip component for informative text on hover or focus.',
     },
-    {
-        path: 'tooltip',
-        component: TooltipComponent,
-        title: 'Tooltip',
-        data: {
-            description: 'Material 3 Expressive Tooltip component for informative text on hover or focus.'
-        }
+  },
+  {
+    path: 'badge',
+    component: BadgeComponent,
+    title: 'Badge',
+    data: {
+      description:
+        'Material 3 Expressive Badge component for conveying dynamic information like counts or status.',
     },
-    {
-        path: 'badge',
-        component: BadgeComponent,
-        title: 'Badge',
-        data: {
-            description: 'Material 3 Expressive Badge component for conveying dynamic information like counts or status.'
-        }
+  },
+  {
+    path: 'divider',
+    component: DividerComponent,
+    title: 'Divider',
+    data: {
+      description:
+        'Material 3 Expressive Divider component for separating content with smooth entrance animations.',
     },
-    {
-        path: 'divider',
-        component: DividerComponent,
-        title: 'Divider',
-        data: {
-            description: 'Material 3 Expressive Divider component for separating content with smooth entrance animations.'
-        }
+  },
+  {
+    path: 'list',
+    component: ListComponent,
+    title: 'List',
+    data: {
+      description:
+        'Material 3 Expressive List components for displaying collections of items with leading and trailing content.',
     },
-    {
-        path: 'list',
-        component: ListComponent,
-        title: 'List',
-        data: {
-            description: 'Material 3 Expressive List components for displaying collections of items with leading and trailing content.'
-        }
+  },
+  {
+    path: 'progress',
+    component: ProgressComponent,
+    title: 'Progress Indicator',
+    data: {
+      description:
+        'Material 3 Expressive Linear Progress Indicator for displaying operation status.',
     },
-    {
-        path: 'progress',
-        component: ProgressComponent,
-        title: 'Divider',
-        data: {
-            description: 'Material 3 Expressive Divider component for separating content with smooth entrance animations.'
-        }
+  },
+  {
+    path: 'tabs',
+    component: TabsComponent,
+    title: 'Tabs',
+    data: {
+      description:
+        'Material 3 Expressive Tabs component for organizing content across screens.',
     },
-    {
-        path: 'progress',
-        component: ProgressComponent,
-        title: 'Progress Indicator',
-        data: {
-            description: 'Material 3 Expressive Linear Progress Indicator for displaying operation status.'
-        }
+  },
+  {
+    path: 'search-bar',
+    component: SearchBarComponent,
+    title: 'Search Bar',
+    data: {
+      description:
+        'Material 3 Expressive Search Bar component for global or local searching.',
     },
-    {
-        path: 'tabs',
-        component: TabsComponent,
-        title: 'Tabs',
-        data: {
-            description: 'Material 3 Expressive Tabs component for organizing content across screens.'
-        }
+  },
+  {
+    path: 'split-button',
+    component: SplitButtonComponent,
+    title: 'Split Button',
+    data: {
+      description:
+        'Material 3 Expressive Split Button component for dual-action interactions.',
     },
-    {
-        path: 'search-bar',
-        component: SearchBarComponent,
-        title: 'Search Bar',
-        data: {
-            description: 'Material 3 Expressive Search Bar component for global or local searching.'
-        }
+  },
+  {
+    path: 'menu',
+    component: MenuComponent,
+    title: 'Menu',
+    data: {
+      description:
+        'Material 3 Expressive Menu component for displaying a list of choices on a temporary surface.',
     },
-    {
-        path: 'split-button',
-        component: SplitButtonComponent,
-        title: 'Split Button',
-        data: {
-            description: 'Material 3 Expressive Split Button component for dual-action interactions.'
-        }
+  },
+  {
+    path: 'loading-indicator',
+    component: LoadingIndicatorComponent,
+    title: 'Loading Indicator',
+    data: {
+      description:
+        'Material 3 Expressive Loading Indicator components to show background activity.',
     },
-    {
-        path: 'menu',
-        component: MenuComponent,
-        title: 'Menu',
-        data: {
-            description: 'Material 3 Expressive Menu component for displaying a list of choices on a temporary surface.'
-        }
+  },
+  {
+    path: 'fab-menu',
+    component: FabMenuComponent,
+    title: 'FAB Menu',
+    data: {
+      description:
+        'Material 3 Expressive Floating Action Button (FAB) Menu component for primary actions.',
     },
-    {
-        path: 'loading-indicator',
-        component: LoadingIndicatorComponent,
-        title: 'Loading Indicator',
-        data: {
-            description: 'Material 3 Expressive Loading Indicator components to show background activity.'
-        }
+  },
+  {
+    path: 'icon-button',
+    component: IconButtonComponent,
+    title: 'Icon Button',
+    data: {
+      description:
+        'Material 3 Expressive Icon Button component with press animations and multiple variants.',
     },
-    {
-        path: 'fab-menu',
-        component: FabMenuComponent,
-        title: 'FAB Menu',
-        data: {
-            description: 'Material 3 Expressive Floating Action Button (FAB) Menu component for primary actions.'
-        }
+  },
+  {
+    path: 'top-app-bar',
+    component: TopAppBarComponent,
+    title: 'Top App Bar',
+    data: {
+      description:
+        'Material 3 Expressive Top App Bar component with multiple size variants and scroll behaviors.',
     },
-    {
-        path: 'icon-button',
-        component: IconButtonComponent,
-        title: 'Icon Button',
-        data: {
-            description: 'Material 3 Expressive Icon Button component with press animations and multiple variants.'
-        }
+  },
+  {
+    path: 'snackbar',
+    component: SnackbarComponent,
+    title: 'Snackbar',
+    data: {
+      description:
+        'Material 3 Expressive Snackbar component for brief feedback messages with animations.',
     },
-    {
-        path: 'top-app-bar',
-        component: TopAppBarComponent,
-        title: 'Top App Bar',
-        data: {
-            description: 'Material 3 Expressive Top App Bar component with multiple size variants and scroll behaviors.'
-        }
+  },
+  {
+    path: 'contact',
+    component: ContactComponent,
+    title: 'Contact',
+    data: {
+      description:
+        'Built and maintained by @banegasn. Questions, ideas, bug reports, and contributions are always welcome.',
     },
-    {
-        path: 'snackbar',
-        component: SnackbarComponent,
-        title: 'Snackbar',
-        data: {
-            description: 'Material 3 Expressive Snackbar component for brief feedback messages with animations.'
-        }
-    },
-    {
-        path: 'contact',
-        component: ContactComponent,
-        title: 'Contact',
-        data: {
-            description: 'Get in touch or find more information about the Material 3 Expressive library creator.'
-        }
-    },
+  },
 ];

--- a/apps/angular-app/src/app/components/page-header/page-header.component.css
+++ b/apps/angular-app/src/app/components/page-header/page-header.component.css
@@ -1,0 +1,122 @@
+:host {
+  display: block;
+  min-width: 0;
+}
+
+.page-intro {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  display: grid;
+  gap: clamp(18px, 3vw, 28px);
+  margin-bottom: clamp(24px, 4vw, 40px);
+  padding: clamp(24px, 4.5vw, 52px);
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: clamp(24px, 3vw, 36px);
+  background: linear-gradient(
+    135deg,
+    color-mix(
+      in srgb,
+      var(--md-sys-color-primary-container) 72%,
+      var(--md-sys-color-surface)
+    ),
+    var(--md-sys-color-surface-container-low) 66%
+  );
+  box-shadow:
+    0 1px 2px color-mix(in srgb, var(--md-sys-color-on-surface) 5%, transparent),
+    0 18px 48px
+      color-mix(in srgb, var(--md-sys-color-on-surface) 7%, transparent);
+}
+
+.page-intro::after {
+  content: '';
+  position: absolute;
+  z-index: -1;
+  inline-size: clamp(180px, 28vw, 360px);
+  aspect-ratio: 1;
+  inset-block-start: -55%;
+  inset-inline-end: -5%;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--md-sys-color-primary) 13%, transparent);
+  filter: blur(1px);
+}
+
+.page-intro__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  justify-self: start;
+  gap: 8px;
+  min-height: 32px;
+  padding: 0 12px;
+  border: 1px solid
+    color-mix(in srgb, var(--md-sys-color-primary) 28%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--md-sys-color-surface) 72%, transparent);
+  color: var(--md-sys-color-primary);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.065em;
+  text-transform: uppercase;
+}
+
+.page-intro__eyebrow .material-symbols-outlined {
+  font-size: 17px;
+}
+
+.page-intro__content {
+  max-width: 800px;
+}
+
+.page-intro h1 {
+  margin: 0;
+  max-width: 18ch;
+  font-size: clamp(2rem, 5vw, 4rem);
+  font-weight: 720;
+  letter-spacing: -0.045em;
+  line-height: 1.02;
+}
+
+.page-intro p {
+  margin: clamp(12px, 2vw, 18px) 0 0;
+  max-width: 68ch;
+  color: var(--md-sys-color-on-surface-variant);
+  font-size: clamp(0.95rem, 1.5vw, 1.075rem);
+  line-height: 1.72;
+}
+
+.page-intro__details {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  color: var(--md-sys-color-on-surface-variant);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+@media (max-width: 600px) {
+  .page-intro {
+    gap: 16px;
+    margin-bottom: 20px;
+    padding: 22px 20px;
+    border-radius: 24px;
+  }
+
+  .page-intro h1 {
+    font-size: clamp(1.8rem, 10vw, 2.6rem);
+  }
+
+  .page-intro__details span[aria-hidden='true'] {
+    display: none;
+  }
+
+  .page-intro__details span:not([aria-hidden='true']) {
+    padding: 4px 9px;
+    border-radius: 999px;
+    background: color-mix(
+      in srgb,
+      var(--md-sys-color-surface) 68%,
+      transparent
+    );
+  }
+}

--- a/apps/angular-app/src/app/components/page-header/page-header.component.html
+++ b/apps/angular-app/src/app/components/page-header/page-header.component.html
@@ -1,0 +1,21 @@
+<header class="page-intro" aria-labelledby="route-page-title">
+  <div class="page-intro__eyebrow">
+    <span class="material-symbols-outlined" aria-hidden="true">{{
+      icon()
+    }}</span>
+    <span>{{ eyebrow() }}</span>
+  </div>
+
+  <div class="page-intro__content">
+    <h1 id="route-page-title">{{ title() }}</h1>
+    <p>{{ description() }}</p>
+  </div>
+
+  <div class="page-intro__details" aria-label="Library details">
+    <span>Material 3</span>
+    <span aria-hidden="true">•</span>
+    <span>Web Component</span>
+    <span aria-hidden="true">•</span>
+    <span>Framework agnostic</span>
+  </div>
+</header>

--- a/apps/angular-app/src/app/components/page-header/page-header.component.spec.ts
+++ b/apps/angular-app/src/app/components/page-header/page-header.component.spec.ts
@@ -1,0 +1,37 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { PageHeaderComponent } from './page-header.component';
+
+describe('PageHeaderComponent', () => {
+  let fixture: ComponentFixture<PageHeaderComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PageHeaderComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PageHeaderComponent);
+    fixture.componentRef.setInput('title', 'Buttons');
+    fixture.componentRef.setInput(
+      'description',
+      'Material 3 button component reference.',
+    );
+    fixture.componentRef.setInput('eyebrow', 'Component reference');
+    fixture.componentRef.setInput('icon', 'deployed_code');
+    fixture.detectChanges();
+  });
+
+  it('renders the route metadata as one accessible page introduction', () => {
+    const element = fixture.nativeElement as HTMLElement;
+
+    expect(element.querySelectorAll('h1')).toHaveLength(1);
+    expect(element.querySelector('h1')?.textContent).toContain('Buttons');
+    expect(element.querySelector('p')?.textContent).toContain(
+      'Material 3 button component reference.',
+    );
+    expect(
+      element.querySelector('header')?.getAttribute('aria-labelledby'),
+    ).toBe('route-page-title');
+  });
+});

--- a/apps/angular-app/src/app/components/page-header/page-header.component.ts
+++ b/apps/angular-app/src/app/components/page-header/page-header.component.ts
@@ -1,0 +1,15 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+
+@Component({
+  selector: 'app-page-header',
+  standalone: true,
+  templateUrl: './page-header.component.html',
+  styleUrl: './page-header.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PageHeaderComponent {
+  readonly title = input.required<string>();
+  readonly description = input.required<string>();
+  readonly eyebrow = input('Component reference');
+  readonly icon = input('deployed_code');
+}

--- a/apps/angular-app/src/pages/badge/badge.component.html
+++ b/apps/angular-app/src/pages/badge/badge.component.html
@@ -1,28 +1,55 @@
 <div class="page-container docs-page">
-  <header class="page-header">
-    <h1>Badge</h1>
-    <p class="subtitle">Badges convey dynamic information, such as a count or status.</p>
-  </header>
-
   <section class="demo-section">
     <h2>Dot Badge</h2>
     <div class="interactive-demo">
-      <div class="demo-row" style="gap: 32px;">
-        <m3-badge><span class="material-symbols-outlined" style="font-size:32px; color: var(--md-sys-color-on-surface)">mail</span></m3-badge>
-        <m3-badge><span class="material-symbols-outlined" style="font-size:32px; color: var(--md-sys-color-on-surface)">notifications</span></m3-badge>
+      <div class="demo-row" style="gap: 32px">
+        <m3-badge
+          ><span
+            class="material-symbols-outlined"
+            style="font-size: 32px; color: var(--md-sys-color-on-surface)"
+            >mail</span
+          ></m3-badge
+        >
+        <m3-badge
+          ><span
+            class="material-symbols-outlined"
+            style="font-size: 32px; color: var(--md-sys-color-on-surface)"
+            >notifications</span
+          ></m3-badge
+        >
       </div>
-      <app-code-block [code]="dotExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="dotExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 
   <section class="demo-section">
     <h2>Labeled Badge</h2>
     <div class="interactive-demo">
-      <div class="demo-row" style="gap: 48px;">
-        <m3-badge label="3"><span class="material-symbols-outlined" style="font-size:32px; color: var(--md-sys-color-on-surface)">mail</span></m3-badge>
-        <m3-badge label="99+"><span class="material-symbols-outlined" style="font-size:32px; color: var(--md-sys-color-on-surface)">notifications</span></m3-badge>
+      <div class="demo-row" style="gap: 48px">
+        <m3-badge label="3"
+          ><span
+            class="material-symbols-outlined"
+            style="font-size: 32px; color: var(--md-sys-color-on-surface)"
+            >mail</span
+          ></m3-badge
+        >
+        <m3-badge label="99+"
+          ><span
+            class="material-symbols-outlined"
+            style="font-size: 32px; color: var(--md-sys-color-on-surface)"
+            >notifications</span
+          ></m3-badge
+        >
       </div>
-      <app-code-block [code]="labelExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="labelExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 </div>

--- a/apps/angular-app/src/pages/buttons/button.component.html
+++ b/apps/angular-app/src/pages/buttons/button.component.html
@@ -1,22 +1,21 @@
 <div class="page-container docs-page">
-  <header class="page-header">
-    <h1>Buttons</h1>
-    <p class="subtitle">
-      Buttons help people take action, such as sending an email, sharing a document, or liking a comment.
-    </p>
-  </header>
-
   <!-- Button Variants -->
   <section class="demo-section">
     <h2>Button Variants</h2>
-    <p>Material Design 3 provides five button types to support different emphasis levels:</p>
+    <p>
+      Material Design 3 provides five button types to support different emphasis
+      levels:
+    </p>
 
     <div class="variant-card">
       <div class="variant-header">
         <h3>Filled Button</h3>
         <span class="emphasis-badge high">High Emphasis</span>
       </div>
-      <p>The most prominent button type. Use for the primary, most important action on a screen.</p>
+      <p>
+        The most prominent button type. Use for the primary, most important
+        action on a screen.
+      </p>
       <div class="demo-buttons">
         <m3-button variant="filled">Filled Button</m3-button>
         <m3-button variant="filled" disabled>Disabled</m3-button>
@@ -28,7 +27,10 @@
         <h3>Elevated Button</h3>
         <span class="emphasis-badge medium-high">Medium-High Emphasis</span>
       </div>
-      <p>Adds dimension to mostly flat layouts. Use for secondary actions that need separation.</p>
+      <p>
+        Adds dimension to mostly flat layouts. Use for secondary actions that
+        need separation.
+      </p>
       <div class="demo-buttons">
         <m3-button variant="elevated">Elevated Button</m3-button>
         <m3-button variant="elevated" disabled>Disabled</m3-button>
@@ -40,7 +42,10 @@
         <h3>Tonal Button</h3>
         <span class="emphasis-badge medium">Medium Emphasis</span>
       </div>
-      <p>An alternative middle ground between filled and outlined buttons. Good for secondary actions.</p>
+      <p>
+        An alternative middle ground between filled and outlined buttons. Good
+        for secondary actions.
+      </p>
       <div class="demo-buttons">
         <m3-button variant="tonal">Tonal Button</m3-button>
         <m3-button variant="tonal" disabled>Disabled</m3-button>
@@ -52,7 +57,10 @@
         <h3>Outlined Button</h3>
         <span class="emphasis-badge medium">Medium Emphasis</span>
       </div>
-      <p>For actions that need attention but aren't the primary focus. Often paired with filled buttons.</p>
+      <p>
+        For actions that need attention but aren't the primary focus. Often
+        paired with filled buttons.
+      </p>
       <div class="demo-buttons">
         <m3-button variant="outlined">Outlined Button</m3-button>
         <m3-button variant="outlined" disabled>Disabled</m3-button>
@@ -64,20 +72,30 @@
         <h3>Text Button</h3>
         <span class="emphasis-badge low">Low Emphasis</span>
       </div>
-      <p>For the least important actions. Often used in cards, dialogs, and toolbars.</p>
+      <p>
+        For the least important actions. Often used in cards, dialogs, and
+        toolbars.
+      </p>
       <div class="demo-buttons">
         <m3-button variant="text">Text Button</m3-button>
         <m3-button variant="text" disabled>Disabled</m3-button>
       </div>
     </div>
-    
-    <app-code-block language="html" variant="sample" [code]="basicExample"></app-code-block>
+
+    <app-code-block
+      language="html"
+      variant="sample"
+      [code]="basicExample"
+    ></app-code-block>
   </section>
 
   <!-- Button Sizes (M3 Expressive) -->
   <section class="demo-section">
     <h2>Button Sizes (Material 3 Expressive)</h2>
-    <p>Five size options to support different layout requirements and emphasis levels.</p>
+    <p>
+      Five size options to support different layout requirements and emphasis
+      levels.
+    </p>
 
     <div class="variant-card">
       <h3>Size Variants</h3>
@@ -88,7 +106,11 @@
         <m3-button variant="filled" size="large">Large</m3-button>
         <m3-button variant="filled" size="extra-large">Extra Large</m3-button>
       </div>
-      <app-code-block language="html" variant="sample" [code]="sizeExample"></app-code-block>
+      <app-code-block
+        language="html"
+        variant="sample"
+        [code]="sizeExample"
+      ></app-code-block>
     </div>
 
     <div class="demo-grid">
@@ -130,7 +152,10 @@
         <p>Large for high emphasis actions</p>
         <m3-button variant="filled" size="large">
           <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
-            <path fill="currentColor" d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z" />
+            <path
+              fill="currentColor"
+              d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"
+            />
           </svg>
           Confirm
         </m3-button>
@@ -141,7 +166,10 @@
         <p>Maximum size for hero actions</p>
         <m3-button variant="filled" size="extra-large">
           <svg slot="icon" viewBox="0 0 24 24" width="28" height="28">
-            <path fill="currentColor" d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z" />
+            <path
+              fill="currentColor"
+              d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"
+            />
           </svg>
           Get Started
         </m3-button>
@@ -158,11 +186,17 @@
       <h3>Round Shape (Default)</h3>
       <p>Fully rounded corners - morphs to less round when pressed</p>
       <div class="demo-buttons">
-        <m3-button variant="filled" shape="round" size="extra-small">Extra Small</m3-button>
+        <m3-button variant="filled" shape="round" size="extra-small"
+          >Extra Small</m3-button
+        >
         <m3-button variant="filled" shape="round" size="small">Small</m3-button>
-        <m3-button variant="filled" shape="round" size="medium">Medium</m3-button>
+        <m3-button variant="filled" shape="round" size="medium"
+          >Medium</m3-button
+        >
         <m3-button variant="filled" shape="round" size="large">Large</m3-button>
-        <m3-button variant="filled" shape="round" size="extra-large">Extra Large</m3-button>
+        <m3-button variant="filled" shape="round" size="extra-large"
+          >Extra Large</m3-button
+        >
       </div>
     </div>
 
@@ -170,33 +204,55 @@
       <h3>Square Shape</h3>
       <p>Minimal rounding - morphs to more round when pressed</p>
       <div class="demo-buttons">
-        <m3-button variant="filled" shape="square" size="extra-small">Extra Small</m3-button>
-        <m3-button variant="filled" shape="square" size="small">Small</m3-button>
-        <m3-button variant="filled" shape="square" size="medium">Medium</m3-button>
-        <m3-button variant="filled" shape="square" size="large">Large</m3-button>
-        <m3-button variant="filled" shape="square" size="extra-large">Extra Large</m3-button>
+        <m3-button variant="filled" shape="square" size="extra-small"
+          >Extra Small</m3-button
+        >
+        <m3-button variant="filled" shape="square" size="small"
+          >Small</m3-button
+        >
+        <m3-button variant="filled" shape="square" size="medium"
+          >Medium</m3-button
+        >
+        <m3-button variant="filled" shape="square" size="large"
+          >Large</m3-button
+        >
+        <m3-button variant="filled" shape="square" size="extra-large"
+          >Extra Large</m3-button
+        >
       </div>
     </div>
-    
-    <app-code-block language="html" variant="sample" [code]="shapeExample"></app-code-block>
+
+    <app-code-block
+      language="html"
+      variant="sample"
+      [code]="shapeExample"
+    ></app-code-block>
 
     <div class="demo-grid">
       <div class="demo-item">
         <h4>Shape with Variants</h4>
-        <div style="display: flex; gap: 8px; flex-direction: column;">
+        <div style="display: flex; gap: 8px; flex-direction: column">
           <m3-button variant="filled" shape="square">Filled Square</m3-button>
-          <m3-button variant="elevated" shape="square">Elevated Square</m3-button>
+          <m3-button variant="elevated" shape="square"
+            >Elevated Square</m3-button
+          >
           <m3-button variant="tonal" shape="square">Tonal Square</m3-button>
-          <m3-button variant="outlined" shape="square">Outlined Square</m3-button>
+          <m3-button variant="outlined" shape="square"
+            >Outlined Square</m3-button
+          >
         </div>
       </div>
 
       <div class="demo-item">
         <h4>Interactive Demo</h4>
         <p class="help-text">Press and hold to see shape morphing animation</p>
-        <div style="display: flex; gap: 12px; flex-wrap: wrap;">
-          <m3-button variant="filled" shape="round" size="large">Press Me (Round)</m3-button>
-          <m3-button variant="filled" shape="square" size="large">Press Me (Square)</m3-button>
+        <div style="display: flex; gap: 12px; flex-wrap: wrap">
+          <m3-button variant="filled" shape="round" size="large"
+            >Press Me (Round)</m3-button
+          >
+          <m3-button variant="filled" shape="square" size="large"
+            >Press Me (Square)</m3-button
+          >
         </div>
       </div>
     </div>
@@ -205,14 +261,21 @@
   <!-- Button Padding (M3 Expressive) -->
   <section class="demo-section">
     <h2>Button Padding (Material 3 Expressive)</h2>
-    <p>Choose between default (24dp) and compact (16dp) padding. Small padding recommended for new designs.</p>
+    <p>
+      Choose between default (24dp) and compact (16dp) padding. Small padding
+      recommended for new designs.
+    </p>
 
     <div class="variant-card">
       <h3>Default Padding (24dp)</h3>
       <p>Traditional spacing - deprecated for small buttons</p>
       <div class="demo-buttons">
-        <m3-button variant="filled" padding="default">Default Padding</m3-button>
-        <m3-button variant="outlined" padding="default">Default Padding</m3-button>
+        <m3-button variant="filled" padding="default"
+          >Default Padding</m3-button
+        >
+        <m3-button variant="outlined" padding="default"
+          >Default Padding</m3-button
+        >
         <m3-button variant="tonal" padding="default">
           <svg slot="icon" viewBox="0 0 24 24" width="18" height="18">
             <path fill="currentColor" d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
@@ -236,14 +299,20 @@
         </m3-button>
       </div>
     </div>
-    
-    <app-code-block language="html" variant="sample" [code]="paddingExample"></app-code-block>
+
+    <app-code-block
+      language="html"
+      variant="sample"
+      [code]="paddingExample"
+    ></app-code-block>
 
     <div class="demo-grid">
       <div class="demo-item">
         <h4>Comparison</h4>
-        <div style="display: flex; gap: 8px; align-items: center;">
-          <m3-button variant="filled" padding="default">Default (24dp)</m3-button>
+        <div style="display: flex; gap: 8px; align-items: center">
+          <m3-button variant="filled" padding="default"
+            >Default (24dp)</m3-button
+          >
           <span>vs</span>
           <m3-button variant="filled" padding="small">Small (16dp)</m3-button>
         </div>
@@ -259,7 +328,12 @@
     <div class="demo-grid">
       <div class="demo-item">
         <h4>Hero CTA</h4>
-        <m3-button variant="filled" size="extra-large" shape="round" padding="small">
+        <m3-button
+          variant="filled"
+          size="extra-large"
+          shape="round"
+          padding="small"
+        >
           <svg slot="icon" viewBox="0 0 24 24" width="28" height="28">
             <path fill="currentColor" d="M8 5v14l11-7z" />
           </svg>
@@ -271,7 +345,10 @@
         <h4>Modern Card Action</h4>
         <m3-button variant="tonal" size="medium" shape="square" padding="small">
           <svg slot="icon" viewBox="0 0 24 24" width="20" height="20">
-            <path fill="currentColor" d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z" />
+            <path
+              fill="currentColor"
+              d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"
+            />
           </svg>
           Complete
         </m3-button>
@@ -279,20 +356,47 @@
 
       <div class="demo-item">
         <h4>Compact Toolbar</h4>
-        <div style="display: flex; gap: 4px;">
-          <m3-button icon-only variant="text" size="extra-small" padding="small" aria-label="Edit">
+        <div style="display: flex; gap: 4px">
+          <m3-button
+            icon-only
+            variant="text"
+            size="extra-small"
+            padding="small"
+            aria-label="Edit"
+          >
             <svg slot="icon" viewBox="0 0 24 24" width="16" height="16">
-              <path fill="currentColor" d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25z" />
+              <path
+                fill="currentColor"
+                d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25z"
+              />
             </svg>
           </m3-button>
-          <m3-button icon-only variant="text" size="extra-small" padding="small" aria-label="Delete">
+          <m3-button
+            icon-only
+            variant="text"
+            size="extra-small"
+            padding="small"
+            aria-label="Delete"
+          >
             <svg slot="icon" viewBox="0 0 24 24" width="16" height="16">
-              <path fill="currentColor" d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12z" />
+              <path
+                fill="currentColor"
+                d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12z"
+              />
             </svg>
           </m3-button>
-          <m3-button icon-only variant="text" size="extra-small" padding="small" aria-label="Share">
+          <m3-button
+            icon-only
+            variant="text"
+            size="extra-small"
+            padding="small"
+            aria-label="Share"
+          >
             <svg slot="icon" viewBox="0 0 24 24" width="16" height="16">
-              <path fill="currentColor" d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92 1.61 0 2.92-1.31 2.92-2.92s-1.31-2.92-2.92-2.92z" />
+              <path
+                fill="currentColor"
+                d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92 1.61 0 2.92-1.31 2.92-2.92s-1.31-2.92-2.92-2.92z"
+              />
             </svg>
           </m3-button>
         </div>
@@ -300,14 +404,29 @@
 
       <div class="demo-item">
         <h4>Form Buttons</h4>
-        <div style="display: flex; gap: 8px; flex-direction: column;">
-          <m3-button variant="filled" size="medium" shape="square" padding="small" full-width>
+        <div style="display: flex; gap: 8px; flex-direction: column">
+          <m3-button
+            variant="filled"
+            size="medium"
+            shape="square"
+            padding="small"
+            full-width
+          >
             <svg slot="icon" viewBox="0 0 24 24" width="20" height="20">
-              <path fill="currentColor" d="M17 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V7l-4-4z" />
+              <path
+                fill="currentColor"
+                d="M17 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V7l-4-4z"
+              />
             </svg>
             Save
           </m3-button>
-          <m3-button variant="outlined" size="medium" shape="square" padding="small" full-width>
+          <m3-button
+            variant="outlined"
+            size="medium"
+            shape="square"
+            padding="small"
+            full-width
+          >
             Cancel
           </m3-button>
         </div>
@@ -335,7 +454,10 @@
         <h4>Elevated with Icon</h4>
         <m3-button variant="elevated">
           <svg slot="icon" viewBox="0 0 24 24" width="18" height="18">
-            <path fill="currentColor" d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z" />
+            <path
+              fill="currentColor"
+              d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"
+            />
           </svg>
           Confirm
         </m3-button>
@@ -345,8 +467,10 @@
         <h4>Tonal with Icon</h4>
         <m3-button variant="tonal">
           <svg slot="icon" viewBox="0 0 24 24" width="18" height="18">
-            <path fill="currentColor"
-              d="M17 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V7l-4-4zm-5 16c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3zm3-10H5V5h10v4z" />
+            <path
+              fill="currentColor"
+              d="M17 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V7l-4-4zm-5 16c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3zm3-10H5V5h10v4z"
+            />
           </svg>
           Save
         </m3-button>
@@ -366,21 +490,30 @@
         <h4>Text with Icon</h4>
         <m3-button variant="text">
           <svg slot="icon" viewBox="0 0 24 24" width="18" height="18">
-            <path fill="currentColor"
-              d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z" />
+            <path
+              fill="currentColor"
+              d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
+            />
           </svg>
           View
         </m3-button>
       </div>
     </div>
 
-    <app-code-block language="html" variant="sample" [code]="iconExample"></app-code-block>
+    <app-code-block
+      language="html"
+      variant="sample"
+      [code]="iconExample"
+    ></app-code-block>
   </section>
 
   <!-- Icon-Only Buttons -->
   <section class="demo-section">
     <h2>Icon-Only Buttons</h2>
-    <p>For compact interfaces. Always include <code>aria-label</code> for accessibility.</p>
+    <p>
+      For compact interfaces. Always include <code>aria-label</code> for
+      accessibility.
+    </p>
 
     <div class="demo-buttons icon-only-demo">
       <m3-button icon-only aria-label="Add" variant="filled">
@@ -391,26 +524,37 @@
 
       <m3-button icon-only aria-label="Edit" variant="tonal">
         <svg slot="icon" viewBox="0 0 24 24" width="18" height="18">
-          <path fill="currentColor"
-            d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z" />
+          <path
+            fill="currentColor"
+            d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+          />
         </svg>
       </m3-button>
 
       <m3-button icon-only aria-label="Delete" variant="outlined">
         <svg slot="icon" viewBox="0 0 24 24" width="18" height="18">
-          <path fill="currentColor" d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z" />
+          <path
+            fill="currentColor"
+            d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+          />
         </svg>
       </m3-button>
 
       <m3-button icon-only aria-label="Share" variant="text">
         <svg slot="icon" viewBox="0 0 24 24" width="18" height="18">
-          <path fill="currentColor"
-            d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92 1.61 0 2.92-1.31 2.92-2.92s-1.31-2.92-2.92-2.92z" />
+          <path
+            fill="currentColor"
+            d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92 1.61 0 2.92-1.31 2.92-2.92s-1.31-2.92-2.92-2.92z"
+          />
         </svg>
       </m3-button>
     </div>
 
-    <app-code-block language="html" variant="sample" [code]="iconOnlyExample"></app-code-block>
+    <app-code-block
+      language="html"
+      variant="sample"
+      [code]="iconOnlyExample"
+    ></app-code-block>
   </section>
 
   <!-- Loading State -->
@@ -428,14 +572,23 @@
       <h4>Try it:</h4>
       <m3-button #button (click)="onButtonClick(button)" variant="filled">
         <svg slot="icon" viewBox="0 0 24 24" width="18" height="18">
-          <path fill="currentColor" d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z" />
+          <path
+            fill="currentColor"
+            d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"
+          />
         </svg>
         Submit Form
       </m3-button>
-      <p class="help-text">Click the button to see the loading state (2 second demo)</p>
+      <p class="help-text">
+        Click the button to see the loading state (2 second demo)
+      </p>
     </div>
 
-    <app-code-block language="html" variant="sample" [code]="loadingExample"></app-code-block>
+    <app-code-block
+      language="html"
+      variant="sample"
+      [code]="loadingExample"
+    ></app-code-block>
   </section>
 
   <!-- Full Width -->
@@ -446,15 +599,21 @@
     <div class="full-width-demo">
       <m3-button variant="filled" full-width>
         <svg slot="icon" viewBox="0 0 24 24" width="18" height="18">
-          <path fill="currentColor"
-            d="M17 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V7l-4-4zm-5 16c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3zm3-10H5V5h10v4z" />
+          <path
+            fill="currentColor"
+            d="M17 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V7l-4-4zm-5 16c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3zm3-10H5V5h10v4z"
+          />
         </svg>
         Save Changes
       </m3-button>
       <m3-button variant="outlined" full-width>Cancel</m3-button>
     </div>
 
-    <app-code-block language="html" variant="sample" [code]="fullWidthExample"></app-code-block>
+    <app-code-block
+      language="html"
+      variant="sample"
+      [code]="fullWidthExample"
+    ></app-code-block>
   </section>
 
   <!-- Common Patterns -->
@@ -463,7 +622,10 @@
 
     <div class="pattern-card">
       <h4>Dialog Actions</h4>
-      <p>Use text buttons for low-emphasis actions and filled for primary actions.</p>
+      <p>
+        Use text buttons for low-emphasis actions and filled for primary
+        actions.
+      </p>
       <div class="dialog-example">
         <div class="dialog-actions">
           <m3-button variant="text">Cancel</m3-button>
@@ -479,7 +641,10 @@
         <m3-button variant="outlined">Reset</m3-button>
         <m3-button variant="filled">
           <svg slot="icon" viewBox="0 0 24 24" width="18" height="18">
-            <path fill="currentColor" d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z" />
+            <path
+              fill="currentColor"
+              d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"
+            />
           </svg>
           Submit
         </m3-button>
@@ -503,14 +668,38 @@
   <section class="demo-section accessibility">
     <h2>♿ Accessibility Features</h2>
     <ul class="feature-list">
-      <li><strong>Keyboard Navigation:</strong> Full support for Enter/Space activation and Tab focus</li>
-      <li><strong>Focus Indicators:</strong> Visible focus rings for keyboard users</li>
-      <li><strong>ARIA Support:</strong> Proper <code>aria-label</code>, <code>aria-busy</code> for loading states</li>
-      <li><strong>Touch Targets:</strong> Minimum 48x48px tap targets (includes invisible padding)</li>
-      <li><strong>Screen Readers:</strong> Disabled and loading states properly announced</li>
-      <li><strong>Color Contrast:</strong> WCAG 2.1 Level AA compliant color combinations</li>
-      <li><strong>Flexible Sizing:</strong> Five size options (extra-small to extra-large) for optimal touch targets</li>
-      <li><strong>Shape Morphing:</strong> Dynamic visual feedback when pressed improves interaction clarity</li>
+      <li>
+        <strong>Keyboard Navigation:</strong> Full support for Enter/Space
+        activation and Tab focus
+      </li>
+      <li>
+        <strong>Focus Indicators:</strong> Visible focus rings for keyboard
+        users
+      </li>
+      <li>
+        <strong>ARIA Support:</strong> Proper <code>aria-label</code>,
+        <code>aria-busy</code> for loading states
+      </li>
+      <li>
+        <strong>Touch Targets:</strong> Minimum 48x48px tap targets (includes
+        invisible padding)
+      </li>
+      <li>
+        <strong>Screen Readers:</strong> Disabled and loading states properly
+        announced
+      </li>
+      <li>
+        <strong>Color Contrast:</strong> WCAG 2.1 Level AA compliant color
+        combinations
+      </li>
+      <li>
+        <strong>Flexible Sizing:</strong> Five size options (extra-small to
+        extra-large) for optimal touch targets
+      </li>
+      <li>
+        <strong>Shape Morphing:</strong> Dynamic visual feedback when pressed
+        improves interaction clarity
+      </li>
     </ul>
   </section>
 
@@ -518,20 +707,32 @@
   <section class="demo-section resources">
     <h2>📚 Resources</h2>
     <div class="resource-links">
-      <a href="https://m3.material.io/components/buttons/overview" target="_blank" rel="noopener">
+      <a
+        href="https://m3.material.io/components/buttons/overview"
+        target="_blank"
+        rel="noopener"
+      >
         <m3-button variant="outlined">
           <svg slot="icon" viewBox="0 0 24 24" width="18" height="18">
-            <path fill="currentColor"
-              d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z" />
+            <path
+              fill="currentColor"
+              d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
+            />
           </svg>
           M3 Guidelines
         </m3-button>
       </a>
-      <a href="https://github.com/banegasn/components/tree/main/packages/m3-button" target="_blank" rel="noopener">
+      <a
+        href="https://github.com/banegasn/components/tree/main/packages/m3-button"
+        target="_blank"
+        rel="noopener"
+      >
         <m3-button variant="outlined">
           <svg slot="icon" viewBox="0 0 24 24" width="18" height="18">
-            <path fill="currentColor"
-              d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+            <path
+              fill="currentColor"
+              d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"
+            />
           </svg>
           View on GitHub
         </m3-button>

--- a/apps/angular-app/src/pages/cards/cards.component.html
+++ b/apps/angular-app/src/pages/cards/cards.component.html
@@ -1,29 +1,28 @@
 <div class="page-container docs-page">
-  <header class="page-header">
-    <h1>Cards</h1>
-    <p class="subtitle">Cards contain content and actions about a single subject</p>
-  </header>
-
   <!-- Card Variants Section -->
   <section class="demo-section">
     <h2>Card Variants</h2>
     <p class="section-description">
-      Material 3 provides three card variants: elevated (default), filled, and outlined.
-      Each variant serves different visual hierarchy needs.
+      Material 3 provides three card variants: elevated (default), filled, and
+      outlined. Each variant serves different visual hierarchy needs.
     </p>
-    
+
     <div class="variant-card">
       <div class="demo-container cards-grid">
         <!-- Elevated Card -->
         <m3-card variant="elevated">
           <h3 slot="header">Elevated Card</h3>
           <p>
-            This is an elevated card with subtle shadow elevation. 
-            It's the default variant and works well for most use cases.
+            This is an elevated card with subtle shadow elevation. It's the
+            default variant and works well for most use cases.
           </p>
           <div slot="actions" class="actions">
-            <m3-button variant="filled" (click)="handleAction('Get Started')">Get Started</m3-button>
-            <m3-button variant="text" (click)="handleAction('Learn More')">Learn More</m3-button>
+            <m3-button variant="filled" (click)="handleAction('Get Started')"
+              >Get Started</m3-button
+            >
+            <m3-button variant="text" (click)="handleAction('Learn More')"
+              >Learn More</m3-button
+            >
           </div>
         </m3-card>
 
@@ -31,12 +30,16 @@
         <m3-card variant="filled">
           <h3 slot="header">Filled Card</h3>
           <p>
-            This is a filled card with a solid background color.
-            Great for dense layouts and secondary content.
+            This is a filled card with a solid background color. Great for dense
+            layouts and secondary content.
           </p>
           <div slot="actions" class="actions">
-            <m3-button variant="filled" (click)="handleAction('Get Started')">Get Started</m3-button>
-            <m3-button variant="text" (click)="handleAction('Learn More')">Learn More</m3-button>
+            <m3-button variant="filled" (click)="handleAction('Get Started')"
+              >Get Started</m3-button
+            >
+            <m3-button variant="text" (click)="handleAction('Learn More')"
+              >Learn More</m3-button
+            >
           </div>
         </m3-card>
 
@@ -44,16 +47,24 @@
         <m3-card variant="outlined">
           <h3 slot="header">Outlined Card</h3>
           <p>
-            This is an outlined card with a border.
-            Perfect for lists and minimal designs.
+            This is an outlined card with a border. Perfect for lists and
+            minimal designs.
           </p>
           <div slot="actions" class="actions">
-            <m3-button variant="outlined" (click)="handleAction('Get Started')">Get Started</m3-button>
-            <m3-button variant="text" (click)="handleAction('Learn More')">Learn More</m3-button>
+            <m3-button variant="outlined" (click)="handleAction('Get Started')"
+              >Get Started</m3-button
+            >
+            <m3-button variant="text" (click)="handleAction('Learn More')"
+              >Learn More</m3-button
+            >
           </div>
         </m3-card>
       </div>
-      <app-code-block language="html" variant="sample" [code]="basicCardExample"></app-code-block>
+      <app-code-block
+        language="html"
+        variant="sample"
+        [code]="basicCardExample"
+      ></app-code-block>
     </div>
   </section>
 
@@ -63,61 +74,112 @@
     <p class="section-description">
       Cards can include images, videos, or other media content at the top.
     </p>
-    
+
     <div class="variant-card">
       <div class="demo-container cards-grid">
         <m3-card variant="elevated">
-          <div slot="media" style="height: 200px; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); display: flex; align-items: center; justify-content: center; color: white; font-size: 48px;">
+          <div
+            slot="media"
+            style="
+              height: 200px;
+              background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+              display: flex;
+              align-items: center;
+              justify-content: center;
+              color: white;
+              font-size: 48px;
+            "
+          >
             🎨
           </div>
           <div slot="header">
-            <h3 style="margin: 0;">Design</h3>
-            <p style="margin: 4px 0 0; color: #666; font-size: 14px;">Creative Solutions</p>
+            <h3 style="margin: 0">Design</h3>
+            <p style="margin: 4px 0 0; color: #666; font-size: 14px">
+              Creative Solutions
+            </p>
           </div>
           <p>
             Beautiful and modern design systems that bring your ideas to life.
           </p>
           <div slot="actions" class="actions">
-            <m3-button variant="filled" (click)="handleAction('View')">View</m3-button>
-            <m3-button variant="tonal" (click)="handleAction('Share')">Share</m3-button>
+            <m3-button variant="filled" (click)="handleAction('View')"
+              >View</m3-button
+            >
+            <m3-button variant="tonal" (click)="handleAction('Share')"
+              >Share</m3-button
+            >
           </div>
         </m3-card>
 
         <m3-card variant="filled">
-          <div slot="media" style="height: 200px; background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%); display: flex; align-items: center; justify-content: center; color: white; font-size: 48px;">
+          <div
+            slot="media"
+            style="
+              height: 200px;
+              background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
+              display: flex;
+              align-items: center;
+              justify-content: center;
+              color: white;
+              font-size: 48px;
+            "
+          >
             ⚡
           </div>
           <div slot="header">
-            <h3 style="margin: 0;">Performance</h3>
-            <p style="margin: 4px 0 0; color: #666; font-size: 14px;">Lightning Fast</p>
+            <h3 style="margin: 0">Performance</h3>
+            <p style="margin: 4px 0 0; color: #666; font-size: 14px">
+              Lightning Fast
+            </p>
           </div>
-          <p>
-            Optimized for speed and efficiency in every interaction.
-          </p>
+          <p>Optimized for speed and efficiency in every interaction.</p>
           <div slot="actions" class="actions">
-            <m3-button variant="filled" (click)="handleAction('View')">View</m3-button>
-            <m3-button variant="text" (click)="handleAction('Share')">Share</m3-button>
+            <m3-button variant="filled" (click)="handleAction('View')"
+              >View</m3-button
+            >
+            <m3-button variant="text" (click)="handleAction('Share')"
+              >Share</m3-button
+            >
           </div>
         </m3-card>
 
         <m3-card variant="outlined">
-          <div slot="media" style="height: 200px; background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%); display: flex; align-items: center; justify-content: center; color: white; font-size: 48px;">
+          <div
+            slot="media"
+            style="
+              height: 200px;
+              background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%);
+              display: flex;
+              align-items: center;
+              justify-content: center;
+              color: white;
+              font-size: 48px;
+            "
+          >
             🚀
           </div>
           <div slot="header">
-            <h3 style="margin: 0;">Innovation</h3>
-            <p style="margin: 4px 0 0; color: #666; font-size: 14px;">Cutting Edge</p>
+            <h3 style="margin: 0">Innovation</h3>
+            <p style="margin: 4px 0 0; color: #666; font-size: 14px">
+              Cutting Edge
+            </p>
           </div>
-          <p>
-            Pushing boundaries with the latest technologies and approaches.
-          </p>
+          <p>Pushing boundaries with the latest technologies and approaches.</p>
           <div slot="actions" class="actions">
-            <m3-button variant="outlined" (click)="handleAction('View')">View</m3-button>
-            <m3-button variant="text" (click)="handleAction('Share')">Share</m3-button>
+            <m3-button variant="outlined" (click)="handleAction('View')"
+              >View</m3-button
+            >
+            <m3-button variant="text" (click)="handleAction('Share')"
+              >Share</m3-button
+            >
           </div>
         </m3-card>
       </div>
-      <app-code-block language="html" variant="sample" [code]="mediaCardExample"></app-code-block>
+      <app-code-block
+        language="html"
+        variant="sample"
+        [code]="mediaCardExample"
+      ></app-code-block>
     </div>
   </section>
 
@@ -125,58 +187,58 @@
   <section class="demo-section">
     <h2>Clickable Cards</h2>
     <p class="section-description">
-      Cards can be made interactive by adding the clickable attribute.
-      They support keyboard navigation and proper accessibility.
+      Cards can be made interactive by adding the clickable attribute. They
+      support keyboard navigation and proper accessibility.
     </p>
-    
+
     <div class="variant-card">
       <div class="demo-container cards-grid">
-        <m3-card 
-          variant="elevated" 
-          clickable 
+        <m3-card
+          variant="elevated"
+          clickable
           aria-label="Navigate to Products"
           (card-click)="onCardClick($event)"
         >
-          <div style="font-size: 48px; text-align: center; padding: 20px;">
+          <div style="font-size: 48px; text-align: center; padding: 20px">
             📦
           </div>
-          <h3 slot="header" style="text-align: center;">Products</h3>
-          <p style="text-align: center;">
+          <h3 slot="header" style="text-align: center">Products</h3>
+          <p style="text-align: center">
             Browse our catalog of amazing products
           </p>
         </m3-card>
 
-        <m3-card 
-          variant="filled" 
-          clickable 
+        <m3-card
+          variant="filled"
+          clickable
           aria-label="Navigate to Services"
           (card-click)="onCardClick($event)"
         >
-          <div style="font-size: 48px; text-align: center; padding: 20px;">
+          <div style="font-size: 48px; text-align: center; padding: 20px">
             🛠️
           </div>
-          <h3 slot="header" style="text-align: center;">Services</h3>
-          <p style="text-align: center;">
-            Explore our professional services
-          </p>
+          <h3 slot="header" style="text-align: center">Services</h3>
+          <p style="text-align: center">Explore our professional services</p>
         </m3-card>
 
-        <m3-card 
-          variant="outlined" 
-          clickable 
+        <m3-card
+          variant="outlined"
+          clickable
           aria-label="Navigate to Support"
           (card-click)="onCardClick($event)"
         >
-          <div style="font-size: 48px; text-align: center; padding: 20px;">
+          <div style="font-size: 48px; text-align: center; padding: 20px">
             💬
           </div>
-          <h3 slot="header" style="text-align: center;">Support</h3>
-          <p style="text-align: center;">
-            Get help from our support team
-          </p>
+          <h3 slot="header" style="text-align: center">Support</h3>
+          <p style="text-align: center">Get help from our support team</p>
         </m3-card>
       </div>
-      <app-code-block language="html" variant="sample" [code]="clickableCardExample"></app-code-block>
+      <app-code-block
+        language="html"
+        variant="sample"
+        [code]="clickableCardExample"
+      ></app-code-block>
     </div>
   </section>
 
@@ -186,15 +248,15 @@
     <p class="section-description">
       Cards support different width options: auto (default), full, and fixed.
     </p>
-    
+
     <div class="variant-card">
       <div class="demo-container">
-        <div style="display: flex; flex-direction: column; gap: 16px;">
+        <div style="display: flex; flex-direction: column; gap: 16px">
           <m3-card variant="elevated" width="full">
             <h3 slot="header">Full Width Card</h3>
             <p>
-              This card takes up the full width of its container.
-              Perfect for mobile layouts or single-column designs.
+              This card takes up the full width of its container. Perfect for
+              mobile layouts or single-column designs.
             </p>
             <div slot="actions" class="actions">
               <m3-button variant="filled">Primary</m3-button>
@@ -202,10 +264,12 @@
             </div>
           </m3-card>
 
-          <div style="display: flex; gap: 16px; flex-wrap: wrap;">
+          <div style="display: flex; gap: 16px; flex-wrap: wrap">
             <m3-card variant="filled" width="fixed">
               <h3 slot="header">Fixed Width</h3>
-              <p>This card has a fixed width of 320px (customizable via CSS).</p>
+              <p>
+                This card has a fixed width of 320px (customizable via CSS).
+              </p>
             </m3-card>
 
             <m3-card variant="outlined" width="auto">
@@ -215,7 +279,11 @@
           </div>
         </div>
       </div>
-      <app-code-block language="html" variant="sample" [code]="widthCardExample"></app-code-block>
+      <app-code-block
+        language="html"
+        variant="sample"
+        [code]="widthCardExample"
+      ></app-code-block>
     </div>
   </section>
 
@@ -223,14 +291,18 @@
   <section class="demo-section">
     <h2>Card States</h2>
     <p class="section-description">
-      Cards support various interaction states including hover, focus, pressed, and disabled.
+      Cards support various interaction states including hover, focus, pressed,
+      and disabled.
     </p>
-    
+
     <div class="variant-card">
       <div class="demo-container cards-grid">
         <m3-card variant="elevated" clickable aria-label="Normal card">
           <h3 slot="header">Normal State</h3>
-          <p>Hover over this card or focus it with keyboard navigation to see state changes.</p>
+          <p>
+            Hover over this card or focus it with keyboard navigation to see
+            state changes.
+          </p>
         </m3-card>
 
         <m3-card variant="filled" disabled>
@@ -246,7 +318,11 @@
           <p>This card shows the dragged state with elevated shadow.</p>
         </m3-card>
       </div>
-      <app-code-block language="html" variant="sample" [code]="stateCardExample"></app-code-block>
+      <app-code-block
+        language="html"
+        variant="sample"
+        [code]="stateCardExample"
+      ></app-code-block>
     </div>
   </section>
 
@@ -256,29 +332,107 @@
     <p class="section-description">
       A real-world example of a product card with all features combined.
     </p>
-    
+
     <div class="variant-card">
-      <div class="demo-container" style="max-width: 400px; margin: 0 auto;">
+      <div class="demo-container" style="max-width: 400px; margin: 0 auto">
         <m3-card variant="elevated">
-          <div slot="media" style="height: 240px; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); display: flex; flex-direction: column; align-items: center; justify-content: center; color: white;">
-            <div style="font-size: 72px; margin-bottom: 8px;">🎧</div>
-            <div style="background: rgba(255,255,255,0.2); padding: 4px 12px; border-radius: 16px; font-size: 12px; font-weight: 500;">NEW</div>
-          </div>
-          <div slot="header">
-            <h3 style="margin: 0; font-size: 24px; color: var(--md-sys-color-on-surface);">Premium Headphones</h3>
-            <div style="display: flex; align-items: center; gap: 8px; margin-top: 8px;">
-              <span style="font-size: 28px; font-weight: 600; color: var(--md-sys-color-primary);">$299</span>
-              <span style="font-size: 16px; color: var(--md-sys-color-on-surface-variant); text-decoration: line-through;">$399</span>
-              <span style="background: var(--md-sys-color-primary-container); color: var(--md-sys-color-on-primary-container); padding: 4px 8px; border-radius: 8px; font-size: 12px; font-weight: 600;">25% OFF</span>
+          <div
+            slot="media"
+            style="
+              height: 240px;
+              background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+              display: flex;
+              flex-direction: column;
+              align-items: center;
+              justify-content: center;
+              color: white;
+            "
+          >
+            <div style="font-size: 72px; margin-bottom: 8px">🎧</div>
+            <div
+              style="
+                background: rgba(255, 255, 255, 0.2);
+                padding: 4px 12px;
+                border-radius: 16px;
+                font-size: 12px;
+                font-weight: 500;
+              "
+            >
+              NEW
             </div>
           </div>
-          <p style="line-height: 1.6;">
+          <div slot="header">
+            <h3
+              style="
+                margin: 0;
+                font-size: 24px;
+                color: var(--md-sys-color-on-surface);
+              "
+            >
+              Premium Headphones
+            </h3>
+            <div
+              style="
+                display: flex;
+                align-items: center;
+                gap: 8px;
+                margin-top: 8px;
+              "
+            >
+              <span
+                style="
+                  font-size: 28px;
+                  font-weight: 600;
+                  color: var(--md-sys-color-primary);
+                "
+                >$299</span
+              >
+              <span
+                style="
+                  font-size: 16px;
+                  color: var(--md-sys-color-on-surface-variant);
+                  text-decoration: line-through;
+                "
+                >$399</span
+              >
+              <span
+                style="
+                  background: var(--md-sys-color-primary-container);
+                  color: var(--md-sys-color-on-primary-container);
+                  padding: 4px 8px;
+                  border-radius: 8px;
+                  font-size: 12px;
+                  font-weight: 600;
+                "
+                >25% OFF</span
+              >
+            </div>
+          </div>
+          <p style="line-height: 1.6">
             Experience premium sound quality with active noise cancellation,
             40-hour battery life, and comfortable over-ear design.
           </p>
-          <div style="display: flex; gap: 8px; margin-top: 12px;">
-            <span style="background: var(--md-sys-color-surface-variant); color: var(--md-sys-color-on-surface-variant); padding: 6px 12px; border-radius: 8px; font-size: 13px;">🎵 Hi-Fi Audio</span>
-            <span style="background: var(--md-sys-color-surface-variant); color: var(--md-sys-color-on-surface-variant); padding: 6px 12px; border-radius: 8px; font-size: 13px;">🔋 40h Battery</span>
+          <div style="display: flex; gap: 8px; margin-top: 12px">
+            <span
+              style="
+                background: var(--md-sys-color-surface-variant);
+                color: var(--md-sys-color-on-surface-variant);
+                padding: 6px 12px;
+                border-radius: 8px;
+                font-size: 13px;
+              "
+              >🎵 Hi-Fi Audio</span
+            >
+            <span
+              style="
+                background: var(--md-sys-color-surface-variant);
+                color: var(--md-sys-color-on-surface-variant);
+                padding: 6px 12px;
+                border-radius: 8px;
+                font-size: 13px;
+              "
+              >🔋 40h Battery</span
+            >
           </div>
           <div slot="actions" class="actions">
             <m3-button variant="filled" (click)="handleAction('Add to Cart')">
@@ -290,10 +444,13 @@
           </div>
         </m3-card>
       </div>
-      <app-code-block language="html" variant="sample" [code]="complexCardExample"></app-code-block>
+      <app-code-block
+        language="html"
+        variant="sample"
+        [code]="complexCardExample"
+      ></app-code-block>
     </div>
   </section>
 
   <!-- Code Examples -- removed -->
 </div>
-

--- a/apps/angular-app/src/pages/checkbox/checkbox.component.html
+++ b/apps/angular-app/src/pages/checkbox/checkbox.component.html
@@ -1,11 +1,4 @@
 <div class="page-container docs-page">
-  <header class="page-header">
-    <h1>Checkbox</h1>
-    <p class="subtitle">
-      Material 3 Expressive Checkbox components allow the user to select one or more items from a set.
-    </p>
-  </header>
-
   <section class="demo-section">
     <h2>Usage</h2>
     <p>Checkboxes can be used to turn an option on or off.</p>
@@ -14,27 +7,37 @@
         <m3-checkbox></m3-checkbox>
         <m3-checkbox checked></m3-checkbox>
       </div>
-      <app-code-block [code]="basicExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="basicExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 
   <section class="demo-section">
     <h2>Indeterminate State</h2>
     <p>
-      Checkboxes can have an indeterminate state, representing a mix of checked and unchecked values.
+      Checkboxes can have an indeterminate state, representing a mix of checked
+      and unchecked values.
     </p>
     <div class="interactive-demo">
       <div class="demo-row">
         <m3-checkbox indeterminate></m3-checkbox>
       </div>
-      <app-code-block [code]="indeterminateExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="indeterminateExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 
   <section class="demo-section">
     <h2>Disabled State</h2>
     <p>
-      Checkboxes can be disabled to prevent user interaction. They can be unchecked, checked, or indeterminate while disabled.
+      Checkboxes can be disabled to prevent user interaction. They can be
+      unchecked, checked, or indeterminate while disabled.
     </p>
     <div class="interactive-demo">
       <div class="demo-row">
@@ -42,20 +45,38 @@
         <m3-checkbox checked disabled></m3-checkbox>
         <m3-checkbox indeterminate disabled></m3-checkbox>
       </div>
-      <app-code-block [code]="disabledExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="disabledExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 
   <section class="demo-section">
     <h2>Interactive Example</h2>
-    <p>Listen to the native <code>change</code> event to respond to user interaction.</p>
+    <p>
+      Listen to the native <code>change</code> event to respond to user
+      interaction.
+    </p>
     <div class="interactive-demo">
-      <div class="demo-row" style="gap: 12px; align-items: center;">
-        <m3-checkbox aria-label="Accept terms" (change)="onCheckboxChange($event, 'terms')"></m3-checkbox>
-        <span style="color: var(--md-sys-color-on-surface)">I accept the terms and conditions</span>
+      <div class="demo-row" style="gap: 12px; align-items: center">
+        <m3-checkbox
+          aria-label="Accept terms"
+          (change)="onCheckboxChange($event, 'terms')"
+        ></m3-checkbox>
+        <span style="color: var(--md-sys-color-on-surface)"
+          >I accept the terms and conditions</span
+        >
       </div>
-      <p>Accepted: <strong>{{ termsAccepted ? 'Yes' : 'No' }}</strong></p>
-      <app-code-block [code]="interactiveExample" language="html" variant="sample"></app-code-block>
+      <p>
+        Accepted: <strong>{{ termsAccepted ? 'Yes' : 'No' }}</strong>
+      </p>
+      <app-code-block
+        [code]="interactiveExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 </div>

--- a/apps/angular-app/src/pages/chips/chips.component.html
+++ b/apps/angular-app/src/pages/chips/chips.component.html
@@ -1,9 +1,4 @@
 <div class="page-container docs-page">
-  <header class="page-header">
-    <h1>Chips</h1>
-    <p class="subtitle">Chips help people enter information, make selections, filter content, or trigger actions.</p>
-  </header>
-
   <section class="demo-section">
     <h2>Assist Chips</h2>
     <div class="interactive-demo">
@@ -11,7 +6,11 @@
         <m3-chip variant="assist">Get directions</m3-chip>
         <m3-chip variant="assist" elevated>Share</m3-chip>
       </div>
-      <app-code-block [code]="assistExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="assistExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 
@@ -23,7 +22,11 @@
         <m3-chip variant="filter" selected>Cycling</m3-chip>
         <m3-chip variant="filter">Hiking</m3-chip>
       </div>
-      <app-code-block [code]="filterExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="filterExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 
@@ -34,7 +37,11 @@
         <m3-chip variant="input" removable>John Doe</m3-chip>
         <m3-chip variant="input" removable>Jane Smith</m3-chip>
       </div>
-      <app-code-block [code]="inputExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="inputExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 
@@ -45,7 +52,11 @@
         <m3-chip variant="suggestion">Try again</m3-chip>
         <m3-chip variant="suggestion">Refresh</m3-chip>
       </div>
-      <app-code-block [code]="suggestionExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="suggestionExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 </div>

--- a/apps/angular-app/src/pages/components/components.component.css
+++ b/apps/angular-app/src/pages/components/components.component.css
@@ -1,141 +1,176 @@
-/* ─── Section groups ─────────────────────────────────────── */
 .motion-note {
-  max-width: 44rem;
-  margin-top: 0.75rem;
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  margin: 0;
+  padding: 15px 18px;
+  border: 1px solid
+    color-mix(
+      in srgb,
+      var(--md-sys-color-primary) 24%,
+      var(--md-sys-color-outline-variant)
+    );
+  border-radius: 16px;
+  background: color-mix(
+    in srgb,
+    var(--md-sys-color-primary-container) 38%,
+    var(--md-sys-color-surface)
+  );
   color: var(--md-sys-color-on-surface-variant);
-  font-size: 0.875rem;
-  line-height: 1.4;
+  font-size: 0.84rem;
+  line-height: 1.55;
+}
+
+.motion-note .material-symbols-outlined {
+  flex: 0 0 auto;
+  margin-top: 1px;
+  color: var(--md-sys-color-primary);
+  font-size: 19px;
 }
 
 .comp-section {
-  padding: 24px 0;
-  border-bottom: 1px solid var(--md-sys-color-outline-variant);
-}
-
-.comp-section:last-child {
-  border-bottom: none;
+  min-width: 0;
+  padding: clamp(20px, 3vw, 30px);
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: clamp(20px, 2.5vw, 28px);
+  background: var(--md-sys-color-surface);
+  box-shadow: 0 12px 32px
+    color-mix(in srgb, var(--md-sys-color-on-surface) 4%, transparent);
 }
 
 .comp-section h2 {
-  font-size: 0.75rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.07em;
-  color: var(--md-sys-color-on-surface-variant);
-  margin: 0 0 12px;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin-bottom: 18px;
 }
 
-@media (max-width: 600px) {
-  .comp-section {
-    padding: 18px 0;
-  }
+.comp-section h2::before {
+  content: '';
+  inline-size: 7px;
+  block-size: 7px;
+  border-radius: 50%;
+  background: var(--md-sys-color-primary);
+  box-shadow: 0 0 0 4px
+    color-mix(in srgb, var(--md-sys-color-primary) 13%, transparent);
 }
 
-/* ─── Table ──────────────────────────────────────────────── */
 .comp-table {
-  border: 1px solid var(--md-sys-color-outline-variant);
-  border-radius: 12px;
-  /* use clip-path instead of overflow:hidden so badge indicators aren't clipped */
-  clip-path: inset(0 round 12px);
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
   min-width: 0;
-  width: 100%;
 }
 
 .comp-row {
+  position: relative;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 280px) 32px;
+  grid-template-columns: minmax(0, 1fr) minmax(100px, 0.7fr) 32px;
   align-items: center;
-  gap: 12px 16px;
-  padding: 13px 20px;
-  border-bottom: 1px solid var(--md-sys-color-outline-variant);
-  cursor: pointer;
-  transition: background var(--md-sys-motion-duration-short3);
+  gap: 12px;
   min-width: 0;
-}
-
-.comp-table > :last-child .comp-row {
-  border-bottom: none;
+  min-height: 112px;
+  padding: 16px;
+  border: 1px solid transparent;
+  border-radius: 18px;
+  background: var(--md-sys-color-surface-container-low);
+  cursor: pointer;
+  transition:
+    background var(--md-sys-motion-duration-short3),
+    border-color var(--md-sys-motion-duration-short3),
+    box-shadow var(--md-sys-motion-duration-short3),
+    transform var(--md-sys-motion-duration-short3);
 }
 
 .comp-row:hover {
-  background: var(--md-sys-color-surface-container-low);
+  border-color: color-mix(
+    in srgb,
+    var(--md-sys-color-primary) 26%,
+    transparent
+  );
+  background: color-mix(
+    in srgb,
+    var(--md-sys-color-primary-container) 30%,
+    var(--md-sys-color-surface)
+  );
+  box-shadow: 0 10px 24px
+    color-mix(in srgb, var(--md-sys-color-on-surface) 7%, transparent);
+  transform: translateY(-2px);
 }
 
-.comp-row:hover .comp-arrow {
-  --md-sys-color-on-surface-variant: var(--md-sys-color-primary);
-  transform: translateX(2px);
+.comp-row:focus-within {
+  outline: 3px solid
+    color-mix(in srgb, var(--md-sys-color-primary) 24%, transparent);
+  outline-offset: 2px;
 }
 
-/* ─── Info column ────────────────────────────────────────── */
 .comp-info {
   display: flex;
   flex-direction: column;
-  gap: 3px;
+  gap: 6px;
   min-width: 0;
-  overflow: hidden;
 }
 
 .comp-name {
-  font-size: 0.8125rem;
-  font-weight: 600;
-  font-family: var(--font-mono);
   color: var(--md-sys-color-on-surface);
-  white-space: normal;
-  word-break: break-word;
-  overflow-wrap: break-word;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  font-weight: 700;
+  overflow-wrap: anywhere;
 }
 
 .comp-desc {
-  font-size: 0.8125rem;
   color: var(--md-sys-color-on-surface-variant);
-  line-height: 1.4;
-  min-width: 0;
+  font-size: 0.76rem;
+  line-height: 1.48;
 }
 
-/* ─── Preview column ─────────────────────────────────────── */
 .comp-preview {
   display: flex;
   align-items: center;
-  gap: 8px;
-  flex-wrap: wrap;
   justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 7px;
   min-width: 0;
+  max-height: 80px;
+  overflow: hidden;
 }
 
 .comp-preview--wide m3-slider,
 .comp-preview--wide m3-text-field,
 .comp-preview--wide m3-progress,
 .comp-preview--wide m3-tabs {
-  width: 100%;
-  max-width: 100%;
-  min-width: 0;
   display: block;
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
 }
 
-/* badge indicators render above the element — give vertical breathing room */
 .comp-preview--badge {
-  padding-top: 12px;
   align-items: flex-end;
+  padding-top: 12px;
 }
 
 .comp-note {
-  font-size: 0.75rem;
   color: var(--md-sys-color-on-surface-variant);
-  opacity: 0.7;
+  font-size: 0.7rem;
   font-style: italic;
+  opacity: 0.75;
   white-space: nowrap;
 }
 
-/* ─── Arrow ──────────────────────────────────────────────── */
 .comp-arrow {
-  --md-sys-color-on-surface-variant: var(--md-sys-color-outline);
-  transition: transform var(--md-sys-motion-duration-short3);
-  flex-shrink: 0;
+  --md-sys-color-on-surface-variant: var(--md-sys-color-primary);
   justify-self: end;
+  flex: 0 0 auto;
+  transition: transform var(--md-sys-motion-duration-short3);
 }
 
-/* ─── Tablet: hide preview to avoid squeeze ─────────────── */
-@media (max-width: 768px) {
+.comp-row:hover .comp-arrow {
+  transform: translateX(3px);
+}
+
+@media (max-width: 1080px) {
   .comp-row {
     grid-template-columns: minmax(0, 1fr) 32px;
   }
@@ -145,10 +180,29 @@
   }
 }
 
-/* ─── Mobile ─────────────────────────────────────────────── */
-@media (max-width: 600px) {
+@media (max-width: 760px) {
+  .comp-table {
+    grid-template-columns: 1fr;
+  }
+
   .comp-row {
-    gap: 4px 8px;
-    padding: 11px 14px;
+    min-height: 88px;
+  }
+}
+
+@media (max-width: 600px) {
+  .motion-note {
+    padding: 14px;
+  }
+
+  .comp-section {
+    padding: 18px 15px;
+    border-radius: 20px;
+  }
+
+  .comp-row {
+    min-height: 82px;
+    padding: 14px;
+    border-radius: 15px;
   }
 }

--- a/apps/angular-app/src/pages/components/components.component.html
+++ b/apps/angular-app/src/pages/components/components.component.html
@@ -1,27 +1,38 @@
 <div class="page-container docs-page">
-  <header class="page-header">
-    <h1>Components</h1>
-    <p class="subtitle">Material 3 web components — drop into any framework.</p>
-    <p class="motion-note">Motion is used for state and hierarchy, not decoration. Use your browser’s reduced-motion emulation to see the same examples resolve to clear static states.</p>
-  </header>
+  <p class="motion-note">
+    <span class="material-symbols-outlined" aria-hidden="true"
+      >motion_mode</span
+    >
+    Motion communicates state and hierarchy. With reduced motion enabled, every
+    example resolves to the same clear static state.
+  </p>
 
   <!-- Inputs & Controls -->
   <section class="comp-section">
     <h2>Inputs &amp; Controls</h2>
     <div class="comp-table">
-
       <app-seo-link href="buttons">
         <div class="comp-row">
           <div class="comp-info">
             <span class="comp-name">m3-button</span>
-            <span class="comp-desc">Filled, elevated, tonal, outlined, text · sizes · loading state</span>
+            <span class="comp-desc"
+              >Filled, elevated, tonal, outlined, text · sizes · loading
+              state</span
+            >
           </div>
           <div class="comp-preview">
             <m3-button size="small">Filled</m3-button>
             <m3-button variant="outlined" size="small">Outlined</m3-button>
             <m3-button variant="text" size="small">Text</m3-button>
           </div>
-          <m3-icon-button size="small" class="comp-arrow" aria-label="View m3-button component"><span class="material-symbols-outlined">arrow_forward</span></m3-icon-button>
+          <m3-icon-button
+            size="small"
+            class="comp-arrow"
+            aria-label="View m3-button component"
+            ><span class="material-symbols-outlined"
+              >arrow_forward</span
+            ></m3-icon-button
+          >
         </div>
       </app-seo-link>
 
@@ -29,13 +40,22 @@
         <div class="comp-row">
           <div class="comp-info">
             <span class="comp-name">m3-switch</span>
-            <span class="comp-desc">Toggle on/off · disabled state · accessible</span>
+            <span class="comp-desc"
+              >Toggle on/off · disabled state · accessible</span
+            >
           </div>
           <div class="comp-preview">
             <m3-switch></m3-switch>
             <m3-switch checked></m3-switch>
           </div>
-          <m3-icon-button size="small" class="comp-arrow" aria-label="View m3-switch component"><span class="material-symbols-outlined">arrow_forward</span></m3-icon-button>
+          <m3-icon-button
+            size="small"
+            class="comp-arrow"
+            aria-label="View m3-switch component"
+            ><span class="material-symbols-outlined"
+              >arrow_forward</span
+            ></m3-icon-button
+          >
         </div>
       </app-seo-link>
 
@@ -43,14 +63,23 @@
         <div class="comp-row">
           <div class="comp-info">
             <span class="comp-name">m3-checkbox</span>
-            <span class="comp-desc">Checked, unchecked, indeterminate · accessible</span>
+            <span class="comp-desc"
+              >Checked, unchecked, indeterminate · accessible</span
+            >
           </div>
           <div class="comp-preview">
             <m3-checkbox></m3-checkbox>
             <m3-checkbox checked></m3-checkbox>
             <m3-checkbox indeterminate></m3-checkbox>
           </div>
-          <m3-icon-button size="small" class="comp-arrow" aria-label="View m3-checkbox component"><span class="material-symbols-outlined">arrow_forward</span></m3-icon-button>
+          <m3-icon-button
+            size="small"
+            class="comp-arrow"
+            aria-label="View m3-checkbox component"
+            ><span class="material-symbols-outlined"
+              >arrow_forward</span
+            ></m3-icon-button
+          >
         </div>
       </app-seo-link>
 
@@ -64,7 +93,14 @@
             <m3-radio-button name="prev" value="1"></m3-radio-button>
             <m3-radio-button name="prev" value="2" checked></m3-radio-button>
           </div>
-          <m3-icon-button size="small" class="comp-arrow" aria-label="View m3-radio-button component"><span class="material-symbols-outlined">arrow_forward</span></m3-icon-button>
+          <m3-icon-button
+            size="small"
+            class="comp-arrow"
+            aria-label="View m3-radio-button component"
+            ><span class="material-symbols-outlined"
+              >arrow_forward</span
+            ></m3-icon-button
+          >
         </div>
       </app-seo-link>
 
@@ -72,12 +108,21 @@
         <div class="comp-row">
           <div class="comp-info">
             <span class="comp-name">m3-slider</span>
-            <span class="comp-desc">Continuous &amp; discrete · range support</span>
+            <span class="comp-desc"
+              >Continuous &amp; discrete · range support</span
+            >
           </div>
           <div class="comp-preview comp-preview--wide">
             <m3-slider min="0" max="100" value="60"></m3-slider>
           </div>
-          <m3-icon-button size="small" class="comp-arrow" aria-label="View m3-slider component"><span class="material-symbols-outlined">arrow_forward</span></m3-icon-button>
+          <m3-icon-button
+            size="small"
+            class="comp-arrow"
+            aria-label="View m3-slider component"
+            ><span class="material-symbols-outlined"
+              >arrow_forward</span
+            ></m3-icon-button
+          >
         </div>
       </app-seo-link>
 
@@ -85,12 +130,21 @@
         <div class="comp-row">
           <div class="comp-info">
             <span class="comp-name">m3-text-field</span>
-            <span class="comp-desc">Filled &amp; outlined · validation · icon slots</span>
+            <span class="comp-desc"
+              >Filled &amp; outlined · validation · icon slots</span
+            >
           </div>
           <div class="comp-preview comp-preview--wide">
             <m3-text-field label="Label"></m3-text-field>
           </div>
-          <m3-icon-button size="small" class="comp-arrow" aria-label="View m3-text-field component"><span class="material-symbols-outlined">arrow_forward</span></m3-icon-button>
+          <m3-icon-button
+            size="small"
+            class="comp-arrow"
+            aria-label="View m3-text-field component"
+            ><span class="material-symbols-outlined"
+              >arrow_forward</span
+            ></m3-icon-button
+          >
         </div>
       </app-seo-link>
 
@@ -98,14 +152,23 @@
         <div class="comp-row">
           <div class="comp-info">
             <span class="comp-name">m3-chip</span>
-            <span class="comp-desc">Assist, filter, input, suggestion variants</span>
+            <span class="comp-desc"
+              >Assist, filter, input, suggestion variants</span
+            >
           </div>
           <div class="comp-preview">
             <m3-chip variant="assist">Assist</m3-chip>
             <m3-chip variant="filter" selected>Filter</m3-chip>
             <m3-chip variant="suggestion">Suggest</m3-chip>
           </div>
-          <m3-icon-button size="small" class="comp-arrow" aria-label="View m3-chip component"><span class="material-symbols-outlined">arrow_forward</span></m3-icon-button>
+          <m3-icon-button
+            size="small"
+            class="comp-arrow"
+            aria-label="View m3-chip component"
+            ><span class="material-symbols-outlined"
+              >arrow_forward</span
+            ></m3-icon-button
+          >
         </div>
       </app-seo-link>
 
@@ -113,13 +176,21 @@
         <div class="comp-row">
           <div class="comp-info">
             <span class="comp-name">m3-search-bar</span>
-            <span class="comp-desc">Leading &amp; trailing slots · keyboard navigation</span>
+            <span class="comp-desc"
+              >Leading &amp; trailing slots · keyboard navigation</span
+            >
           </div>
           <div class="comp-preview"></div>
-          <m3-icon-button size="small" class="comp-arrow" aria-label="View m3-search-bar component"><span class="material-symbols-outlined">arrow_forward</span></m3-icon-button>
+          <m3-icon-button
+            size="small"
+            class="comp-arrow"
+            aria-label="View m3-search-bar component"
+            ><span class="material-symbols-outlined"
+              >arrow_forward</span
+            ></m3-icon-button
+          >
         </div>
       </app-seo-link>
-
     </div>
   </section>
 
@@ -127,17 +198,25 @@
   <section class="comp-section">
     <h2>Navigation</h2>
     <div class="comp-table">
-
       <app-seo-link href="navigation-rail">
         <div class="comp-row">
           <div class="comp-info">
             <span class="comp-name">m3-navigation-rail</span>
-            <span class="comp-desc">Collapsible vertical nav · badge support · bottom slot</span>
+            <span class="comp-desc"
+              >Collapsible vertical nav · badge support · bottom slot</span
+            >
           </div>
           <div class="comp-preview">
             <span class="comp-note">← visible on desktop</span>
           </div>
-          <m3-icon-button size="small" class="comp-arrow" aria-label="View m3-navigation-rail component"><span class="material-symbols-outlined">arrow_forward</span></m3-icon-button>
+          <m3-icon-button
+            size="small"
+            class="comp-arrow"
+            aria-label="View m3-navigation-rail component"
+            ><span class="material-symbols-outlined"
+              >arrow_forward</span
+            ></m3-icon-button
+          >
         </div>
       </app-seo-link>
 
@@ -145,12 +224,21 @@
         <div class="comp-row">
           <div class="comp-info">
             <span class="comp-name">m3-navigation-bar</span>
-            <span class="comp-desc">Responsive bottom nav · auto-layout switching</span>
+            <span class="comp-desc"
+              >Responsive bottom nav · auto-layout switching</span
+            >
           </div>
           <div class="comp-preview">
             <span class="comp-note">↓ visible on mobile</span>
           </div>
-          <m3-icon-button size="small" class="comp-arrow" aria-label="View m3-navigation-bar component"><span class="material-symbols-outlined">arrow_forward</span></m3-icon-button>
+          <m3-icon-button
+            size="small"
+            class="comp-arrow"
+            aria-label="View m3-navigation-bar component"
+            ><span class="material-symbols-outlined"
+              >arrow_forward</span
+            ></m3-icon-button
+          >
         </div>
       </app-seo-link>
 
@@ -158,7 +246,9 @@
         <div class="comp-row">
           <div class="comp-info">
             <span class="comp-name">m3-tabs</span>
-            <span class="comp-desc">Primary &amp; secondary tabs · icon support</span>
+            <span class="comp-desc"
+              >Primary &amp; secondary tabs · icon support</span
+            >
           </div>
           <div class="comp-preview comp-preview--wide">
             <m3-tabs>
@@ -167,7 +257,14 @@
               <m3-tab>Explore</m3-tab>
             </m3-tabs>
           </div>
-          <m3-icon-button size="small" class="comp-arrow" aria-label="View m3-tabs component"><span class="material-symbols-outlined">arrow_forward</span></m3-icon-button>
+          <m3-icon-button
+            size="small"
+            class="comp-arrow"
+            aria-label="View m3-tabs component"
+            ><span class="material-symbols-outlined"
+              >arrow_forward</span
+            ></m3-icon-button
+          >
         </div>
       </app-seo-link>
 
@@ -175,10 +272,19 @@
         <div class="comp-row">
           <div class="comp-info">
             <span class="comp-name">m3-menu</span>
-            <span class="comp-desc">Anchored popup · keyboard navigation · accessible</span>
+            <span class="comp-desc"
+              >Anchored popup · keyboard navigation · accessible</span
+            >
           </div>
           <div class="comp-preview"></div>
-          <m3-icon-button size="small" class="comp-arrow" aria-label="View m3-menu component"><span class="material-symbols-outlined">arrow_forward</span></m3-icon-button>
+          <m3-icon-button
+            size="small"
+            class="comp-arrow"
+            aria-label="View m3-menu component"
+            ><span class="material-symbols-outlined"
+              >arrow_forward</span
+            ></m3-icon-button
+          >
         </div>
       </app-seo-link>
 
@@ -186,10 +292,19 @@
         <div class="comp-row">
           <div class="comp-info">
             <span class="comp-name">m3-fab-menu</span>
-            <span class="comp-desc">Floating action button with animated menu</span>
+            <span class="comp-desc"
+              >Floating action button with animated menu</span
+            >
           </div>
           <div class="comp-preview"></div>
-          <m3-icon-button size="small" class="comp-arrow" aria-label="View m3-fab-menu component"><span class="material-symbols-outlined">arrow_forward</span></m3-icon-button>
+          <m3-icon-button
+            size="small"
+            class="comp-arrow"
+            aria-label="View m3-fab-menu component"
+            ><span class="material-symbols-outlined"
+              >arrow_forward</span
+            ></m3-icon-button
+          >
         </div>
       </app-seo-link>
 
@@ -197,10 +312,19 @@
         <div class="comp-row">
           <div class="comp-info">
             <span class="comp-name">m3-split-button</span>
-            <span class="comp-desc">Primary action + dropdown · shape morphing</span>
+            <span class="comp-desc"
+              >Primary action + dropdown · shape morphing</span
+            >
           </div>
           <div class="comp-preview"></div>
-          <m3-icon-button size="small" class="comp-arrow" aria-label="View m3-split-button component"><span class="material-symbols-outlined">arrow_forward</span></m3-icon-button>
+          <m3-icon-button
+            size="small"
+            class="comp-arrow"
+            aria-label="View m3-split-button component"
+            ><span class="material-symbols-outlined"
+              >arrow_forward</span
+            ></m3-icon-button
+          >
         </div>
       </app-seo-link>
 
@@ -208,16 +332,32 @@
         <div class="comp-row">
           <div class="comp-info">
             <span class="comp-name">m3-icon-button</span>
-            <span class="comp-desc">Standard, filled, tonal, outlined · toggle · sizes</span>
+            <span class="comp-desc"
+              >Standard, filled, tonal, outlined · toggle · sizes</span
+            >
           </div>
           <div class="comp-preview">
-            <m3-icon-button size="small" aria-label="Preview"><span class="material-symbols-outlined">settings</span></m3-icon-button>
-            <m3-icon-button variant="filled" size="small" aria-label="Preview"><span class="material-symbols-outlined">add</span></m3-icon-button>
+            <m3-icon-button size="small" aria-label="Preview"
+              ><span class="material-symbols-outlined"
+                >settings</span
+              ></m3-icon-button
+            >
+            <m3-icon-button variant="filled" size="small" aria-label="Preview"
+              ><span class="material-symbols-outlined"
+                >add</span
+              ></m3-icon-button
+            >
           </div>
-          <m3-icon-button size="small" class="comp-arrow" aria-label="View m3-icon-button component"><span class="material-symbols-outlined">arrow_forward</span></m3-icon-button>
+          <m3-icon-button
+            size="small"
+            class="comp-arrow"
+            aria-label="View m3-icon-button component"
+            ><span class="material-symbols-outlined"
+              >arrow_forward</span
+            ></m3-icon-button
+          >
         </div>
       </app-seo-link>
-
     </div>
   </section>
 
@@ -225,15 +365,23 @@
   <section class="comp-section">
     <h2>Surfaces &amp; Feedback</h2>
     <div class="comp-table">
-
       <app-seo-link href="cards">
         <div class="comp-row">
           <div class="comp-info">
             <span class="comp-name">m3-card</span>
-            <span class="comp-desc">Elevated, filled, outlined · media &amp; action slots</span>
+            <span class="comp-desc"
+              >Elevated, filled, outlined · media &amp; action slots</span
+            >
           </div>
           <div class="comp-preview"></div>
-          <m3-icon-button size="small" class="comp-arrow" aria-label="View m3-card component"><span class="material-symbols-outlined">arrow_forward</span></m3-icon-button>
+          <m3-icon-button
+            size="small"
+            class="comp-arrow"
+            aria-label="View m3-card component"
+            ><span class="material-symbols-outlined"
+              >arrow_forward</span
+            ></m3-icon-button
+          >
         </div>
       </app-seo-link>
 
@@ -241,12 +389,21 @@
         <div class="comp-row">
           <div class="comp-info">
             <span class="comp-name">m3-divider</span>
-            <span class="comp-desc">Full-width, inset, middle · vertical · pulsing animation</span>
+            <span class="comp-desc"
+              >Full-width, inset, middle · vertical · pulsing animation</span
+            >
           </div>
           <div class="comp-preview comp-preview--wide">
-            <m3-divider style="width:120px;" no-animation></m3-divider>
+            <m3-divider style="width: 120px" no-animation></m3-divider>
           </div>
-          <m3-icon-button size="small" class="comp-arrow" aria-label="View m3-divider component"><span class="material-symbols-outlined">arrow_forward</span></m3-icon-button>
+          <m3-icon-button
+            size="small"
+            class="comp-arrow"
+            aria-label="View m3-divider component"
+            ><span class="material-symbols-outlined"
+              >arrow_forward</span
+            ></m3-icon-button
+          >
         </div>
       </app-seo-link>
 
@@ -254,15 +411,25 @@
         <div class="comp-row">
           <div class="comp-info">
             <span class="comp-name">m3-list</span>
-            <span class="comp-desc">One, two, three lines · leading/trailing · staggered animation</span>
+            <span class="comp-desc"
+              >One, two, three lines · leading/trailing · staggered
+              animation</span
+            >
           </div>
           <div class="comp-preview comp-preview--wide">
-            <m3-list style="width:180px;">
+            <m3-list style="width: 180px">
               <m3-list-item>Apple</m3-list-item>
               <m3-list-item>Banana</m3-list-item>
             </m3-list>
           </div>
-          <m3-icon-button size="small" class="comp-arrow" aria-label="View m3-list component"><span class="material-symbols-outlined">arrow_forward</span></m3-icon-button>
+          <m3-icon-button
+            size="small"
+            class="comp-arrow"
+            aria-label="View m3-list component"
+            ><span class="material-symbols-outlined"
+              >arrow_forward</span
+            ></m3-icon-button
+          >
         </div>
       </app-seo-link>
 
@@ -270,10 +437,19 @@
         <div class="comp-row">
           <div class="comp-info">
             <span class="comp-name">m3-dialog</span>
-            <span class="comp-desc">Modal · scrim overlay · focus trapping · keyboard dismiss</span>
+            <span class="comp-desc"
+              >Modal · scrim overlay · focus trapping · keyboard dismiss</span
+            >
           </div>
           <div class="comp-preview"></div>
-          <m3-icon-button size="small" class="comp-arrow" aria-label="View m3-dialog component"><span class="material-symbols-outlined">arrow_forward</span></m3-icon-button>
+          <m3-icon-button
+            size="small"
+            class="comp-arrow"
+            aria-label="View m3-dialog component"
+            ><span class="material-symbols-outlined"
+              >arrow_forward</span
+            ></m3-icon-button
+          >
         </div>
       </app-seo-link>
 
@@ -281,10 +457,19 @@
         <div class="comp-row">
           <div class="comp-info">
             <span class="comp-name">m3-tooltip</span>
-            <span class="comp-desc">Plain &amp; rich variants · configurable placement</span>
+            <span class="comp-desc"
+              >Plain &amp; rich variants · configurable placement</span
+            >
           </div>
           <div class="comp-preview"></div>
-          <m3-icon-button size="small" class="comp-arrow" aria-label="View m3-tooltip component"><span class="material-symbols-outlined">arrow_forward</span></m3-icon-button>
+          <m3-icon-button
+            size="small"
+            class="comp-arrow"
+            aria-label="View m3-tooltip component"
+            ><span class="material-symbols-outlined"
+              >arrow_forward</span
+            ></m3-icon-button
+          >
         </div>
       </app-seo-link>
 
@@ -292,12 +477,21 @@
         <div class="comp-row">
           <div class="comp-info">
             <span class="comp-name">m3-progress</span>
-            <span class="comp-desc">Linear &amp; circular · determinate &amp; indeterminate</span>
+            <span class="comp-desc"
+              >Linear &amp; circular · determinate &amp; indeterminate</span
+            >
           </div>
           <div class="comp-preview comp-preview--wide">
             <m3-progress value="0.6"></m3-progress>
           </div>
-          <m3-icon-button size="small" class="comp-arrow" aria-label="View m3-progress component"><span class="material-symbols-outlined">arrow_forward</span></m3-icon-button>
+          <m3-icon-button
+            size="small"
+            class="comp-arrow"
+            aria-label="View m3-progress component"
+            ><span class="material-symbols-outlined"
+              >arrow_forward</span
+            ></m3-icon-button
+          >
         </div>
       </app-seo-link>
 
@@ -305,10 +499,19 @@
         <div class="comp-row">
           <div class="comp-info">
             <span class="comp-name">m3-loading-indicator</span>
-            <span class="comp-desc">Shape-morphing loading animation · contained variant</span>
+            <span class="comp-desc"
+              >Shape-morphing loading animation · contained variant</span
+            >
           </div>
           <div class="comp-preview"></div>
-          <m3-icon-button size="small" class="comp-arrow" aria-label="View m3-loading-indicator component"><span class="material-symbols-outlined">arrow_forward</span></m3-icon-button>
+          <m3-icon-button
+            size="small"
+            class="comp-arrow"
+            aria-label="View m3-loading-indicator component"
+            ><span class="material-symbols-outlined"
+              >arrow_forward</span
+            ></m3-icon-button
+          >
         </div>
       </app-seo-link>
 
@@ -316,10 +519,19 @@
         <div class="comp-row">
           <div class="comp-info">
             <span class="comp-name">m3-top-app-bar</span>
-            <span class="comp-desc">Small, center-aligned, medium, large · scroll behaviors</span>
+            <span class="comp-desc"
+              >Small, center-aligned, medium, large · scroll behaviors</span
+            >
           </div>
           <div class="comp-preview"></div>
-          <m3-icon-button size="small" class="comp-arrow" aria-label="View m3-top-app-bar component"><span class="material-symbols-outlined">arrow_forward</span></m3-icon-button>
+          <m3-icon-button
+            size="small"
+            class="comp-arrow"
+            aria-label="View m3-top-app-bar component"
+            ><span class="material-symbols-outlined"
+              >arrow_forward</span
+            ></m3-icon-button
+          >
         </div>
       </app-seo-link>
 
@@ -327,10 +539,19 @@
         <div class="comp-row">
           <div class="comp-info">
             <span class="comp-name">m3-snackbar</span>
-            <span class="comp-desc">Auto-dismiss · action slot · entrance/exit animations</span>
+            <span class="comp-desc"
+              >Auto-dismiss · action slot · entrance/exit animations</span
+            >
           </div>
           <div class="comp-preview"></div>
-          <m3-icon-button size="small" class="comp-arrow" aria-label="View m3-snackbar component"><span class="material-symbols-outlined">arrow_forward</span></m3-icon-button>
+          <m3-icon-button
+            size="small"
+            class="comp-arrow"
+            aria-label="View m3-snackbar component"
+            ><span class="material-symbols-outlined"
+              >arrow_forward</span
+            ></m3-icon-button
+          >
         </div>
       </app-seo-link>
 
@@ -338,17 +559,30 @@
         <div class="comp-row">
           <div class="comp-info">
             <span class="comp-name">m3-badge</span>
-            <span class="comp-desc">Dot &amp; count variants · wraps any element</span>
+            <span class="comp-desc"
+              >Dot &amp; count variants · wraps any element</span
+            >
           </div>
           <div class="comp-preview comp-preview--badge">
-            <m3-badge><span class="material-symbols-outlined">mail</span></m3-badge>
-            <m3-badge label="5"><span class="material-symbols-outlined">notifications</span></m3-badge>
+            <m3-badge
+              ><span class="material-symbols-outlined">mail</span></m3-badge
+            >
+            <m3-badge label="5"
+              ><span class="material-symbols-outlined"
+                >notifications</span
+              ></m3-badge
+            >
           </div>
-          <m3-icon-button size="small" class="comp-arrow" aria-label="View m3-badge component"><span class="material-symbols-outlined">arrow_forward</span></m3-icon-button>
+          <m3-icon-button
+            size="small"
+            class="comp-arrow"
+            aria-label="View m3-badge component"
+            ><span class="material-symbols-outlined"
+              >arrow_forward</span
+            ></m3-icon-button
+          >
         </div>
       </app-seo-link>
-
     </div>
   </section>
-
 </div>

--- a/apps/angular-app/src/pages/contact/contact.component.css
+++ b/apps/angular-app/src/pages/contact/contact.component.css
@@ -1,7 +1,8 @@
 .contact-sections {
   display: flex;
   flex-direction: column;
-  gap: 0;
+  gap: clamp(16px, 2.4vw, 24px);
+  max-width: 860px;
 }
 
 /* ─── Contrib checklist ──────────────────────────────────── */
@@ -42,14 +43,16 @@
   align-items: center;
   gap: 7px;
   padding: 8px 14px;
-  border-radius: 8px;
+  border-radius: 999px;
   border: 1px solid var(--md-sys-color-outline-variant);
   background: var(--md-sys-color-surface-container-low);
   color: var(--md-sys-color-on-surface);
   font-size: 0.875rem;
   font-weight: 500;
   text-decoration: none;
-  transition: background var(--md-sys-motion-duration-short3), border-color var(--md-sys-motion-duration-short3);
+  transition:
+    background var(--md-sys-motion-duration-short3),
+    border-color var(--md-sys-motion-duration-short3);
 }
 
 .contact-link .material-symbols-outlined {
@@ -72,13 +75,13 @@
   border-color: #60a5fa;
 }
 
-:root[theme="dark"] .contact-link--support {
+:root[theme='dark'] .contact-link--support {
   border-color: #1e3a5f;
   color: #93c5fd;
   background: #0c1a2e;
 }
 
-:root[theme="dark"] .contact-link--support:hover {
+:root[theme='dark'] .contact-link--support:hover {
   background: #112240;
   border-color: #2563eb;
 }

--- a/apps/angular-app/src/pages/contact/contact.component.html
+++ b/apps/angular-app/src/pages/contact/contact.component.html
@@ -1,23 +1,28 @@
 <div class="page-container docs-page">
-  <header class="page-header">
-    <h1>Contact</h1>
-    <p>Built and maintained by <strong>@banegasn</strong>. Questions, ideas, and contributions are always welcome.</p>
-  </header>
-
   <div class="contact-sections">
-
     <div class="page-section">
       <h2>Get in touch</h2>
       <p>
-        Have a question about a component, found a bug, or want to suggest a new feature?
-        The best way to reach out is through GitHub — open an issue and I'll get back to you.
+        Have a question about a component, found a bug, or want to suggest a new
+        feature? The best way to reach out is through GitHub — open an issue and
+        I'll get back to you.
       </p>
       <div class="contact-links">
-        <a class="contact-link" href="https://github.com/banegasn/components/issues" target="_blank" rel="noopener">
+        <a
+          class="contact-link"
+          href="https://github.com/banegasn/components/issues"
+          target="_blank"
+          rel="noopener"
+        >
           <span class="material-symbols-outlined">bug_report</span>
           Open an issue
         </a>
-        <a class="contact-link" href="https://github.com/banegasn" target="_blank" rel="noopener">
+        <a
+          class="contact-link"
+          href="https://github.com/banegasn"
+          target="_blank"
+          rel="noopener"
+        >
           <span class="material-symbols-outlined">person</span>
           GitHub Profile
         </a>
@@ -27,8 +32,9 @@
     <div class="page-section">
       <h2>Contributing</h2>
       <p>
-        This is an open source project and contributions are genuinely appreciated.
-        Whether it's a small typo fix, a new component, or a big refactor — all pull requests are welcome.
+        This is an open source project and contributions are genuinely
+        appreciated. Whether it's a small typo fix, a new component, or a big
+        refactor — all pull requests are welcome.
       </p>
       <ul class="contrib-list">
         <li>
@@ -45,11 +51,21 @@
         </li>
       </ul>
       <div class="contact-links">
-        <a class="contact-link" href="https://github.com/banegasn/components" target="_blank" rel="noopener">
+        <a
+          class="contact-link"
+          href="https://github.com/banegasn/components"
+          target="_blank"
+          rel="noopener"
+        >
           <span class="material-symbols-outlined">code</span>
           View repository
         </a>
-        <a class="contact-link" href="https://github.com/banegasn/components/pulls" target="_blank" rel="noopener">
+        <a
+          class="contact-link"
+          href="https://github.com/banegasn/components/pulls"
+          target="_blank"
+          rel="noopener"
+        >
           <span class="material-symbols-outlined">merge</span>
           Pull requests
         </a>
@@ -59,21 +75,30 @@
     <div class="page-section">
       <h2>Support the project</h2>
       <p>
-        This library is free and open source. If it saves you time or helps your project,
-        consider supporting its development. Every bit helps keep the components up to date
-        with the latest Material Design specs.
+        This library is free and open source. If it saves you time or helps your
+        project, consider supporting its development. Every bit helps keep the
+        components up to date with the latest Material Design specs.
       </p>
       <div class="contact-links">
-        <a class="contact-link contact-link--support" href="https://paypal.me/banegasn" target="_blank" rel="noopener">
+        <a
+          class="contact-link contact-link--support"
+          href="https://paypal.me/banegasn"
+          target="_blank"
+          rel="noopener"
+        >
           <span class="material-symbols-outlined">favorite</span>
           Donate via PayPal
         </a>
-        <a class="contact-link" href="https://github.com/banegasn/components" target="_blank" rel="noopener">
+        <a
+          class="contact-link"
+          href="https://github.com/banegasn/components"
+          target="_blank"
+          rel="noopener"
+        >
           <span class="material-symbols-outlined">star</span>
           Star on GitHub
         </a>
       </div>
     </div>
-
   </div>
 </div>

--- a/apps/angular-app/src/pages/dialog/dialog.component.html
+++ b/apps/angular-app/src/pages/dialog/dialog.component.html
@@ -1,9 +1,4 @@
 <div class="page-container docs-page">
-  <header class="page-header">
-    <h1>Dialog</h1>
-    <p class="subtitle">Dialogs provide important prompts in a user flow.</p>
-  </header>
-
   <section class="demo-section">
     <h2>Usage</h2>
     <p>

--- a/apps/angular-app/src/pages/divider/divider.component.html
+++ b/apps/angular-app/src/pages/divider/divider.component.html
@@ -1,16 +1,15 @@
 <div class="page-container docs-page">
-  <header class="page-header">
-    <h1>Divider</h1>
-    <p class="subtitle">Dividers separate content into clear groups with expressive entrance animations.</p>
-  </header>
-
   <section class="demo-section">
     <h2>Full-Width</h2>
     <div class="interactive-demo">
       <div class="demo-row divider-demo">
         <m3-divider></m3-divider>
       </div>
-      <app-code-block [code]="fullWidthExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="fullWidthExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 
@@ -20,7 +19,11 @@
       <div class="demo-row divider-demo">
         <m3-divider variant="inset"></m3-divider>
       </div>
-      <app-code-block [code]="insetExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="insetExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 
@@ -30,7 +33,11 @@
       <div class="demo-row divider-demo">
         <m3-divider variant="middle"></m3-divider>
       </div>
-      <app-code-block [code]="middleExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="middleExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 
@@ -39,12 +46,16 @@
     <div class="interactive-demo">
       <div class="vertical-demo">
         <span>Item A</span>
-        <m3-divider orientation="vertical" style="height:24px;"></m3-divider>
+        <m3-divider orientation="vertical" style="height: 24px"></m3-divider>
         <span>Item B</span>
-        <m3-divider orientation="vertical" style="height:24px;"></m3-divider>
+        <m3-divider orientation="vertical" style="height: 24px"></m3-divider>
         <span>Item C</span>
       </div>
-      <app-code-block [code]="verticalExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="verticalExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 
@@ -56,7 +67,11 @@
         <m3-divider thickness="2"></m3-divider>
         <m3-divider thickness="4"></m3-divider>
       </div>
-      <app-code-block [code]="thicknessExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="thicknessExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 
@@ -66,7 +81,11 @@
       <div class="demo-row divider-demo">
         <m3-divider pulsing></m3-divider>
       </div>
-      <app-code-block [code]="pulsingExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="pulsingExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 </div>

--- a/apps/angular-app/src/pages/fab-menu/fab-menu.component.html
+++ b/apps/angular-app/src/pages/fab-menu/fab-menu.component.html
@@ -1,14 +1,17 @@
 <div class="page-container docs-page">
-  <header class="page-header">
-    <h1>FAB Menu</h1>
-    <p class="subtitle">A Floating Action Button that opens a related accessible menu.</p>
-  </header>
-
   <section class="demo-section">
     <h2>Interactive Demo</h2>
-    <div class="variant-card"
-      style="height: 400px; position: relative; background-color: var(--md-sys-color-surface-container-low, #f7f2fa); overflow: hidden; border-radius: 16px;">
-      <div style="position: absolute; bottom: 24px; right: 24px;">
+    <div
+      class="variant-card"
+      style="
+        height: 400px;
+        position: relative;
+        background-color: var(--md-sys-color-surface-container-low, #f7f2fa);
+        overflow: hidden;
+        border-radius: 16px;
+      "
+    >
+      <div style="position: absolute; bottom: 24px; right: 24px">
         <m3-fab-menu label="Create item">
           <m3-menu slot="menu" placement="top-end">
             <m3-menu-item value="edit">Edit</m3-menu-item>
@@ -18,15 +21,26 @@
         </m3-fab-menu>
       </div>
     </div>
-    <app-code-block language="html" variant="sample" [code]="basicExample"></app-code-block>
+    <app-code-block
+      language="html"
+      variant="sample"
+      [code]="basicExample"
+    ></app-code-block>
   </section>
 
   <section class="demo-section accessibility">
     <h2>♿ Accessibility</h2>
     <ul class="feature-list">
-      <li><strong>Keyboard:</strong> Arrow keys, Home, and End enter the menu.</li>
-      <li><strong>Focus:</strong> Escape and outside click return to the FAB.</li>
-      <li><strong>ARIA:</strong> The configured label, expanded state, and controls relationship are exposed.</li>
+      <li>
+        <strong>Keyboard:</strong> Arrow keys, Home, and End enter the menu.
+      </li>
+      <li>
+        <strong>Focus:</strong> Escape and outside click return to the FAB.
+      </li>
+      <li>
+        <strong>ARIA:</strong> The configured label, expanded state, and
+        controls relationship are exposed.
+      </li>
     </ul>
   </section>
 </div>

--- a/apps/angular-app/src/pages/home/home-preview.css
+++ b/apps/angular-app/src/pages/home/home-preview.css
@@ -1,0 +1,174 @@
+app-home .hero-preview {
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid
+    color-mix(in srgb, var(--md-sys-color-outline) 75%, transparent);
+  border-radius: 26px;
+  background: var(--md-sys-color-surface);
+  box-shadow:
+    0 2px 4px color-mix(in srgb, var(--md-sys-color-on-surface) 7%, transparent),
+    0 28px 70px
+      color-mix(in srgb, var(--md-sys-color-on-surface) 16%, transparent);
+  transform: rotate(1.5deg);
+}
+
+app-home .preview-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 46px;
+  padding: 0 14px;
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+  background: var(--md-sys-color-surface-container-low);
+}
+
+app-home .preview-toolbar > span {
+  inline-size: 8px;
+  block-size: 8px;
+  border-radius: 50%;
+  background: var(--md-sys-color-outline);
+}
+
+app-home .preview-toolbar > span:first-child {
+  background: var(--md-sys-color-primary);
+}
+
+app-home .preview-address {
+  min-width: 0;
+  margin-inline-start: 8px;
+  padding: 5px 12px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--md-sys-color-surface);
+  color: var(--md-sys-color-on-surface-variant);
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+app-home .preview-content {
+  padding: clamp(24px, 4vw, 40px);
+}
+
+app-home .preview-label {
+  color: var(--md-sys-color-primary);
+  font-size: 0.7rem;
+  font-weight: 750;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+app-home .preview-content h2 {
+  margin: 8px 0;
+  font-size: clamp(1.4rem, 3vw, 2.1rem);
+  letter-spacing: -0.035em;
+}
+
+app-home .preview-content > p {
+  margin: 0 0 28px;
+  font-size: 0.875rem;
+}
+
+app-home .preview-setting {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 17px;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: 18px;
+  background: var(--md-sys-color-surface-container-low);
+}
+
+app-home .preview-setting > span {
+  display: grid;
+  gap: 2px;
+}
+
+app-home .preview-setting strong {
+  font-size: 0.82rem;
+}
+
+app-home .preview-setting small {
+  color: var(--md-sys-color-on-surface-variant);
+  font-size: 0.7rem;
+}
+
+app-home .preview-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 22px;
+}
+
+app-home .home-footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 28px 4px 0;
+}
+
+app-home .frameworks {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 16px;
+  padding: 22px;
+}
+
+app-home .frameworks-label {
+  margin: 0;
+  color: var(--md-sys-color-on-surface-variant);
+  font-size: 0.75rem;
+  font-weight: 650;
+}
+
+app-home .framework-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+app-home .framework-badge {
+  padding: 5px 12px;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: 999px;
+  background: var(--md-sys-color-surface);
+  color: var(--md-sys-color-on-surface-variant);
+  font-size: 0.72rem;
+  font-weight: 600;
+}
+
+app-home .home-footer p {
+  margin: 0;
+  color: var(--md-sys-color-on-surface-variant);
+  font-size: 0.75rem;
+}
+
+@media (max-width: 980px) {
+  app-home .hero-preview {
+    width: min(100%, 560px);
+    transform: none;
+  }
+}
+
+@media (max-width: 640px) {
+  app-home .hero-preview {
+    border-radius: 20px;
+  }
+
+  app-home .preview-content {
+    padding: 22px 18px;
+  }
+
+  app-home .preview-setting small {
+    display: none;
+  }
+
+  app-home .home-footer {
+    flex-direction: column;
+    gap: 4px;
+  }
+}

--- a/apps/angular-app/src/pages/home/home.component.css
+++ b/apps/angular-app/src/pages/home/home.component.css
@@ -1,315 +1,351 @@
+:host {
+  display: block;
+}
+
 .hero {
-  padding: 72px 0 64px;
-  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+  position: relative;
+  isolation: isolate;
+  display: grid;
+  grid-template-columns: minmax(0, 1.08fr) minmax(360px, 0.92fr);
+  align-items: center;
+  gap: clamp(36px, 6vw, 80px);
+  min-height: min(720px, calc(100dvh - 104px));
+  padding: clamp(52px, 7vw, 88px) clamp(28px, 5vw, 64px);
+  overflow: hidden;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: clamp(28px, 4vw, 44px);
+  background:
+    radial-gradient(
+      circle at 88% 8%,
+      color-mix(in srgb, var(--md-sys-color-primary) 19%, transparent),
+      transparent 31%
+    ),
+    linear-gradient(
+      145deg,
+      var(--md-sys-color-surface),
+      color-mix(
+        in srgb,
+        var(--md-sys-color-primary-container) 48%,
+        var(--md-sys-color-surface)
+      )
+    );
+  box-shadow: 0 24px 64px
+    color-mix(in srgb, var(--md-sys-color-on-surface) 8%, transparent);
 }
+
+.hero::before {
+  content: '';
+  position: absolute;
+  z-index: -1;
+  inline-size: 260px;
+  aspect-ratio: 1;
+  inset-inline-start: -120px;
+  inset-block-end: -130px;
+  border: 44px solid
+    color-mix(in srgb, var(--md-sys-color-primary) 8%, transparent);
+  border-radius: 50%;
+}
+
+.hero-copy {
+  min-width: 0;
+}
+
 .hero-eyebrow {
-  font-size: .8125rem;
-  font-weight: 500;
-  letter-spacing: .06em;
-  text-transform: uppercase;
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  margin-bottom: 22px;
   color: var(--md-sys-color-primary);
-  margin-bottom: 16px;
+  font-size: 0.75rem;
+  font-weight: 750;
+  letter-spacing: 0.075em;
+  text-transform: uppercase;
 }
+
+.hero-status {
+  inline-size: 9px;
+  block-size: 9px;
+  border: 2px solid var(--md-sys-color-surface);
+  border-radius: 50%;
+  background: var(--md-sys-color-primary);
+  box-shadow: 0 0 0 3px
+    color-mix(in srgb, var(--md-sys-color-primary) 22%, transparent);
+}
+
 .hero h1 {
-  font-size: clamp(2rem, 5vw, 3.25rem);
-  font-weight: 700;
-  line-height: 1.1;
-  letter-spacing: -.03em;
+  max-width: 11ch;
+  margin: 0 0 24px;
   color: var(--md-sys-color-on-surface);
-  margin: 0 0 20px;
+  font-size: clamp(2.65rem, 6vw, 5.25rem);
+  font-weight: 760;
+  letter-spacing: -0.06em;
+  line-height: 0.98;
 }
+
+.hero h1 span {
+  color: var(--md-sys-color-primary);
+}
+
 .subtitle {
-  font-size: clamp(.9375rem, 1.5vw, 1.0625rem);
+  max-width: 58ch;
+  margin: 0 0 34px;
   color: var(--md-sys-color-on-surface-variant);
-  margin: 0 0 36px;
-  line-height: 1.7;
-  max-width: 52ch;
+  font-size: clamp(0.98rem, 1.5vw, 1.1rem);
+  line-height: 1.72;
 }
+
 .button-group {
   display: flex;
-  gap: 10px;
-  flex-wrap: wrap;
   align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
 }
-.features {
-  padding: 56px 0;
-  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+
+.features,
+.components,
+.install,
+.frameworks {
+  margin-top: clamp(22px, 3vw, 34px);
 }
+
 .features-list {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 32px 40px;
-}
-.feature-item {
-  display: flex;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 14px;
-  align-items: flex-start;
 }
+
+.feature-item {
+  display: grid;
+  align-content: start;
+  gap: 14px;
+  min-width: 0;
+  padding: 22px;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: 22px;
+  background: var(--md-sys-color-surface);
+  box-shadow: 0 8px 24px
+    color-mix(in srgb, var(--md-sys-color-on-surface) 4%, transparent);
+}
+
 .feature-icon {
-  font-size: 20px;
-  color: var(--md-sys-color-primary);
-  margin-top: 2px;
-  flex-shrink: 0;
+  inline-size: 40px;
+  block-size: 40px;
+  border-radius: 13px;
+  background: var(--md-sys-color-primary-container);
+  color: var(--md-sys-color-on-primary-container);
 }
+
 .feature-item h3 {
-  font-size: .9375rem;
-  font-weight: 600;
-  margin: 0 0 4px;
-  color: var(--md-sys-color-on-surface);
+  margin: 0 0 5px;
+  font-size: 0.95rem;
+  font-weight: 680;
 }
+
 .feature-item p {
-  font-size: .875rem;
   margin: 0;
-  line-height: 1.6;
-  color: var(--md-sys-color-on-surface-variant);
+  font-size: 0.82rem;
+  line-height: 1.58;
 }
-.components {
-  padding: 56px 0;
-  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+
+.components,
+.install {
+  padding: clamp(22px, 3.5vw, 36px);
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: 28px;
+  background: var(--md-sys-color-surface);
+  box-shadow: 0 12px 34px
+    color-mix(in srgb, var(--md-sys-color-on-surface) 4%, transparent);
 }
+
 .section-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 16px;
   margin-bottom: 20px;
 }
-.section-header h2 {
-  font-size: .75rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: .07em;
-  color: var(--md-sys-color-on-surface-variant);
+
+.section-header h2,
+.install h2 {
   margin: 0;
+  font-size: clamp(1.15rem, 2vw, 1.45rem);
+  letter-spacing: -0.025em;
 }
+
 .component-table {
-  border: 1px solid var(--md-sys-color-outline-variant);
-  border-radius: 12px;
-  overflow: hidden;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
 }
+
 .component-row {
   display: grid;
-  grid-template-columns: minmax(0, 10rem) 1fr auto auto;
+  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-rows: auto auto;
   align-items: center;
-  gap: 12px 16px;
-  padding: 13px 20px;
-  border-bottom: 1px solid var(--md-sys-color-outline-variant);
-  transition: background var(--md-sys-motion-duration-short3);
-  cursor: pointer;
-}
-.component-table > :last-child .component-row {
-  border-bottom: none;
-}
-.component-row:not(.muted):hover {
+  gap: 2px 12px;
+  min-height: 76px;
+  padding: 14px 16px;
+  border: 1px solid transparent;
+  border-radius: 16px;
   background: var(--md-sys-color-surface-container-low);
+  cursor: pointer;
+  transition:
+    background var(--md-sys-motion-duration-short3),
+    border-color var(--md-sys-motion-duration-short3),
+    transform var(--md-sys-motion-duration-short3);
 }
-.component-row:not(.muted):hover .component-arrow {
-  color: var(--md-sys-color-primary);
-  transform: translateX(2px);
+
+.component-row:hover {
+  border-color: color-mix(
+    in srgb,
+    var(--md-sys-color-primary) 28%,
+    transparent
+  );
+  background: color-mix(
+    in srgb,
+    var(--md-sys-color-primary-container) 36%,
+    var(--md-sys-color-surface)
+  );
+  transform: translateY(-1px);
 }
-.component-row.muted {
-  opacity: .5;
-  cursor: default;
-  border-bottom: none;
-}
+
 .component-name {
-  font-size: .8125rem;
-  font-weight: 600;
-  font-family: var(--font-mono);
-  color: var(--md-sys-color-on-surface);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.component-desc {
-  font-size: .875rem;
-  color: var(--md-sys-color-on-surface-variant);
   min-width: 0;
+  overflow: hidden;
+  color: var(--md-sys-color-on-surface);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
+
+.component-desc {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--md-sys-color-on-surface-variant);
+  font-size: 0.76rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .component-badge {
-  font-size: .6875rem;
-  font-weight: 500;
-  padding: 2px 8px;
-  border-radius: 5px;
+  grid-column: 2;
+  grid-row: 1;
+  padding: 3px 8px;
+  border-radius: 999px;
   background: var(--md-sys-color-primary-container);
   color: var(--md-sys-color-on-primary-container);
-  white-space: nowrap;
+  font-size: 0.64rem;
+  font-weight: 650;
 }
-.component-badge.soon {
-  background: var(--md-sys-color-surface-container);
-  color: var(--md-sys-color-on-surface-variant);
-}
+
 .component-arrow {
-  font-size: 16px;
-  color: var(--md-sys-color-outline);
-  transition: color var(--md-sys-motion-duration-short3), transform var(--md-sys-motion-duration-short3);
-  flex-shrink: 0;
+  grid-column: 2;
+  grid-row: 2;
+  justify-self: end;
+  color: var(--md-sys-color-primary);
+  font-size: 17px;
 }
+
 .install {
-  padding: 56px 0;
-  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+  display: grid;
+  grid-template-columns: minmax(160px, 0.4fr) minmax(0, 1fr);
+  gap: 24px 40px;
+  align-items: start;
 }
+
 .install h2 {
-  font-size: .75rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: .07em;
-  color: var(--md-sys-color-on-surface-variant);
-  margin: 0 0 20px;
+  grid-row: 1 / span 2;
 }
+
 .install-options {
-  display: flex;
-  flex-direction: column;
+  display: grid;
   gap: 10px;
-  margin-bottom: 24px;
-  max-width: 480px;
 }
+
 .install-option {
-  display: flex;
+  display: grid;
+  grid-template-columns: 54px minmax(0, 1fr);
   align-items: center;
   gap: 12px;
-  padding: 12px 16px;
-  background: var(--md-sys-color-surface-container-low);
+  min-width: 0;
+  padding: 13px 15px;
   border: 1px solid var(--md-sys-color-outline-variant);
-  border-radius: 8px;
+  border-radius: 14px;
+  background: var(--md-sys-color-surface-container-low);
 }
+
 .install-label {
-  font-size: .75rem;
-  font-weight: 600;
+  color: var(--md-sys-color-primary);
+  font-size: 0.68rem;
+  font-weight: 750;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
-  letter-spacing: .05em;
-  color: var(--md-sys-color-on-surface-variant);
-  width: 36px;
-  flex-shrink: 0;
 }
+
 .install-option code {
-  font-size: .8125rem;
-  background: 0;
+  min-width: 0;
+  overflow: hidden;
   border: 0;
-  padding: 0;
-  color: var(--md-sys-color-on-surface);
-}
-.frameworks {
-  padding: 40px 0;
-  border-bottom: 1px solid var(--md-sys-color-outline-variant);
-  display: flex;
-  align-items: center;
-  gap: 20px;
-  flex-wrap: wrap;
-}
-.frameworks-label {
-  font-size: .8125rem;
-  font-weight: 500;
-  color: var(--md-sys-color-on-surface-variant);
-  margin: 0;
+  background: transparent;
+  font-size: 0.76rem;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
-.framework-badges {
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-}
-.framework-badge {
-  padding: 4px 12px;
-  border-radius: 6px;
-  background: var(--md-sys-color-surface-container);
-  color: var(--md-sys-color-on-surface-variant);
-  font-size: .8125rem;
-  font-weight: 500;
-  border: 1px solid var(--md-sys-color-outline-variant);
-}
-.home-footer {
-  padding: 40px 0 24px;
-  color: var(--md-sys-color-on-surface-variant);
-}
-.home-footer p {
-  margin: 4px 0;
-  font-size: .875rem;
-}
-.license {
-  font-size: .8125rem;
-  opacity: .6;
-}
-@media (max-width: 600px) {
+
+@media (max-width: 980px) {
   .hero {
-    padding: 28px 0 32px;
+    grid-template-columns: 1fr;
+    min-height: auto;
   }
-  .hero-eyebrow {
-    margin-bottom: 10px;
-  }
+
   .hero h1 {
-    font-size: 1.75rem;
-    margin-bottom: 12px;
+    max-width: 13ch;
   }
-  .subtitle {
-    font-size: .9375rem;
-    margin-bottom: 24px;
-  }
-  .button-group {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-  .features {
-    padding: 28px 0;
-  }
+
   .features-list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .hero {
+    gap: 32px;
+    padding: 32px 20px;
+    border-radius: 26px;
+  }
+
+  .hero h1 {
+    font-size: clamp(2.35rem, 12vw, 3.2rem);
+  }
+
+  .button-group {
+    align-items: stretch;
+  }
+
+  .features-list,
+  .component-table {
+    grid-template-columns: 1fr;
+  }
+
+  .feature-item {
+    grid-template-columns: 40px 1fr;
+  }
+
+  .components,
+  .install {
+    padding: 20px 16px;
+    border-radius: 22px;
+  }
+
+  .install {
     grid-template-columns: 1fr;
     gap: 16px;
   }
-  .components {
-    padding: 28px 0;
-  }
-  .section-header {
-    margin-bottom: 12px;
-  }
-  .component-row {
-    grid-template-columns: 1fr auto;
-    grid-template-rows: auto auto;
-    gap: 2px 8px;
-    padding: 10px 14px;
-  }
-  .component-name {
-    grid-column: 1;
-    grid-row: 1;
-  }
-  .component-arrow {
-    grid-column: 2;
-    grid-row: 1 / 3;
-    align-self: center;
-  }
-  .component-desc {
-    grid-column: 1;
-    grid-row: 2;
-    font-size: .8125rem;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-  .component-badge {
-    display: none;
-  }
-  .install {
-    padding: 28px 0;
-  }
+
   .install h2 {
-    margin-bottom: 14px;
-  }
-  .install-options {
-    margin-bottom: 16px;
-  }
-  .install-option {
-    padding: 10px 12px;
-  }
-  .install-option code {
-    font-size: .75rem;
-    word-break: break-all;
-  }
-  .frameworks {
-    padding: 24px 0;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 10px;
-  }
-  .home-footer {
-    padding: 24px 0 16px;
+    grid-row: auto;
   }
 }

--- a/apps/angular-app/src/pages/home/home.component.html
+++ b/apps/angular-app/src/pages/home/home.component.html
@@ -1,21 +1,50 @@
 <header class="hero">
-  <div class="hero-eyebrow">Material 3 Web Components</div>
-  <h1>Build expressive,<br>beautiful UIs<br>any framework.</h1>
-  <p class="subtitle">
-    Framework-agnostic web components following the Material 3 spec with expressive design support.
-    Drop them into Angular, React, Vue, Svelte, or plain HTML.
-  </p>
-  <div class="button-group">
-    <app-seo-link href="quick-start">
-      <m3-button variant="filled" size="large">Get started</m3-button>
-    </app-seo-link>
-    <app-seo-link href="components">
-      <m3-button variant="outlined" size="large">Browse components</m3-button>
-    </app-seo-link>
-    <m3-button variant="text" size="large" (click)="openGitHub()">
-      <span slot="icon" class="material-symbols-outlined">code</span>
-      GitHub
-    </m3-button>
+  <div class="hero-copy">
+    <div class="hero-eyebrow">
+      <span class="hero-status" aria-hidden="true"></span>
+      Material 3 Web Components
+    </div>
+    <h1>Build expressive UIs. <span>Use any framework.</span></h1>
+    <p class="subtitle">
+      A production-ready component library built on web standards and the
+      Material 3 Expressive design system. Use it with Angular, React, Vue,
+      Svelte, or plain HTML.
+    </p>
+    <div class="button-group">
+      <app-seo-link href="quick-start">
+        <m3-button variant="filled" size="large">Get started</m3-button>
+      </app-seo-link>
+      <app-seo-link href="components">
+        <m3-button variant="outlined" size="large">Browse components</m3-button>
+      </app-seo-link>
+      <m3-button variant="text" size="large" (click)="openGitHub()">
+        <span slot="icon" class="material-symbols-outlined">code</span>
+        GitHub
+      </m3-button>
+    </div>
+  </div>
+
+  <div class="hero-preview" aria-label="Material component preview">
+    <div class="preview-toolbar" aria-hidden="true">
+      <span></span><span></span><span></span>
+      <div class="preview-address">ui.banegasn.dev</div>
+    </div>
+    <div class="preview-content">
+      <span class="preview-label">Workspace settings</span>
+      <h2>Make it yours</h2>
+      <p>Configure your experience with accessible, expressive controls.</p>
+      <div class="preview-setting">
+        <span>
+          <strong>Smart suggestions</strong>
+          <small>Recommended actions as you work</small>
+        </span>
+        <m3-switch checked aria-label="Smart suggestions"></m3-switch>
+      </div>
+      <div class="preview-actions">
+        <m3-button variant="text">Later</m3-button>
+        <m3-button variant="filled">Continue</m3-button>
+      </div>
+    </div>
   </div>
 </header>
 
@@ -32,7 +61,10 @@
       <span class="feature-icon material-symbols-outlined">palette</span>
       <div>
         <h3>Material Design 3 Expressive</h3>
-        <p>Implements the latest Material 3 expressive update, themeable via CSS custom properties.</p>
+        <p>
+          Implements the latest Material 3 expressive update, themeable via CSS
+          custom properties.
+        </p>
       </div>
     </div>
     <div class="feature-item">
@@ -67,153 +99,229 @@
     <app-seo-link href="buttons">
       <div class="component-row">
         <span class="component-name">m3-button</span>
-        <span class="component-desc">5 variants · sizes · icon support · loading state</span>
+        <span class="component-desc"
+          >5 variants · sizes · icon support · loading state</span
+        >
         <span class="component-badge">v1.x</span>
-        <span class="component-arrow material-symbols-outlined">arrow_forward</span>
+        <span class="component-arrow material-symbols-outlined"
+          >arrow_forward</span
+        >
       </div>
     </app-seo-link>
     <app-seo-link href="cards">
       <div class="component-row">
         <span class="component-name">m3-card</span>
-        <span class="component-desc">Elevated, filled, outlined · media &amp; action slots</span>
+        <span class="component-desc"
+          >Elevated, filled, outlined · media &amp; action slots</span
+        >
         <span class="component-badge">v1.x</span>
-        <span class="component-arrow material-symbols-outlined">arrow_forward</span>
+        <span class="component-arrow material-symbols-outlined"
+          >arrow_forward</span
+        >
       </div>
     </app-seo-link>
     <app-seo-link href="navigation-rail">
       <div class="component-row">
         <span class="component-name">m3-navigation-rail</span>
-        <span class="component-desc">Collapsible vertical nav · badge support</span>
+        <span class="component-desc"
+          >Collapsible vertical nav · badge support</span
+        >
         <span class="component-badge">v1.x</span>
-        <span class="component-arrow material-symbols-outlined">arrow_forward</span>
+        <span class="component-arrow material-symbols-outlined"
+          >arrow_forward</span
+        >
       </div>
     </app-seo-link>
     <app-seo-link href="navigation-bar">
       <div class="component-row">
         <span class="component-name">m3-navigation-bar</span>
-        <span class="component-desc">Responsive bottom nav · auto-layout switching</span>
+        <span class="component-desc"
+          >Responsive bottom nav · auto-layout switching</span
+        >
         <span class="component-badge">v1.x</span>
-        <span class="component-arrow material-symbols-outlined">arrow_forward</span>
+        <span class="component-arrow material-symbols-outlined"
+          >arrow_forward</span
+        >
       </div>
     </app-seo-link>
     <app-seo-link href="switches">
       <div class="component-row">
         <span class="component-name">m3-switch</span>
-        <span class="component-desc">Toggle · checked, unchecked &amp; disabled states</span>
+        <span class="component-desc"
+          >Toggle · checked, unchecked &amp; disabled states</span
+        >
         <span class="component-badge">v1.x</span>
-        <span class="component-arrow material-symbols-outlined">arrow_forward</span>
+        <span class="component-arrow material-symbols-outlined"
+          >arrow_forward</span
+        >
       </div>
     </app-seo-link>
     <app-seo-link href="radio-buttons">
       <div class="component-row">
         <span class="component-name">m3-radio-button</span>
-        <span class="component-desc">Radio group management · accessibility support</span>
+        <span class="component-desc"
+          >Radio group management · accessibility support</span
+        >
         <span class="component-badge">v1.x</span>
-        <span class="component-arrow material-symbols-outlined">arrow_forward</span>
+        <span class="component-arrow material-symbols-outlined"
+          >arrow_forward</span
+        >
       </div>
     </app-seo-link>
     <app-seo-link href="checkboxes">
       <div class="component-row">
         <span class="component-name">m3-checkbox</span>
-        <span class="component-desc">Checked, unchecked &amp; indeterminate states</span>
+        <span class="component-desc"
+          >Checked, unchecked &amp; indeterminate states</span
+        >
         <span class="component-badge">v1.x</span>
-        <span class="component-arrow material-symbols-outlined">arrow_forward</span>
+        <span class="component-arrow material-symbols-outlined"
+          >arrow_forward</span
+        >
       </div>
     </app-seo-link>
     <app-seo-link href="chips">
       <div class="component-row">
         <span class="component-name">m3-chip</span>
-        <span class="component-desc">Filter, input, suggestion &amp; assist variants</span>
+        <span class="component-desc"
+          >Filter, input, suggestion &amp; assist variants</span
+        >
         <span class="component-badge">v1.x</span>
-        <span class="component-arrow material-symbols-outlined">arrow_forward</span>
+        <span class="component-arrow material-symbols-outlined"
+          >arrow_forward</span
+        >
       </div>
     </app-seo-link>
     <app-seo-link href="text-fields">
       <div class="component-row">
         <span class="component-name">m3-text-field</span>
-        <span class="component-desc">Filled &amp; outlined · validation · icon slots</span>
+        <span class="component-desc"
+          >Filled &amp; outlined · validation · icon slots</span
+        >
         <span class="component-badge">v1.x</span>
-        <span class="component-arrow material-symbols-outlined">arrow_forward</span>
+        <span class="component-arrow material-symbols-outlined"
+          >arrow_forward</span
+        >
       </div>
     </app-seo-link>
     <app-seo-link href="sliders">
       <div class="component-row">
         <span class="component-name">m3-slider</span>
-        <span class="component-desc">Continuous &amp; discrete · range support</span>
+        <span class="component-desc"
+          >Continuous &amp; discrete · range support</span
+        >
         <span class="component-badge">v1.x</span>
-        <span class="component-arrow material-symbols-outlined">arrow_forward</span>
+        <span class="component-arrow material-symbols-outlined"
+          >arrow_forward</span
+        >
       </div>
     </app-seo-link>
     <app-seo-link href="tabs">
       <div class="component-row">
         <span class="component-name">m3-tabs</span>
-        <span class="component-desc">Primary &amp; secondary tabs · icon support</span>
+        <span class="component-desc"
+          >Primary &amp; secondary tabs · icon support</span
+        >
         <span class="component-badge">v1.x</span>
-        <span class="component-arrow material-symbols-outlined">arrow_forward</span>
+        <span class="component-arrow material-symbols-outlined"
+          >arrow_forward</span
+        >
       </div>
     </app-seo-link>
     <app-seo-link href="dialog">
       <div class="component-row">
         <span class="component-name">m3-dialog</span>
-        <span class="component-desc">Modal dialogs · backdrop · action slots</span>
+        <span class="component-desc"
+          >Modal dialogs · backdrop · action slots</span
+        >
         <span class="component-badge">v1.x</span>
-        <span class="component-arrow material-symbols-outlined">arrow_forward</span>
+        <span class="component-arrow material-symbols-outlined"
+          >arrow_forward</span
+        >
       </div>
     </app-seo-link>
     <app-seo-link href="search-bar">
       <div class="component-row">
         <span class="component-name">m3-search-bar</span>
-        <span class="component-desc">Leading &amp; trailing slots · keyboard navigation</span>
+        <span class="component-desc"
+          >Leading &amp; trailing slots · keyboard navigation</span
+        >
         <span class="component-badge">v1.x</span>
-        <span class="component-arrow material-symbols-outlined">arrow_forward</span>
+        <span class="component-arrow material-symbols-outlined"
+          >arrow_forward</span
+        >
       </div>
     </app-seo-link>
     <app-seo-link href="badge">
       <div class="component-row">
         <span class="component-name">m3-badge</span>
-        <span class="component-desc">Notification badges · dot &amp; count variants</span>
+        <span class="component-desc"
+          >Notification badges · dot &amp; count variants</span
+        >
         <span class="component-badge">v1.x</span>
-        <span class="component-arrow material-symbols-outlined">arrow_forward</span>
+        <span class="component-arrow material-symbols-outlined"
+          >arrow_forward</span
+        >
       </div>
     </app-seo-link>
     <app-seo-link href="tooltip">
       <div class="component-row">
         <span class="component-name">m3-tooltip</span>
-        <span class="component-desc">Plain &amp; rich tooltips · placement control</span>
+        <span class="component-desc"
+          >Plain &amp; rich tooltips · placement control</span
+        >
         <span class="component-badge">v1.x</span>
-        <span class="component-arrow material-symbols-outlined">arrow_forward</span>
+        <span class="component-arrow material-symbols-outlined"
+          >arrow_forward</span
+        >
       </div>
     </app-seo-link>
     <app-seo-link href="progress">
       <div class="component-row">
         <span class="component-name">m3-progress</span>
-        <span class="component-desc">Linear &amp; circular · determinate &amp; indeterminate</span>
+        <span class="component-desc"
+          >Linear &amp; circular · determinate &amp; indeterminate</span
+        >
         <span class="component-badge">v1.x</span>
-        <span class="component-arrow material-symbols-outlined">arrow_forward</span>
+        <span class="component-arrow material-symbols-outlined"
+          >arrow_forward</span
+        >
       </div>
     </app-seo-link>
     <app-seo-link href="menu">
       <div class="component-row">
         <span class="component-name">m3-menu</span>
-        <span class="component-desc">Contextual menus · keyboard navigation · accessible</span>
+        <span class="component-desc"
+          >Contextual menus · keyboard navigation · accessible</span
+        >
         <span class="component-badge">v0.1</span>
-        <span class="component-arrow material-symbols-outlined">arrow_forward</span>
+        <span class="component-arrow material-symbols-outlined"
+          >arrow_forward</span
+        >
       </div>
     </app-seo-link>
     <app-seo-link href="split-button">
       <div class="component-row">
         <span class="component-name">m3-split-button</span>
-        <span class="component-desc">Main action + dropdown menu in one control</span>
+        <span class="component-desc"
+          >Main action + dropdown menu in one control</span
+        >
         <span class="component-badge">v0.1</span>
-        <span class="component-arrow material-symbols-outlined">arrow_forward</span>
+        <span class="component-arrow material-symbols-outlined"
+          >arrow_forward</span
+        >
       </div>
     </app-seo-link>
     <app-seo-link href="fab-menu">
       <div class="component-row">
         <span class="component-name">m3-fab-menu</span>
-        <span class="component-desc">Floating action button with animated menu</span>
+        <span class="component-desc"
+          >Floating action button with animated menu</span
+        >
         <span class="component-badge">v0.1</span>
-        <span class="component-arrow material-symbols-outlined">arrow_forward</span>
+        <span class="component-arrow material-symbols-outlined"
+          >arrow_forward</span
+        >
       </div>
     </app-seo-link>
     <app-seo-link href="loading-indicator">
@@ -221,47 +329,69 @@
         <span class="component-name">m3-loading-indicator</span>
         <span class="component-desc">Shape-morphing loading animation</span>
         <span class="component-badge">v0.1</span>
-        <span class="component-arrow material-symbols-outlined">arrow_forward</span>
+        <span class="component-arrow material-symbols-outlined"
+          >arrow_forward</span
+        >
       </div>
     </app-seo-link>
     <app-seo-link href="divider">
       <div class="component-row">
         <span class="component-name">m3-divider</span>
-        <span class="component-desc">Full-width, inset, middle · vertical · pulsing animation</span>
+        <span class="component-desc"
+          >Full-width, inset, middle · vertical · pulsing animation</span
+        >
         <span class="component-badge">v1.0</span>
-        <span class="component-arrow material-symbols-outlined">arrow_forward</span>
+        <span class="component-arrow material-symbols-outlined"
+          >arrow_forward</span
+        >
       </div>
     </app-seo-link>
     <app-seo-link href="list">
       <div class="component-row">
         <span class="component-name">m3-list</span>
-        <span class="component-desc">One, two, three lines · leading/trailing · staggered animation</span>
+        <span class="component-desc"
+          >One, two, three lines · leading/trailing · staggered animation</span
+        >
         <span class="component-badge">v1.0</span>
-        <span class="component-arrow material-symbols-outlined">arrow_forward</span>
+        <span class="component-arrow material-symbols-outlined"
+          >arrow_forward</span
+        >
       </div>
     </app-seo-link>
     <app-seo-link href="icon-button">
       <div class="component-row">
         <span class="component-name">m3-icon-button</span>
-        <span class="component-desc">Standard, filled, tonal, outlined · toggle · sizes</span>
+        <span class="component-desc"
+          >Standard, filled, tonal, outlined · toggle · sizes</span
+        >
         <span class="component-badge">v1.0</span>
-        <span class="component-arrow material-symbols-outlined">arrow_forward</span>
+        <span class="component-arrow material-symbols-outlined"
+          >arrow_forward</span
+        >
       </div>
     </app-seo-link>
     <app-seo-link href="top-app-bar">
       <div class="component-row">
         <span class="component-name">m3-top-app-bar</span>
-        <span class="component-desc">Small, center-aligned, medium, large · scroll behaviors</span>
+        <span class="component-desc"
+          >Small, center-aligned, medium, large · scroll behaviors</span
+        >
         <span class="component-badge">v1.0</span>
-        <span class="component-arrow material-symbols-outlined">arrow_forward</span>
+        <span class="component-arrow material-symbols-outlined"
+          >arrow_forward</span
+        >
       </div>
     </app-seo-link>
     <app-seo-link href="snackbar">
       <div class="component-row">
         <span class="component-name">m3-snackbar</span>
-        <span class="component-desc">Auto-dismiss · action slot · entrance/exit animations</span>
+        <span class="component-desc"
+          >Auto-dismiss · action slot · entrance/exit animations</span
+        >
         <span class="component-badge">v1.0</span>
-        <span class="component-arrow material-symbols-outlined">arrow_forward</span>
+        <span class="component-arrow material-symbols-outlined"
+          >arrow_forward</span
+        >
       </div>
     </app-seo-link>
   </div>

--- a/apps/angular-app/src/pages/icon-button/icon-button.component.html
+++ b/apps/angular-app/src/pages/icon-button/icon-button.component.html
@@ -1,18 +1,27 @@
 <div class="page-container docs-page">
-  <header class="page-header">
-    <h1>Icon Button</h1>
-    <p class="subtitle">Icon buttons trigger an action with expressive press animations and multiple variants.</p>
-  </header>
-
   <section class="demo-section">
     <h2>Standard</h2>
     <div class="interactive-demo">
       <div class="demo-row icon-button-demo">
-        <m3-icon-button aria-label="Settings"><span class="material-symbols-outlined">settings</span></m3-icon-button>
-        <m3-icon-button aria-label="Search"><span class="material-symbols-outlined">search</span></m3-icon-button>
-        <m3-icon-button aria-label="More"><span class="material-symbols-outlined">more_vert</span></m3-icon-button>
+        <m3-icon-button aria-label="Settings"
+          ><span class="material-symbols-outlined"
+            >settings</span
+          ></m3-icon-button
+        >
+        <m3-icon-button aria-label="Search"
+          ><span class="material-symbols-outlined">search</span></m3-icon-button
+        >
+        <m3-icon-button aria-label="More"
+          ><span class="material-symbols-outlined"
+            >more_vert</span
+          ></m3-icon-button
+        >
       </div>
-      <app-code-block [code]="standardExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="standardExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 
@@ -20,11 +29,21 @@
     <h2>Filled</h2>
     <div class="interactive-demo">
       <div class="demo-row icon-button-demo">
-        <m3-icon-button variant="filled" aria-label="Add"><span class="material-symbols-outlined">add</span></m3-icon-button>
-        <m3-icon-button variant="filled" aria-label="Edit"><span class="material-symbols-outlined">edit</span></m3-icon-button>
-        <m3-icon-button variant="filled" aria-label="Delete"><span class="material-symbols-outlined">delete</span></m3-icon-button>
+        <m3-icon-button variant="filled" aria-label="Add"
+          ><span class="material-symbols-outlined">add</span></m3-icon-button
+        >
+        <m3-icon-button variant="filled" aria-label="Edit"
+          ><span class="material-symbols-outlined">edit</span></m3-icon-button
+        >
+        <m3-icon-button variant="filled" aria-label="Delete"
+          ><span class="material-symbols-outlined">delete</span></m3-icon-button
+        >
       </div>
-      <app-code-block [code]="filledExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="filledExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 
@@ -32,11 +51,25 @@
     <h2>Tonal</h2>
     <div class="interactive-demo">
       <div class="demo-row icon-button-demo">
-        <m3-icon-button variant="tonal" aria-label="Favorite"><span class="material-symbols-outlined">favorite</span></m3-icon-button>
-        <m3-icon-button variant="tonal" aria-label="Share"><span class="material-symbols-outlined">share</span></m3-icon-button>
-        <m3-icon-button variant="tonal" aria-label="Bookmark"><span class="material-symbols-outlined">bookmark</span></m3-icon-button>
+        <m3-icon-button variant="tonal" aria-label="Favorite"
+          ><span class="material-symbols-outlined"
+            >favorite</span
+          ></m3-icon-button
+        >
+        <m3-icon-button variant="tonal" aria-label="Share"
+          ><span class="material-symbols-outlined">share</span></m3-icon-button
+        >
+        <m3-icon-button variant="tonal" aria-label="Bookmark"
+          ><span class="material-symbols-outlined"
+            >bookmark</span
+          ></m3-icon-button
+        >
       </div>
-      <app-code-block [code]="tonalExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="tonalExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 
@@ -44,11 +77,23 @@
     <h2>Outlined</h2>
     <div class="interactive-demo">
       <div class="demo-row icon-button-demo">
-        <m3-icon-button variant="outlined" aria-label="Menu"><span class="material-symbols-outlined">menu</span></m3-icon-button>
-        <m3-icon-button variant="outlined" aria-label="Filter"><span class="material-symbols-outlined">filter_list</span></m3-icon-button>
-        <m3-icon-button variant="outlined" aria-label="Sort"><span class="material-symbols-outlined">sort</span></m3-icon-button>
+        <m3-icon-button variant="outlined" aria-label="Menu"
+          ><span class="material-symbols-outlined">menu</span></m3-icon-button
+        >
+        <m3-icon-button variant="outlined" aria-label="Filter"
+          ><span class="material-symbols-outlined"
+            >filter_list</span
+          ></m3-icon-button
+        >
+        <m3-icon-button variant="outlined" aria-label="Sort"
+          ><span class="material-symbols-outlined">sort</span></m3-icon-button
+        >
       </div>
-      <app-code-block [code]="outlinedExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="outlinedExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 
@@ -56,11 +101,27 @@
     <h2>Toggle</h2>
     <div class="interactive-demo">
       <div class="demo-row icon-button-demo">
-        <m3-icon-button toggle aria-label="Bookmark"><span class="material-symbols-outlined">bookmark</span></m3-icon-button>
-        <m3-icon-button toggle aria-label="Favorite"><span class="material-symbols-outlined">favorite</span></m3-icon-button>
-        <m3-icon-button toggle aria-label="Notifications"><span class="material-symbols-outlined">notifications</span></m3-icon-button>
+        <m3-icon-button toggle aria-label="Bookmark"
+          ><span class="material-symbols-outlined"
+            >bookmark</span
+          ></m3-icon-button
+        >
+        <m3-icon-button toggle aria-label="Favorite"
+          ><span class="material-symbols-outlined"
+            >favorite</span
+          ></m3-icon-button
+        >
+        <m3-icon-button toggle aria-label="Notifications"
+          ><span class="material-symbols-outlined"
+            >notifications</span
+          ></m3-icon-button
+        >
       </div>
-      <app-code-block [code]="toggleExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="toggleExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 
@@ -68,11 +129,21 @@
     <h2>Sizes</h2>
     <div class="interactive-demo">
       <div class="demo-row icon-button-demo">
-        <m3-icon-button size="small" aria-label="Close"><span class="material-symbols-outlined">close</span></m3-icon-button>
-        <m3-icon-button aria-label="Close"><span class="material-symbols-outlined">close</span></m3-icon-button>
-        <m3-icon-button size="large" aria-label="Close"><span class="material-symbols-outlined">close</span></m3-icon-button>
+        <m3-icon-button size="small" aria-label="Close"
+          ><span class="material-symbols-outlined">close</span></m3-icon-button
+        >
+        <m3-icon-button aria-label="Close"
+          ><span class="material-symbols-outlined">close</span></m3-icon-button
+        >
+        <m3-icon-button size="large" aria-label="Close"
+          ><span class="material-symbols-outlined">close</span></m3-icon-button
+        >
       </div>
-      <app-code-block [code]="sizesExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="sizesExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 </div>

--- a/apps/angular-app/src/pages/list/list.component.html
+++ b/apps/angular-app/src/pages/list/list.component.html
@@ -1,9 +1,4 @@
 <div class="page-container docs-page">
-  <header class="page-header">
-    <h1>List</h1>
-    <p class="subtitle">Lists display a continuous group of text or images with expressive entrance animations.</p>
-  </header>
-
   <section class="demo-section">
     <h2>Simple List</h2>
     <div class="interactive-demo">
@@ -14,7 +9,11 @@
           <m3-list-item>Item Three</m3-list-item>
         </m3-list>
       </div>
-      <app-code-block [code]="simpleExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="simpleExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 
@@ -29,7 +28,11 @@
           <m3-list-item>Animated 4</m3-list-item>
         </m3-list>
       </div>
-      <app-code-block [code]="staggeredExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="staggeredExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 
@@ -55,7 +58,11 @@
           </m3-list-item>
         </m3-list>
       </div>
-      <app-code-block [code]="twoLineExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="twoLineExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 
@@ -69,7 +76,11 @@
           <m3-list-item>Normal Item</m3-list-item>
         </m3-list>
       </div>
-      <app-code-block [code]="selectedExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="selectedExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 
@@ -83,7 +94,11 @@
           <m3-list-item shape="rounded">Rounded Item 3</m3-list-item>
         </m3-list>
       </div>
-      <app-code-block [code]="roundedExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="roundedExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 </div>

--- a/apps/angular-app/src/pages/loading-indicator/loading-indicator.component.html
+++ b/apps/angular-app/src/pages/loading-indicator/loading-indicator.component.html
@@ -1,62 +1,88 @@
 <div class="page-container docs-page">
-    <header class="page-header">
-        <h1>Loading Indicator</h1>
-        <p class="subtitle">
-            Expressive loading indicators that morph shapes to indicate activity.
-        </p>
-    </header>
+  <section class="demo-section">
+    <h2>Variants</h2>
+    <p>
+      Loading indicators can be circular or square, and can morph between
+      shapes.
+    </p>
 
-    <section class="demo-section">
-        <h2>Variants</h2>
-        <p>Loading indicators can be circular or square, and can morph between shapes.</p>
-
-        <div class="variant-card">
-            <div class="variant-header">
-                <h3>Standard Indicators</h3>
-            </div>
-            <div class="demo-row" style="gap: 48px; align-items: center; justify-content: center; padding: 24px;">
-                <div style="text-align: center;">
-                    <m3-loading-indicator></m3-loading-indicator>
-                    <p style="margin-top: 8px; font-size: 0.875rem;">Round (Default)</p>
-                </div>
-                <div style="text-align: center;">
-                    <m3-loading-indicator shape="square"></m3-loading-indicator>
-                    <p style="margin-top: 8px; font-size: 0.875rem;">Square</p>
-                </div>
-            </div>
-            <app-code-block language="html" variant="sample" [code]="defaultExample"></app-code-block>
+    <div class="variant-card">
+      <div class="variant-header">
+        <h3>Standard Indicators</h3>
+      </div>
+      <div
+        class="demo-row"
+        style="
+          gap: 48px;
+          align-items: center;
+          justify-content: center;
+          padding: 24px;
+        "
+      >
+        <div style="text-align: center">
+          <m3-loading-indicator></m3-loading-indicator>
+          <p style="margin-top: 8px; font-size: 0.875rem">Round (Default)</p>
         </div>
-    </section>
-
-    <section class="demo-section">
-        <h2>Contained Usage</h2>
-        <p>Use the <code>contained</code> variant when placing the indicator inside a button or chip.</p>
-
-        <div class="variant-card">
-            <div class="variant-header">
-                <h3>Inside Buttons</h3>
-            </div>
-            <div class="demo-row" style="gap: 24px;">
-                <m3-button>
-                    <m3-loading-indicator variant="contained" slot="icon"></m3-loading-indicator>
-                    Saving...
-                </m3-button>
-
-                <m3-button variant="tonal">
-                    <m3-loading-indicator variant="contained" slot="icon"></m3-loading-indicator>
-                    Processing
-                </m3-button>
-            </div>
-            <app-code-block language="html" variant="sample" [code]="containedExample"></app-code-block>
+        <div style="text-align: center">
+          <m3-loading-indicator shape="square"></m3-loading-indicator>
+          <p style="margin-top: 8px; font-size: 0.875rem">Square</p>
         </div>
-    </section>
+      </div>
+      <app-code-block
+        language="html"
+        variant="sample"
+        [code]="defaultExample"
+      ></app-code-block>
+    </div>
+  </section>
 
-    <section class="demo-section accessibility">
-        <h2>♿ Accessibility</h2>
-        <ul class="feature-list">
-            <li><strong>ARIA:</strong> Automatically includes <code>role="progressbar"</code>.</li>
-            <li><strong>Reduced Motion:</strong> Respects user's reduced motion preferences by simplifying animations.
-            </li>
-        </ul>
-    </section>
+  <section class="demo-section">
+    <h2>Contained Usage</h2>
+    <p>
+      Use the <code>contained</code> variant when placing the indicator inside a
+      button or chip.
+    </p>
+
+    <div class="variant-card">
+      <div class="variant-header">
+        <h3>Inside Buttons</h3>
+      </div>
+      <div class="demo-row" style="gap: 24px">
+        <m3-button>
+          <m3-loading-indicator
+            variant="contained"
+            slot="icon"
+          ></m3-loading-indicator>
+          Saving...
+        </m3-button>
+
+        <m3-button variant="tonal">
+          <m3-loading-indicator
+            variant="contained"
+            slot="icon"
+          ></m3-loading-indicator>
+          Processing
+        </m3-button>
+      </div>
+      <app-code-block
+        language="html"
+        variant="sample"
+        [code]="containedExample"
+      ></app-code-block>
+    </div>
+  </section>
+
+  <section class="demo-section accessibility">
+    <h2>♿ Accessibility</h2>
+    <ul class="feature-list">
+      <li>
+        <strong>ARIA:</strong> Automatically includes
+        <code>role="progressbar"</code>.
+      </li>
+      <li>
+        <strong>Reduced Motion:</strong> Respects user's reduced motion
+        preferences by simplifying animations.
+      </li>
+    </ul>
+  </section>
 </div>

--- a/apps/angular-app/src/pages/menu/menu.component.html
+++ b/apps/angular-app/src/pages/menu/menu.component.html
@@ -1,111 +1,147 @@
 <div class="page-container docs-page">
-    <header class="page-header">
-        <h1>Menu</h1>
-        <p class="subtitle">
-            Menus display a list of choices on a temporary elevated surface anchored to a trigger.
+  <section class="demo-section">
+    <h2>Standalone Menu</h2>
+    <p>
+      Use menus for contextual actions, overflow options, and lightweight
+      selections.
+    </p>
+
+    <div class="variant-card">
+      <div class="variant-header">
+        <h3>Anchored Example</h3>
+        <span class="emphasis-badge medium">M3 menu surface</span>
+      </div>
+
+      <div class="menu-demo">
+        <div class="demo-toolbar">
+          <div class="menu-anchor">
+            <m3-button variant="filled" (click)="toggleMenu()"
+              >Open menu</m3-button
+            >
+            <m3-menu
+              [attr.open]="menuOpen ? '' : null"
+              [placement]="examplePlacement"
+              (menu-dismiss)="closeMenu()"
+              (menu-item-select)="handleMenuSelect($event)"
+            >
+              <m3-menu-item value="profile">
+                <span slot="leading-icon" class="material-symbols-outlined"
+                  >person</span
+                >
+                Profile
+              </m3-menu-item>
+              <m3-menu-item value="share">
+                <span slot="leading-icon" class="material-symbols-outlined"
+                  >share</span
+                >
+                Share
+              </m3-menu-item>
+              <m3-menu-item value="archive">
+                <span slot="leading-icon" class="material-symbols-outlined"
+                  >archive</span
+                >
+                Archive
+              </m3-menu-item>
+            </m3-menu>
+          </div>
+          <div class="menu-anchor placement-anchor">
+            <m3-button variant="tonal" (click)="togglePlacementMenu()">
+              Position: {{ examplePlacement }}
+            </m3-button>
+            <m3-menu
+              placement="bottom-start"
+              [attr.open]="placementMenuOpen ? '' : null"
+              (menu-dismiss)="closePlacementMenu()"
+              (menu-item-select)="handlePlacementSelect($event)"
+            >
+              @for (p of placementOptions; track p) {
+                <m3-menu-item [value]="p">{{ p }}</m3-menu-item>
+              }
+            </m3-menu>
+          </div>
+        </div>
+
+        <p class="selection-note">
+          Last selection: <strong>{{ lastSelection }}</strong>
         </p>
-    </header>
+      </div>
 
-    <section class="demo-section">
-        <h2>Standalone Menu</h2>
-        <p>Use menus for contextual actions, overflow options, and lightweight selections.</p>
+      <app-code-block
+        language="html"
+        variant="sample"
+        [code]="basicExample"
+      ></app-code-block>
+    </div>
+  </section>
 
-        <div class="variant-card">
-            <div class="variant-header">
-                <h3>Anchored Example</h3>
-                <span class="emphasis-badge medium">M3 menu surface</span>
-            </div>
+  <section class="demo-section">
+    <h2>Positioning API</h2>
+    <p>
+      Use <code>placement</code> to choose where the menu opens relative to its
+      anchor, and <code>offset</code> to control the gap in pixels.
+    </p>
 
-            <div class="menu-demo">
-                <div class="demo-toolbar">
-                    <div class="menu-anchor">
-                        <m3-button variant="filled" (click)="toggleMenu()">Open menu</m3-button>
-                        <m3-menu [attr.open]="menuOpen ? '' : null" [placement]="examplePlacement"
-                            (menu-dismiss)="closeMenu()" (menu-item-select)="handleMenuSelect($event)">
-                            <m3-menu-item value="profile">
-                                <span slot="leading-icon" class="material-symbols-outlined">person</span>
-                                Profile
-                            </m3-menu-item>
-                            <m3-menu-item value="share">
-                                <span slot="leading-icon" class="material-symbols-outlined">share</span>
-                                Share
-                            </m3-menu-item>
-                            <m3-menu-item value="archive">
-                                <span slot="leading-icon" class="material-symbols-outlined">archive</span>
-                                Archive
-                            </m3-menu-item>
-                        </m3-menu>
-                    </div>
-                    <div class="menu-anchor placement-anchor">
-                        <m3-button variant="tonal" (click)="togglePlacementMenu()">
-                            Position: {{ examplePlacement }}
-                        </m3-button>
-                        <m3-menu placement="bottom-start" [attr.open]="placementMenuOpen ? '' : null"
-                            (menu-dismiss)="closePlacementMenu()" (menu-item-select)="handlePlacementSelect($event)">
-                            @for (p of placementOptions; track p) {
-                                <m3-menu-item [value]="p">{{ p }}</m3-menu-item>
-                            }
-                        </m3-menu>
-                    </div>
-                </div>
+    <div class="variant-card">
+      <div class="variant-header">
+        <h3>Placement Options</h3>
+        <span class="emphasis-badge medium"
+          >Built into <code>m3-menu</code></span
+        >
+      </div>
 
-                <p class="selection-note">Last selection: <strong>{{ lastSelection }}</strong></p>
-            </div>
-
-            <app-code-block language="html" variant="sample" [code]="basicExample"></app-code-block>
+      <div class="placement-grid">
+        <div class="placement-group">
+          <h4>Bottom</h4>
+          <code>bottom-start</code>
+          <code>bottom-center</code>
+          <code>bottom-end</code>
         </div>
-    </section>
-
-    <section class="demo-section">
-        <h2>Positioning API</h2>
-        <p>Use <code>placement</code> to choose where the menu opens relative to its anchor, and <code>offset</code> to control the gap in pixels.</p>
-
-        <div class="variant-card">
-            <div class="variant-header">
-                <h3>Placement Options</h3>
-                <span class="emphasis-badge medium">Built into <code>m3-menu</code></span>
-            </div>
-
-            <div class="placement-grid">
-                <div class="placement-group">
-                    <h4>Bottom</h4>
-                    <code>bottom-start</code>
-                    <code>bottom-center</code>
-                    <code>bottom-end</code>
-                </div>
-                <div class="placement-group">
-                    <h4>Top</h4>
-                    <code>top-start</code>
-                    <code>top-center</code>
-                    <code>top-end</code>
-                </div>
-                <div class="placement-group">
-                    <h4>Right</h4>
-                    <code>right-start</code>
-                    <code>right-center</code>
-                    <code>right-end</code>
-                </div>
-                <div class="placement-group">
-                    <h4>Left</h4>
-                    <code>left-start</code>
-                    <code>left-center</code>
-                    <code>left-end</code>
-                </div>
-            </div>
-
-            <p class="selection-note">Example: <code>placement="right-center" offset="12"</code></p>
-            <app-code-block language="html" variant="sample" [code]="positioningExample"></app-code-block>
+        <div class="placement-group">
+          <h4>Top</h4>
+          <code>top-start</code>
+          <code>top-center</code>
+          <code>top-end</code>
         </div>
-    </section>
+        <div class="placement-group">
+          <h4>Right</h4>
+          <code>right-start</code>
+          <code>right-center</code>
+          <code>right-end</code>
+        </div>
+        <div class="placement-group">
+          <h4>Left</h4>
+          <code>left-start</code>
+          <code>left-center</code>
+          <code>left-end</code>
+        </div>
+      </div>
 
-    <section class="demo-section accessibility">
-        <h2>♿ Accessibility</h2>
-        <ul class="feature-list">
-            <li><strong>Role Mapping:</strong> The surface uses <code>role="menu"</code> and items use
-                <code>role="menuitem"</code>.
-            </li>
-            <li><strong>Keyboard Navigation:</strong> Arrow keys, Home, End, Escape, and Tab dismissal are supported.</li>
-            <li><strong>Dismissal:</strong> Menus close on outside click, Escape, Tab, or item selection.</li>
-        </ul>
-    </section>
+      <p class="selection-note">
+        Example: <code>placement="right-center" offset="12"</code>
+      </p>
+      <app-code-block
+        language="html"
+        variant="sample"
+        [code]="positioningExample"
+      ></app-code-block>
+    </div>
+  </section>
+
+  <section class="demo-section accessibility">
+    <h2>♿ Accessibility</h2>
+    <ul class="feature-list">
+      <li>
+        <strong>Role Mapping:</strong> The surface uses
+        <code>role="menu"</code> and items use <code>role="menuitem"</code>.
+      </li>
+      <li>
+        <strong>Keyboard Navigation:</strong> Arrow keys, Home, End, Escape, and
+        Tab dismissal are supported.
+      </li>
+      <li>
+        <strong>Dismissal:</strong> Menus close on outside click, Escape, Tab,
+        or item selection.
+      </li>
+    </ul>
+  </section>
 </div>

--- a/apps/angular-app/src/pages/navigation-bar/navigation-bar.component.html
+++ b/apps/angular-app/src/pages/navigation-bar/navigation-bar.component.html
@@ -1,412 +1,566 @@
 <div class="page-container docs-page">
-<header class="page-header">
-  <h1>Navigation Bar</h1>
-  <p class="subtitle">
-    A horizontal navigation component placed at the bottom of the screen, designed for smaller devices.
-    The flexible navigation bar is shorter than the original and supports both vertical (compact windows) 
-    and horizontal (medium windows) navigation item layouts.
-  </p>
-</header>
+  <section class="demo-section">
+    <h2>Overview</h2>
+    <p>
+      The Navigation Bar is a horizontal navigation component that provides
+      quick access to top-level destinations in your app. It adapts its layout
+      based on window size, showing vertical items in compact windows and
+      horizontal items in medium windows.
+    </p>
 
-<section class="demo-section">
-  <h2>Overview</h2>
-  <p>
-    The Navigation Bar is a horizontal navigation component that provides quick access to top-level destinations 
-    in your app. It adapts its layout based on window size, showing vertical items in compact windows and 
-    horizontal items in medium windows.
-  </p>
+    <div class="component-grid">
+      <div class="component-card">
+        <h3>m3-navigation-bar</h3>
+        <p>
+          Main container that holds navigation items and manages layout
+          (vertical/horizontal).
+        </p>
+      </div>
+      <div class="component-card">
+        <h3>m3-navigation-bar-item</h3>
+        <p>
+          Individual navigation items with icons, labels, and badge support.
+        </p>
+      </div>
+    </div>
+  </section>
 
-  <div class="component-grid">
-    <div class="component-card">
+  <section class="demo-section">
+    <h2>Live Examples</h2>
+
+    <div class="variant-card">
+      <div class="variant-header">
+        <h3>Basic Navigation Bar</h3>
+      </div>
+      <p>
+        A simple navigation bar with three items. Click on items to see the
+        active state change.
+      </p>
+
+      <div class="example-container">
+        <div class="demo-wrapper">
+          <div class="demo-frame">
+            <m3-navigation-bar id="basic-bar" class="demo-bar">
+              <m3-navigation-bar-item
+                label="Home"
+                [active]="selectedItem === 'Home'"
+                (item-click)="onItemClick($event)"
+              >
+                <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
+                  <path
+                    fill="currentColor"
+                    d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"
+                  />
+                </svg>
+              </m3-navigation-bar-item>
+
+              <m3-navigation-bar-item
+                label="Music"
+                [active]="selectedItem === 'Music'"
+                (item-click)="onItemClick($event)"
+              >
+                <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
+                  <path
+                    fill="currentColor"
+                    d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z"
+                  />
+                </svg>
+              </m3-navigation-bar-item>
+
+              <m3-navigation-bar-item
+                label="Podcasts"
+                [active]="selectedItem === 'Podcasts'"
+                (item-click)="onItemClick($event)"
+              >
+                <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
+                  <path
+                    fill="currentColor"
+                    d="M12 14c1.66 0 2.99-1.34 2.99-3L15 5c0-1.66-1.34-3-3-3S9 3.34 9 5v6c0 1.66 1.34 3 3 3zm5.3-3c0 3-2.54 5.1-5.3 5.1S6.7 14 6.7 11H5c0 3.41 2.72 6.23 6 6.72V21h2v-3.28c3.28-.48 6-3.3 6-6.72h-1.7z"
+                  />
+                </svg>
+              </m3-navigation-bar-item>
+            </m3-navigation-bar>
+          </div>
+
+          <div class="demo-content">
+            <p>
+              💡 <strong>Try it:</strong> Click on any navigation item to see it
+              become active. The active indicator and colors will change.
+            </p>
+            <p>
+              In compact windows (&lt;600px), items are arranged vertically and
+              dynamically resize. In medium windows (≥600px), items have fixed
+              widths.
+            </p>
+            <p>
+              <strong>Current selection:</strong>
+              <code>{{ selectedItem }}</code>
+            </p>
+          </div>
+        </div>
+      </div>
+      <app-code-block
+        language="html"
+        variant="sample"
+        [code]="basicBarExample"
+      ></app-code-block>
+    </div>
+
+    <div class="variant-card">
+      <div class="variant-header">
+        <h3>Navigation Bar with Badges</h3>
+      </div>
+      <p>
+        Badges can display notification counts or status indicators on
+        navigation items.
+      </p>
+
+      <div class="example-container">
+        <div class="demo-wrapper">
+          <div class="demo-frame">
+            <m3-navigation-bar id="badge-bar" class="demo-bar">
+              <m3-navigation-bar-item label="Inbox" active badge="5">
+                <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
+                  <path
+                    fill="currentColor"
+                    d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"
+                  />
+                </svg>
+              </m3-navigation-bar-item>
+
+              <m3-navigation-bar-item label="Messages" badge="12">
+                <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
+                  <path
+                    fill="currentColor"
+                    d="M20 2H4c-1.1 0-2 .9-2 2v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2z"
+                  />
+                </svg>
+              </m3-navigation-bar-item>
+
+              <m3-navigation-bar-item label="Notifications" badge="">
+                <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
+                  <path
+                    fill="currentColor"
+                    d="M12 22c1.1 0 2-.9 2-2h-4c0 1.1.9 2 2 2zm6-6v-5c0-3.07-1.64-5.64-4.5-6.32V4c0-.83-.67-1.5-1.5-1.5s-1.5.67-1.5 1.5v.68C7.63 5.36 6 7.92 6 11v5l-2 2v1h16v-1l-2-2z"
+                  />
+                </svg>
+              </m3-navigation-bar-item>
+
+              <m3-navigation-bar-item label="Tasks" badge="3">
+                <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
+                  <path
+                    fill="currentColor"
+                    d="M19 3h-4.18C14.4 1.84 13.3 1 12 1c-1.3 0-2.4.84-2.82 2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 0c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zm-2 14l-4-4 1.41-1.41L10 14.17l6.59-6.59L18 9l-8 8z"
+                  />
+                </svg>
+              </m3-navigation-bar-item>
+            </m3-navigation-bar>
+          </div>
+
+          <div class="demo-content">
+            <p>📊 <strong>Badge Types:</strong></p>
+            <ul>
+              <li>
+                <strong>Number badges:</strong> Display counts (e.g., "5", "12",
+                "3")
+              </li>
+              <li>
+                <strong>Dot badges:</strong> Show presence without counts (empty
+                string)
+              </li>
+              <li>
+                <strong>No badge:</strong> Standard item without indicators
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <app-code-block
+        language="html"
+        variant="sample"
+        [code]="badgeExample"
+      ></app-code-block>
+    </div>
+
+    <div class="variant-card">
+      <div class="variant-header">
+        <h3>Horizontal Layout (Medium Windows)</h3>
+      </div>
+      <p>
+        In medium windows (≥600px), the navigation bar automatically switches to
+        horizontal item layout with fixed widths.
+      </p>
+
+      <div class="example-container">
+        <div class="demo-wrapper">
+          <div class="demo-frame horizontal-demo">
+            <m3-navigation-bar layout="horizontal" class="demo-bar">
+              <m3-navigation-bar-item label="Home" active>
+                <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
+                  <path
+                    fill="currentColor"
+                    d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"
+                  />
+                </svg>
+              </m3-navigation-bar-item>
+
+              <m3-navigation-bar-item label="Search">
+                <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
+                  <path
+                    fill="currentColor"
+                    d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                  />
+                </svg>
+              </m3-navigation-bar-item>
+
+              <m3-navigation-bar-item label="Library">
+                <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
+                  <path
+                    fill="currentColor"
+                    d="M4 6H2v14c0 1.1.9 2 2 2h14v-2H4V6zm16-4H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-1 9H9V9h10v2zm-4 4H9v-2h6v2zm4-8H9V5h10v2z"
+                  />
+                </svg>
+              </m3-navigation-bar-item>
+
+              <m3-navigation-bar-item label="Profile">
+                <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
+                  <path
+                    fill="currentColor"
+                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+                  />
+                </svg>
+              </m3-navigation-bar-item>
+            </m3-navigation-bar>
+          </div>
+
+          <div class="demo-content">
+            <p>
+              🔄 <strong>Horizontal Layout:</strong> Items have fixed widths
+              (min 80px, max 168px) and extra space is added to the ends of the
+              navigation bar.
+            </p>
+            <p>
+              This layout is perfect for medium-sized windows where you want
+              consistent item sizes.
+            </p>
+          </div>
+        </div>
+      </div>
+      <app-code-block
+        language="html"
+        variant="sample"
+        [code]="horizontalExample"
+      ></app-code-block>
+    </div>
+
+    <div class="variant-card">
+      <div class="variant-header">
+        <h3>Auto Layout (Responsive)</h3>
+      </div>
+      <p>
+        Enable automatic layout switching based on window size using the
+        <code>auto-layout</code> attribute.
+      </p>
+
+      <div class="example-container">
+        <div class="demo-wrapper">
+          <div class="demo-frame">
+            <m3-navigation-bar auto-layout class="demo-bar">
+              <m3-navigation-bar-item label="Home" active>
+                <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
+                  <path
+                    fill="currentColor"
+                    d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"
+                  />
+                </svg>
+              </m3-navigation-bar-item>
+
+              <m3-navigation-bar-item label="Explore">
+                <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
+                  <path
+                    fill="currentColor"
+                    d="M12 10.9c-.61 0-1.1.49-1.1 1.1s.49 1.1 1.1 1.1c.61 0 1.1-.49 1.1-1.1s-.49-1.1-1.1-1.1zM12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm2.19 12.19L6 18l3.81-8.19L18 6l-3.81 8.19z"
+                  />
+                </svg>
+              </m3-navigation-bar-item>
+
+              <m3-navigation-bar-item label="Favorites">
+                <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
+                  <path
+                    fill="currentColor"
+                    d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"
+                  />
+                </svg>
+              </m3-navigation-bar-item>
+            </m3-navigation-bar>
+          </div>
+
+          <div class="demo-content">
+            <p>
+              📱 <strong>Responsive:</strong> The navigation bar automatically
+              switches between vertical and horizontal layouts based on window
+              width.
+            </p>
+            <ul>
+              <li>
+                <strong>Compact windows (&lt;600px):</strong> Vertical layout
+                with dynamic item widths
+              </li>
+              <li>
+                <strong>Medium windows (≥600px):</strong> Horizontal layout with
+                fixed item widths
+              </li>
+            </ul>
+            <p>
+              <strong>Try it:</strong> Resize your browser window to see the
+              layout change!
+            </p>
+          </div>
+        </div>
+      </div>
+      <app-code-block
+        language="html"
+        variant="sample"
+        [code]="autoLayoutExample"
+      ></app-code-block>
+    </div>
+  </section>
+
+  <section class="demo-section">
+    <h2>Basic Usage</h2>
+    <app-code-block
+      variant="block"
+      language="html"
+      [code]="basicUsageExample"
+    ></app-code-block>
+  </section>
+
+  <section class="demo-section">
+    <h2>API Reference</h2>
+
+    <div class="api-card">
       <h3>m3-navigation-bar</h3>
-      <p>Main container that holds navigation items and manages layout (vertical/horizontal).</p>
+      <p>Main container component for the navigation bar.</p>
+
+      <h4>Properties</h4>
+      <table class="api-table">
+        <thead>
+          <tr>
+            <th>Property</th>
+            <th>Type</th>
+            <th>Default</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>layout</code></td>
+            <td><code>'vertical' | 'horizontal'</code></td>
+            <td>'vertical'</td>
+            <td>Layout mode for navigation items</td>
+          </tr>
+          <tr>
+            <td><code>auto-layout</code></td>
+            <td>boolean</td>
+            <td>false</td>
+            <td>
+              Automatically switch between vertical/horizontal based on window
+              width (≥600px = horizontal)
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h4>Events</h4>
+      <table class="api-table">
+        <thead>
+          <tr>
+            <th>Event</th>
+            <th>Detail</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>item-click</code></td>
+            <td><code>&#123; label: string &#125;</code></td>
+            <td>
+              Fired when a navigation item is clicked (bubbles from items)
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h4>Slots</h4>
+      <table class="api-table">
+        <thead>
+          <tr>
+            <th>Slot</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>(default)</td>
+            <td>Navigation bar items</td>
+          </tr>
+        </tbody>
+      </table>
     </div>
-    <div class="component-card">
+
+    <div class="api-card">
       <h3>m3-navigation-bar-item</h3>
-      <p>Individual navigation items with icons, labels, and badge support.</p>
-    </div>
-  </div>
-</section>
+      <p>Individual navigation item with icon and label.</p>
 
-<section class="demo-section">
-  <h2>Live Examples</h2>
-  
-  <div class="variant-card">
-    <div class="variant-header">
-      <h3>Basic Navigation Bar</h3>
-    </div>
-    <p>A simple navigation bar with three items. Click on items to see the active state change.</p>
-    
-    <div class="example-container">
-      <div class="demo-wrapper">
-        <div class="demo-frame">
-          <m3-navigation-bar id="basic-bar" class="demo-bar">
-            <m3-navigation-bar-item label="Home" [active]="selectedItem === 'Home'" (item-click)="onItemClick($event)">
-              <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
-                <path fill="currentColor" d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"/>
-              </svg>
-            </m3-navigation-bar-item>
-            
-            <m3-navigation-bar-item label="Music" [active]="selectedItem === 'Music'" (item-click)="onItemClick($event)">
-              <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
-                <path fill="currentColor" d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z"/>
-              </svg>
-            </m3-navigation-bar-item>
-            
-            <m3-navigation-bar-item label="Podcasts" [active]="selectedItem === 'Podcasts'" (item-click)="onItemClick($event)">
-              <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
-                <path fill="currentColor" d="M12 14c1.66 0 2.99-1.34 2.99-3L15 5c0-1.66-1.34-3-3-3S9 3.34 9 5v6c0 1.66 1.34 3 3 3zm5.3-3c0 3-2.54 5.1-5.3 5.1S6.7 14 6.7 11H5c0 3.41 2.72 6.23 6 6.72V21h2v-3.28c3.28-.48 6-3.3 6-6.72h-1.7z"/>
-              </svg>
-            </m3-navigation-bar-item>
-          </m3-navigation-bar>
-        </div>
-        
-        <div class="demo-content">
-          <p>💡 <strong>Try it:</strong> Click on any navigation item to see it become active. The active indicator and colors will change.</p>
-          <p>In compact windows (&lt;600px), items are arranged vertically and dynamically resize. In medium windows (≥600px), items have fixed widths.</p>
-          <p><strong>Current selection:</strong> <code>{{ selectedItem }}</code></p>
-        </div>
-      </div>
-    </div>
-    <app-code-block language="html" variant="sample" [code]="basicBarExample"></app-code-block>
-  </div>
+      <h4>Properties</h4>
+      <table class="api-table">
+        <thead>
+          <tr>
+            <th>Property</th>
+            <th>Type</th>
+            <th>Default</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>active</code></td>
+            <td>boolean</td>
+            <td>false</td>
+            <td>Whether the item is currently active/selected</td>
+          </tr>
+          <tr>
+            <td><code>label</code></td>
+            <td>string</td>
+            <td>''</td>
+            <td>Text label for the navigation item</td>
+          </tr>
+          <tr>
+            <td><code>badge</code></td>
+            <td>string</td>
+            <td>''</td>
+            <td>Badge text to display (empty string shows a dot badge)</td>
+          </tr>
+          <tr>
+            <td><code>largeBadge</code></td>
+            <td>string</td>
+            <td>''</td>
+            <td>Large badge text (displays larger badge)</td>
+          </tr>
+          <tr>
+            <td><code>layout</code></td>
+            <td><code>'vertical' | 'horizontal'</code></td>
+            <td>'vertical'</td>
+            <td>Layout mode (automatically set by parent bar)</td>
+          </tr>
+        </tbody>
+      </table>
 
-  <div class="variant-card">
-    <div class="variant-header">
-      <h3>Navigation Bar with Badges</h3>
-    </div>
-    <p>Badges can display notification counts or status indicators on navigation items.</p>
-    
-    <div class="example-container">
-      <div class="demo-wrapper">
-        <div class="demo-frame">
-          <m3-navigation-bar id="badge-bar" class="demo-bar">
-            <m3-navigation-bar-item label="Inbox" active badge="5">
-              <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
-                <path fill="currentColor" d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/>
-              </svg>
-            </m3-navigation-bar-item>
-            
-            <m3-navigation-bar-item label="Messages" badge="12">
-              <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
-                <path fill="currentColor" d="M20 2H4c-1.1 0-2 .9-2 2v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2z"/>
-              </svg>
-            </m3-navigation-bar-item>
-            
-            <m3-navigation-bar-item label="Notifications" badge="">
-              <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
-                <path fill="currentColor" d="M12 22c1.1 0 2-.9 2-2h-4c0 1.1.9 2 2 2zm6-6v-5c0-3.07-1.64-5.64-4.5-6.32V4c0-.83-.67-1.5-1.5-1.5s-1.5.67-1.5 1.5v.68C7.63 5.36 6 7.92 6 11v5l-2 2v1h16v-1l-2-2z"/>
-              </svg>
-            </m3-navigation-bar-item>
-            
-            <m3-navigation-bar-item label="Tasks" badge="3">
-              <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
-                <path fill="currentColor" d="M19 3h-4.18C14.4 1.84 13.3 1 12 1c-1.3 0-2.4.84-2.82 2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 0c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zm-2 14l-4-4 1.41-1.41L10 14.17l6.59-6.59L18 9l-8 8z"/>
-              </svg>
-            </m3-navigation-bar-item>
-          </m3-navigation-bar>
-        </div>
-        
-        <div class="demo-content">
-          <p>📊 <strong>Badge Types:</strong></p>
-          <ul>
-            <li><strong>Number badges:</strong> Display counts (e.g., "5", "12", "3")</li>
-            <li><strong>Dot badges:</strong> Show presence without counts (empty string)</li>
-            <li><strong>No badge:</strong> Standard item without indicators</li>
-          </ul>
-        </div>
-      </div>
-    </div>
-    <app-code-block language="html" variant="sample" [code]="badgeExample"></app-code-block>
-  </div>
+      <h4>Events</h4>
+      <table class="api-table">
+        <thead>
+          <tr>
+            <th>Event</th>
+            <th>Detail</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>item-click</code></td>
+            <td><code>&#123; label: string &#125;</code></td>
+            <td>Fired when the item is clicked</td>
+          </tr>
+        </tbody>
+      </table>
 
-  <div class="variant-card">
-    <div class="variant-header">
-      <h3>Horizontal Layout (Medium Windows)</h3>
+      <h4>Slots</h4>
+      <table class="api-table">
+        <thead>
+          <tr>
+            <th>Slot</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>icon</code></td>
+            <td>SVG or icon element (24x24px recommended)</td>
+          </tr>
+        </tbody>
+      </table>
     </div>
-    <p>In medium windows (≥600px), the navigation bar automatically switches to horizontal item layout with fixed widths.</p>
-    
-    <div class="example-container">
-      <div class="demo-wrapper">
-        <div class="demo-frame horizontal-demo">
-          <m3-navigation-bar layout="horizontal" class="demo-bar">
-            <m3-navigation-bar-item label="Home" active>
-              <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
-                <path fill="currentColor" d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"/>
-              </svg>
-            </m3-navigation-bar-item>
-            
-            <m3-navigation-bar-item label="Search">
-              <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
-                <path fill="currentColor" d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
-              </svg>
-            </m3-navigation-bar-item>
-            
-            <m3-navigation-bar-item label="Library">
-              <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
-                <path fill="currentColor" d="M4 6H2v14c0 1.1.9 2 2 2h14v-2H4V6zm16-4H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-1 9H9V9h10v2zm-4 4H9v-2h6v2zm4-8H9V5h10v2z"/>
-              </svg>
-            </m3-navigation-bar-item>
-            
-            <m3-navigation-bar-item label="Profile">
-              <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
-                <path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"/>
-              </svg>
-            </m3-navigation-bar-item>
-          </m3-navigation-bar>
-        </div>
-        
-        <div class="demo-content">
-          <p>🔄 <strong>Horizontal Layout:</strong> Items have fixed widths (min 80px, max 168px) and extra space is added to the ends of the navigation bar.</p>
-          <p>This layout is perfect for medium-sized windows where you want consistent item sizes.</p>
-        </div>
-      </div>
+  </section>
+
+  <section class="demo-section">
+    <h2>Framework Integration</h2>
+
+    <div class="framework-card">
+      <h3>Angular</h3>
+      <app-code-block
+        variant="block"
+        language="typescript"
+        [code]="angularExample"
+      ></app-code-block>
     </div>
-    <app-code-block language="html" variant="sample" [code]="horizontalExample"></app-code-block>
-  </div>
 
-  <div class="variant-card">
-    <div class="variant-header">
-      <h3>Auto Layout (Responsive)</h3>
+    <div class="framework-card">
+      <h3>React</h3>
+      <app-code-block
+        variant="block"
+        language="javascript"
+        [code]="reactExample"
+      ></app-code-block>
     </div>
-    <p>Enable automatic layout switching based on window size using the <code>auto-layout</code> attribute.</p>
-    
-    <div class="example-container">
-      <div class="demo-wrapper">
-        <div class="demo-frame">
-          <m3-navigation-bar auto-layout class="demo-bar">
-            <m3-navigation-bar-item label="Home" active>
-              <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
-                <path fill="currentColor" d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"/>
-              </svg>
-            </m3-navigation-bar-item>
-            
-            <m3-navigation-bar-item label="Explore">
-              <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
-                <path fill="currentColor" d="M12 10.9c-.61 0-1.1.49-1.1 1.1s.49 1.1 1.1 1.1c.61 0 1.1-.49 1.1-1.1s-.49-1.1-1.1-1.1zM12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm2.19 12.19L6 18l3.81-8.19L18 6l-3.81 8.19z"/>
-              </svg>
-            </m3-navigation-bar-item>
-            
-            <m3-navigation-bar-item label="Favorites">
-              <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
-                <path fill="currentColor" d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
-              </svg>
-            </m3-navigation-bar-item>
-          </m3-navigation-bar>
-        </div>
-        
-        <div class="demo-content">
-          <p>📱 <strong>Responsive:</strong> The navigation bar automatically switches between vertical and horizontal layouts based on window width.</p>
-          <ul>
-            <li><strong>Compact windows (&lt;600px):</strong> Vertical layout with dynamic item widths</li>
-            <li><strong>Medium windows (≥600px):</strong> Horizontal layout with fixed item widths</li>
-          </ul>
-          <p><strong>Try it:</strong> Resize your browser window to see the layout change!</p>
-        </div>
-      </div>
+
+    <div class="framework-card">
+      <h3>Vue</h3>
+      <app-code-block
+        variant="block"
+        language="html"
+        [code]="vueExample"
+      ></app-code-block>
     </div>
-    <app-code-block language="html" variant="sample" [code]="autoLayoutExample"></app-code-block>
-  </div>
-</section>
+  </section>
 
-<section class="demo-section">
-  <h2>Basic Usage</h2>
-  <app-code-block variant="block" language="html" [code]="basicUsageExample"></app-code-block>
-</section>
-
-<section class="demo-section">
-  <h2>API Reference</h2>
-  
-  <div class="api-card">
-    <h3>m3-navigation-bar</h3>
-    <p>Main container component for the navigation bar.</p>
-    
-    <h4>Properties</h4>
-    <table class="api-table">
-      <thead>
-        <tr>
-          <th>Property</th>
-          <th>Type</th>
-          <th>Default</th>
-          <th>Description</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><code>layout</code></td>
-          <td><code>'vertical' | 'horizontal'</code></td>
-          <td>'vertical'</td>
-          <td>Layout mode for navigation items</td>
-        </tr>
-        <tr>
-          <td><code>auto-layout</code></td>
-          <td>boolean</td>
-          <td>false</td>
-          <td>Automatically switch between vertical/horizontal based on window width (≥600px = horizontal)</td>
-        </tr>
-      </tbody>
-    </table>
-    
-    <h4>Events</h4>
-    <table class="api-table">
-      <thead>
-        <tr>
-          <th>Event</th>
-          <th>Detail</th>
-          <th>Description</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><code>item-click</code></td>
-          <td><code>&#123; label: string &#125;</code></td>
-          <td>Fired when a navigation item is clicked (bubbles from items)</td>
-        </tr>
-      </tbody>
-    </table>
-    
-    <h4>Slots</h4>
-    <table class="api-table">
-      <thead>
-        <tr>
-          <th>Slot</th>
-          <th>Description</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>(default)</td>
-          <td>Navigation bar items</td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-  
-  <div class="api-card">
-    <h3>m3-navigation-bar-item</h3>
-    <p>Individual navigation item with icon and label.</p>
-    
-    <h4>Properties</h4>
-    <table class="api-table">
-      <thead>
-        <tr>
-          <th>Property</th>
-          <th>Type</th>
-          <th>Default</th>
-          <th>Description</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><code>active</code></td>
-          <td>boolean</td>
-          <td>false</td>
-          <td>Whether the item is currently active/selected</td>
-        </tr>
-        <tr>
-          <td><code>label</code></td>
-          <td>string</td>
-          <td>''</td>
-          <td>Text label for the navigation item</td>
-        </tr>
-        <tr>
-          <td><code>badge</code></td>
-          <td>string</td>
-          <td>''</td>
-          <td>Badge text to display (empty string shows a dot badge)</td>
-        </tr>
-        <tr>
-          <td><code>largeBadge</code></td>
-          <td>string</td>
-          <td>''</td>
-          <td>Large badge text (displays larger badge)</td>
-        </tr>
-        <tr>
-          <td><code>layout</code></td>
-          <td><code>'vertical' | 'horizontal'</code></td>
-          <td>'vertical'</td>
-          <td>Layout mode (automatically set by parent bar)</td>
-        </tr>
-      </tbody>
-    </table>
-    
-    <h4>Events</h4>
-    <table class="api-table">
-      <thead>
-        <tr>
-          <th>Event</th>
-          <th>Detail</th>
-          <th>Description</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><code>item-click</code></td>
-          <td><code>&#123; label: string &#125;</code></td>
-          <td>Fired when the item is clicked</td>
-        </tr>
-      </tbody>
-    </table>
-    
-    <h4>Slots</h4>
-    <table class="api-table">
-      <thead>
-        <tr>
-          <th>Slot</th>
-          <th>Description</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><code>icon</code></td>
-          <td>SVG or icon element (24x24px recommended)</td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-</section>
-
-<section class="demo-section">
-  <h2>Framework Integration</h2>
-  
-  <div class="framework-card">
-    <h3>Angular</h3>
-    <app-code-block variant="block" language="typescript" [code]="angularExample"></app-code-block>
-  </div>
-  
-  <div class="framework-card">
-    <h3>React</h3>
-    <app-code-block variant="block" language="javascript" [code]="reactExample"></app-code-block>
-  </div>
-  
-  <div class="framework-card">
-    <h3>Vue</h3>
-    <app-code-block variant="block" language="html" [code]="vueExample"></app-code-block>
-  </div>
-</section>
-
-<section class="demo-section">
-  <h2>Design Tokens</h2>
-  <p>
-    The navigation bar follows Material Design 3 specifications and uses the following design tokens:
-  </p>
-  <div class="api-card">
-    <h4>Color Tokens</h4>
-    <ul>
-      <li><strong>Container:</strong> <code>md.sys.color.surface-container</code></li>
-      <li><strong>Elevation:</strong> <code>md.sys.elevation.level2</code></li>
-      <li><strong>Active Indicator:</strong> <code>md.sys.color.secondary-container</code></li>
-      <li><strong>Active Label:</strong> <code>md.sys.color.secondary</code></li>
-      <li><strong>Active Icon:</strong> <code>md.sys.color.on-secondary-container</code></li>
-      <li><strong>Inactive Label/Icon:</strong> <code>md.sys.color.on-surface-variant</code></li>
-    </ul>
-    <h4>State Layers</h4>
-    <ul>
-      <li><strong>Hover:</strong> 8% state layer opacity</li>
-      <li><strong>Focus:</strong> 10% state layer opacity</li>
-      <li><strong>Pressed:</strong> 10% state layer opacity</li>
-    </ul>
-  </div>
-</section>
+  <section class="demo-section">
+    <h2>Design Tokens</h2>
+    <p>
+      The navigation bar follows Material Design 3 specifications and uses the
+      following design tokens:
+    </p>
+    <div class="api-card">
+      <h4>Color Tokens</h4>
+      <ul>
+        <li>
+          <strong>Container:</strong>
+          <code>md.sys.color.surface-container</code>
+        </li>
+        <li>
+          <strong>Elevation:</strong> <code>md.sys.elevation.level2</code>
+        </li>
+        <li>
+          <strong>Active Indicator:</strong>
+          <code>md.sys.color.secondary-container</code>
+        </li>
+        <li>
+          <strong>Active Label:</strong> <code>md.sys.color.secondary</code>
+        </li>
+        <li>
+          <strong>Active Icon:</strong>
+          <code>md.sys.color.on-secondary-container</code>
+        </li>
+        <li>
+          <strong>Inactive Label/Icon:</strong>
+          <code>md.sys.color.on-surface-variant</code>
+        </li>
+      </ul>
+      <h4>State Layers</h4>
+      <ul>
+        <li><strong>Hover:</strong> 8% state layer opacity</li>
+        <li><strong>Focus:</strong> 10% state layer opacity</li>
+        <li><strong>Pressed:</strong> 10% state layer opacity</li>
+      </ul>
+    </div>
+  </section>
 </div>
-

--- a/apps/angular-app/src/pages/navigation-rail/navigation-rail.component.html
+++ b/apps/angular-app/src/pages/navigation-rail/navigation-rail.component.html
@@ -1,389 +1,520 @@
 <div class="page-container docs-page">
-<header class="page-header">
-  <h1>Navigation Rail</h1>
-  <p class="subtitle">
-    A vertical navigation component that provides quick access to top-level destinations in your app.
-    It can expand to show labels alongside icons for better clarity.
-  </p>
-</header>
+  <section class="demo-section">
+    <h2>Overview</h2>
+    <p>
+      The Navigation Rail is a compact, vertical navigation component designed
+      for primary navigation in apps. It consists of three main components that
+      work together to create a cohesive navigation experience.
+    </p>
 
-<section class="demo-section">
-  <h2>Overview</h2>
-  <p>
-    The Navigation Rail is a compact, vertical navigation component designed for primary navigation in apps.
-    It consists of three main components that work together to create a cohesive navigation experience.
-  </p>
+    <div class="component-grid">
+      <div class="component-card">
+        <h3>m3-navigation-rail</h3>
+        <p>
+          Main container that holds navigation items and manages the expanded
+          state.
+        </p>
+      </div>
+      <div class="component-card">
+        <h3>m3-navigation-rail-item</h3>
+        <p>
+          Individual navigation items with icons, labels, and badge support.
+        </p>
+      </div>
+      <div class="component-card">
+        <h3>m3-navigation-rail-toggle</h3>
+        <p>Toggle button to expand/collapse the rail to show or hide labels.</p>
+      </div>
+    </div>
+  </section>
 
-  <div class="component-grid">
-    <div class="component-card">
+  <section class="demo-section">
+    <h2>Live Examples</h2>
+
+    <div class="variant-card">
+      <div class="variant-header">
+        <h3>Basic Navigation Rail</h3>
+      </div>
+      <p>
+        A simple navigation rail with three items. Click on items to see the
+        active state change.
+      </p>
+
+      <div class="example-container">
+        <m3-navigation-rail id="basic-rail" class="demo-rail">
+          <m3-navigation-rail-toggle></m3-navigation-rail-toggle>
+
+          <m3-navigation-rail-item
+            label="Home"
+            active
+            (item-click)="onItemClick($event)"
+          >
+            <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
+              <path
+                fill="currentColor"
+                d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"
+              />
+            </svg>
+          </m3-navigation-rail-item>
+
+          <m3-navigation-rail-item
+            label="Search"
+            (item-click)="onItemClick($event)"
+          >
+            <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
+              <path
+                fill="currentColor"
+                d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+              />
+            </svg>
+          </m3-navigation-rail-item>
+
+          <m3-navigation-rail-item
+            label="Library"
+            (item-click)="onItemClick($event)"
+          >
+            <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
+              <path
+                fill="currentColor"
+                d="M4 6H2v14c0 1.1.9 2 2 2h14v-2H4V6zm16-4H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-1 9H9V9h10v2zm-4 4H9v-2h6v2zm4-8H9V5h10v2z"
+              />
+            </svg>
+          </m3-navigation-rail-item>
+        </m3-navigation-rail>
+
+        <div class="demo-content">
+          <p>
+            💡 <strong>Try it:</strong> Click the toggle button at the top to
+            expand the rail and see labels appear next to icons.
+          </p>
+          <p>Click on any navigation item to see it become active.</p>
+        </div>
+      </div>
+      <app-code-block
+        language="html"
+        variant="sample"
+        [code]="basicRailExample"
+      ></app-code-block>
+    </div>
+
+    <div class="variant-card">
+      <div class="variant-header">
+        <h3>Navigation Rail with Badges</h3>
+      </div>
+      <p>
+        Badges can display notification counts or status indicators on
+        navigation items.
+      </p>
+
+      <div class="example-container">
+        <m3-navigation-rail id="badge-rail" class="demo-rail">
+          <m3-navigation-rail-toggle></m3-navigation-rail-toggle>
+
+          <m3-navigation-rail-item
+            label="Inbox"
+            active
+            (item-click)="onItemClick($event)"
+          >
+            <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
+              <path
+                fill="currentColor"
+                d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"
+              />
+            </svg>
+          </m3-navigation-rail-item>
+
+          <m3-navigation-rail-item
+            label="Messages"
+            badge="12"
+            (item-click)="onItemClick($event)"
+          >
+            <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
+              <path
+                fill="currentColor"
+                d="M20 2H4c-1.1 0-2 .9-2 2v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2z"
+              />
+            </svg>
+          </m3-navigation-rail-item>
+
+          <m3-navigation-rail-item
+            label="Notifications"
+            badge=""
+            (item-click)="onItemClick($event)"
+          >
+            <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
+              <path
+                fill="currentColor"
+                d="M12 22c1.1 0 2-.9 2-2h-4c0 1.1.9 2 2 2zm6-6v-5c0-3.07-1.64-5.64-4.5-6.32V4c0-.83-.67-1.5-1.5-1.5s-1.5.67-1.5 1.5v.68C7.63 5.36 6 7.92 6 11v5l-2 2v1h16v-1l-2-2z"
+              />
+            </svg>
+          </m3-navigation-rail-item>
+
+          <m3-navigation-rail-item
+            label="Tasks"
+            badge="3"
+            (item-click)="onItemClick($event)"
+          >
+            <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
+              <path
+                fill="currentColor"
+                d="M19 3h-4.18C14.4 1.84 13.3 1 12 1c-1.3 0-2.4.84-2.82 2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 0c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zm-2 14l-4-4 1.41-1.41L10 14.17l6.59-6.59L18 9l-8 8z"
+              />
+            </svg>
+          </m3-navigation-rail-item>
+        </m3-navigation-rail>
+
+        <div class="demo-content">
+          <p>📊 <strong>Badge Types:</strong></p>
+          <ul>
+            <li>
+              <strong>Number badges:</strong> Display counts (e.g., "12", "3")
+            </li>
+            <li>
+              <strong>Dot badges:</strong> Show presence without counts (empty
+              string)
+            </li>
+            <li><strong>No badge:</strong> Standard item without indicators</li>
+          </ul>
+        </div>
+      </div>
+      <app-code-block
+        language="html"
+        variant="sample"
+        [code]="badgeExample"
+      ></app-code-block>
+    </div>
+
+    <div class="variant-card">
+      <div class="variant-header">
+        <h3>Navigation Rail with Bottom Items</h3>
+      </div>
+      <p>
+        Use the bottom slot for secondary actions like settings or profile
+        access.
+      </p>
+
+      <div class="example-container">
+        <m3-navigation-rail id="bottom-rail" class="demo-rail">
+          <m3-navigation-rail-toggle></m3-navigation-rail-toggle>
+
+          <m3-navigation-rail-item
+            label="Home"
+            active
+            (item-click)="onItemClick($event)"
+          >
+            <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
+              <path
+                fill="currentColor"
+                d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"
+              />
+            </svg>
+          </m3-navigation-rail-item>
+
+          <m3-navigation-rail-item
+            label="Explore"
+            (item-click)="onItemClick($event)"
+          >
+            <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
+              <path
+                fill="currentColor"
+                d="M12 10.9c-.61 0-1.1.49-1.1 1.1s.49 1.1 1.1 1.1c.61 0 1.1-.49 1.1-1.1s-.49-1.1-1.1-1.1zM12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm2.19 12.19L6 18l3.81-8.19L18 6l-3.81 8.19z"
+              />
+            </svg>
+          </m3-navigation-rail-item>
+
+          <m3-navigation-rail-item
+            label="Favorites"
+            (item-click)="onItemClick($event)"
+          >
+            <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
+              <path
+                fill="currentColor"
+                d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"
+              />
+            </svg>
+          </m3-navigation-rail-item>
+
+          <m3-navigation-rail-item
+            slot="bottom"
+            label="Settings"
+            (item-click)="onItemClick($event)"
+          >
+            <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
+              <path
+                fill="currentColor"
+                d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.07.62-.07.94s.02.64.07.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z"
+              />
+            </svg>
+          </m3-navigation-rail-item>
+
+          <m3-navigation-rail-item
+            slot="bottom"
+            label="Profile"
+            (item-click)="onItemClick($event)"
+          >
+            <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
+              <path
+                fill="currentColor"
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+              />
+            </svg>
+          </m3-navigation-rail-item>
+        </m3-navigation-rail>
+
+        <div class="demo-content">
+          <p>
+            🔽 <strong>Bottom Slot:</strong> Items in the bottom slot are
+            separated from main navigation and anchored to the bottom of the
+            rail.
+          </p>
+          <p>
+            Perfect for settings, user profile, or help sections that should
+            always be accessible.
+          </p>
+        </div>
+      </div>
+      <app-code-block
+        language="html"
+        variant="sample"
+        [code]="bottomItemExample"
+      ></app-code-block>
+    </div>
+  </section>
+
+  <section class="demo-section">
+    <h2>Basic Usage</h2>
+    <app-code-block
+      variant="block"
+      language="html"
+      [code]="basicUsageExample"
+    ></app-code-block>
+  </section>
+
+  <section class="demo-section">
+    <h2>API Reference</h2>
+
+    <div class="api-card">
       <h3>m3-navigation-rail</h3>
-      <p>Main container that holds navigation items and manages the expanded state.</p>
+      <p>Main container component for the navigation rail.</p>
+
+      <h4>Properties</h4>
+      <table class="api-table">
+        <thead>
+          <tr>
+            <th>Property</th>
+            <th>Type</th>
+            <th>Default</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>expanded</code></td>
+            <td>boolean</td>
+            <td>false</td>
+            <td>Whether the rail is expanded to show labels</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h4>Events</h4>
+      <table class="api-table">
+        <thead>
+          <tr>
+            <th>Event</th>
+            <th>Detail</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>menu-toggle</code></td>
+            <td><code>&#123; expanded: boolean &#125;</code></td>
+            <td>Fired when the toggle button is clicked</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h4>Slots</h4>
+      <table class="api-table">
+        <thead>
+          <tr>
+            <th>Slot</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>(default)</td>
+            <td>Navigation rail items and toggle</td>
+          </tr>
+          <tr>
+            <td><code>bottom</code></td>
+            <td>Items anchored to the bottom of the rail</td>
+          </tr>
+        </tbody>
+      </table>
     </div>
-    <div class="component-card">
+
+    <div class="api-card">
       <h3>m3-navigation-rail-item</h3>
-      <p>Individual navigation items with icons, labels, and badge support.</p>
+      <p>Individual navigation item with icon and label.</p>
+
+      <h4>Properties</h4>
+      <table class="api-table">
+        <thead>
+          <tr>
+            <th>Property</th>
+            <th>Type</th>
+            <th>Default</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>active</code></td>
+            <td>boolean</td>
+            <td>false</td>
+            <td>Whether the item is currently active/selected</td>
+          </tr>
+          <tr>
+            <td><code>label</code></td>
+            <td>string</td>
+            <td>''</td>
+            <td>Text label for the navigation item</td>
+          </tr>
+          <tr>
+            <td><code>badge</code></td>
+            <td>string</td>
+            <td>''</td>
+            <td>Badge text to display (empty string shows a dot)</td>
+          </tr>
+          <tr>
+            <td><code>expanded</code></td>
+            <td>boolean</td>
+            <td>false</td>
+            <td>Automatically set by parent rail</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h4>Events</h4>
+      <table class="api-table">
+        <thead>
+          <tr>
+            <th>Event</th>
+            <th>Detail</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>item-click</code></td>
+            <td><code>&#123; label: string &#125;</code></td>
+            <td>Fired when the item is clicked</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h4>Slots</h4>
+      <table class="api-table">
+        <thead>
+          <tr>
+            <th>Slot</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>icon</code></td>
+            <td>SVG or icon element (24x24px recommended)</td>
+          </tr>
+        </tbody>
+      </table>
     </div>
-    <div class="component-card">
+
+    <div class="api-card">
       <h3>m3-navigation-rail-toggle</h3>
-      <p>Toggle button to expand/collapse the rail to show or hide labels.</p>
-    </div>
-  </div>
-</section>
+      <p>Toggle button to expand/collapse the navigation rail.</p>
 
-<section class="demo-section">
-  <h2>Live Examples</h2>
-  
-  <div class="variant-card">
-    <div class="variant-header">
-      <h3>Basic Navigation Rail</h3>
-    </div>
-    <p>A simple navigation rail with three items. Click on items to see the active state change.</p>
-    
-    <div class="example-container">
-      <m3-navigation-rail id="basic-rail" class="demo-rail">
-        <m3-navigation-rail-toggle></m3-navigation-rail-toggle>
-        
-        <m3-navigation-rail-item label="Home" active (item-click)="onItemClick($event)">
-          <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
-            <path fill="currentColor" d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"/>
-          </svg>
-        </m3-navigation-rail-item>
-        
-        <m3-navigation-rail-item label="Search" (item-click)="onItemClick($event)">
-          <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
-            <path fill="currentColor" d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
-          </svg>
-        </m3-navigation-rail-item>
-        
-        <m3-navigation-rail-item label="Library" (item-click)="onItemClick($event)">
-          <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
-            <path fill="currentColor" d="M4 6H2v14c0 1.1.9 2 2 2h14v-2H4V6zm16-4H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-1 9H9V9h10v2zm-4 4H9v-2h6v2zm4-8H9V5h10v2z"/>
-          </svg>
-        </m3-navigation-rail-item>
-      </m3-navigation-rail>
-      
-      <div class="demo-content">
-        <p>💡 <strong>Try it:</strong> Click the toggle button at the top to expand the rail and see labels appear next to icons.</p>
-        <p>Click on any navigation item to see it become active.</p>
-      </div>
-    </div>
-    <app-code-block language="html" variant="sample" [code]="basicRailExample"></app-code-block>
-  </div>
+      <h4>Properties</h4>
+      <table class="api-table">
+        <thead>
+          <tr>
+            <th>Property</th>
+            <th>Type</th>
+            <th>Default</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>expanded</code></td>
+            <td>boolean</td>
+            <td>false</td>
+            <td>Whether the rail is expanded</td>
+          </tr>
+        </tbody>
+      </table>
 
-  <div class="variant-card">
-    <div class="variant-header">
-      <h3>Navigation Rail with Badges</h3>
+      <h4>Events</h4>
+      <table class="api-table">
+        <thead>
+          <tr>
+            <th>Event</th>
+            <th>Detail</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>toggle-click</code></td>
+            <td><code>&#123; expanded: boolean &#125;</code></td>
+            <td>Fired when toggle is clicked</td>
+          </tr>
+        </tbody>
+      </table>
     </div>
-    <p>Badges can display notification counts or status indicators on navigation items.</p>
-    
-    <div class="example-container">
-      <m3-navigation-rail id="badge-rail" class="demo-rail">
-        <m3-navigation-rail-toggle></m3-navigation-rail-toggle>
-        
-        <m3-navigation-rail-item label="Inbox" active (item-click)="onItemClick($event)">
-          <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
-            <path fill="currentColor" d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/>
-          </svg>
-        </m3-navigation-rail-item>
-        
-        <m3-navigation-rail-item label="Messages" badge="12" (item-click)="onItemClick($event)">
-          <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
-            <path fill="currentColor" d="M20 2H4c-1.1 0-2 .9-2 2v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2z"/>
-          </svg>
-        </m3-navigation-rail-item>
-        
-        <m3-navigation-rail-item label="Notifications" badge="" (item-click)="onItemClick($event)">
-          <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
-            <path fill="currentColor" d="M12 22c1.1 0 2-.9 2-2h-4c0 1.1.9 2 2 2zm6-6v-5c0-3.07-1.64-5.64-4.5-6.32V4c0-.83-.67-1.5-1.5-1.5s-1.5.67-1.5 1.5v.68C7.63 5.36 6 7.92 6 11v5l-2 2v1h16v-1l-2-2z"/>
-          </svg>
-        </m3-navigation-rail-item>
-        
-        <m3-navigation-rail-item label="Tasks" badge="3" (item-click)="onItemClick($event)">
-          <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
-            <path fill="currentColor" d="M19 3h-4.18C14.4 1.84 13.3 1 12 1c-1.3 0-2.4.84-2.82 2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 0c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zm-2 14l-4-4 1.41-1.41L10 14.17l6.59-6.59L18 9l-8 8z"/>
-          </svg>
-        </m3-navigation-rail-item>
-      </m3-navigation-rail>
-      
-      <div class="demo-content">
-        <p>📊 <strong>Badge Types:</strong></p>
-        <ul>
-          <li><strong>Number badges:</strong> Display counts (e.g., "12", "3")</li>
-          <li><strong>Dot badges:</strong> Show presence without counts (empty string)</li>
-          <li><strong>No badge:</strong> Standard item without indicators</li>
-        </ul>
-      </div>
+  </section>
+
+  <section class="demo-section">
+    <h2>Framework Integration</h2>
+
+    <div class="framework-card">
+      <h3>Angular</h3>
+      <app-code-block
+        variant="block"
+        language="typescript"
+        [code]="angularExample"
+      ></app-code-block>
     </div>
-    <app-code-block language="html" variant="sample" [code]="badgeExample"></app-code-block>
-  </div>
 
-  <div class="variant-card">
-    <div class="variant-header">
-      <h3>Navigation Rail with Bottom Items</h3>
+    <div class="framework-card">
+      <h3>React</h3>
+      <app-code-block
+        variant="block"
+        language="javascript"
+        [code]="reactExample"
+      ></app-code-block>
     </div>
-    <p>Use the bottom slot for secondary actions like settings or profile access.</p>
-    
-    <div class="example-container">
-      <m3-navigation-rail id="bottom-rail" class="demo-rail">
-        <m3-navigation-rail-toggle></m3-navigation-rail-toggle>
-        
-        <m3-navigation-rail-item label="Home" active (item-click)="onItemClick($event)">
-          <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
-            <path fill="currentColor" d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"/>
-          </svg>
-        </m3-navigation-rail-item>
-        
-        <m3-navigation-rail-item label="Explore" (item-click)="onItemClick($event)">
-          <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
-            <path fill="currentColor" d="M12 10.9c-.61 0-1.1.49-1.1 1.1s.49 1.1 1.1 1.1c.61 0 1.1-.49 1.1-1.1s-.49-1.1-1.1-1.1zM12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm2.19 12.19L6 18l3.81-8.19L18 6l-3.81 8.19z"/>
-          </svg>
-        </m3-navigation-rail-item>
-        
-        <m3-navigation-rail-item label="Favorites" (item-click)="onItemClick($event)">
-          <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
-            <path fill="currentColor" d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
-          </svg>
-        </m3-navigation-rail-item>
-        
-        <m3-navigation-rail-item slot="bottom" label="Settings" (item-click)="onItemClick($event)">
-          <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
-            <path fill="currentColor" d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.07.62-.07.94s.02.64.07.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z"/>
-          </svg>
-        </m3-navigation-rail-item>
-        
-        <m3-navigation-rail-item slot="bottom" label="Profile" (item-click)="onItemClick($event)">
-          <svg slot="icon" viewBox="0 0 24 24" width="24" height="24">
-            <path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"/>
-          </svg>
-        </m3-navigation-rail-item>
-      </m3-navigation-rail>
-      
-      <div class="demo-content">
-        <p>🔽 <strong>Bottom Slot:</strong> Items in the bottom slot are separated from main navigation and anchored to the bottom of the rail.</p>
-        <p>Perfect for settings, user profile, or help sections that should always be accessible.</p>
-      </div>
+
+    <div class="framework-card">
+      <h3>Vue</h3>
+      <app-code-block
+        variant="block"
+        language="html"
+        [code]="vueExample"
+      ></app-code-block>
     </div>
-    <app-code-block language="html" variant="sample" [code]="bottomItemExample"></app-code-block>
-  </div>
-</section>
+  </section>
 
-<section class="demo-section">
-  <h2>Basic Usage</h2>
-  <app-code-block variant="block" language="html" [code]="basicUsageExample"></app-code-block>
-</section>
-
-<section class="demo-section">
-  <h2>API Reference</h2>
-  
-  <div class="api-card">
-    <h3>m3-navigation-rail</h3>
-    <p>Main container component for the navigation rail.</p>
-    
-    <h4>Properties</h4>
-    <table class="api-table">
-      <thead>
-        <tr>
-          <th>Property</th>
-          <th>Type</th>
-          <th>Default</th>
-          <th>Description</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><code>expanded</code></td>
-          <td>boolean</td>
-          <td>false</td>
-          <td>Whether the rail is expanded to show labels</td>
-        </tr>
-      </tbody>
-    </table>
-    
-    <h4>Events</h4>
-    <table class="api-table">
-      <thead>
-        <tr>
-          <th>Event</th>
-          <th>Detail</th>
-          <th>Description</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><code>menu-toggle</code></td>
-          <td><code>&#123; expanded: boolean &#125;</code></td>
-          <td>Fired when the toggle button is clicked</td>
-        </tr>
-      </tbody>
-    </table>
-    
-    <h4>Slots</h4>
-    <table class="api-table">
-      <thead>
-        <tr>
-          <th>Slot</th>
-          <th>Description</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>(default)</td>
-          <td>Navigation rail items and toggle</td>
-        </tr>
-        <tr>
-          <td><code>bottom</code></td>
-          <td>Items anchored to the bottom of the rail</td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-  
-  <div class="api-card">
-    <h3>m3-navigation-rail-item</h3>
-    <p>Individual navigation item with icon and label.</p>
-    
-    <h4>Properties</h4>
-    <table class="api-table">
-      <thead>
-        <tr>
-          <th>Property</th>
-          <th>Type</th>
-          <th>Default</th>
-          <th>Description</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><code>active</code></td>
-          <td>boolean</td>
-          <td>false</td>
-          <td>Whether the item is currently active/selected</td>
-        </tr>
-        <tr>
-          <td><code>label</code></td>
-          <td>string</td>
-          <td>''</td>
-          <td>Text label for the navigation item</td>
-        </tr>
-        <tr>
-          <td><code>badge</code></td>
-          <td>string</td>
-          <td>''</td>
-          <td>Badge text to display (empty string shows a dot)</td>
-        </tr>
-        <tr>
-          <td><code>expanded</code></td>
-          <td>boolean</td>
-          <td>false</td>
-          <td>Automatically set by parent rail</td>
-        </tr>
-      </tbody>
-    </table>
-    
-    <h4>Events</h4>
-    <table class="api-table">
-      <thead>
-        <tr>
-          <th>Event</th>
-          <th>Detail</th>
-          <th>Description</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><code>item-click</code></td>
-          <td><code>&#123; label: string &#125;</code></td>
-          <td>Fired when the item is clicked</td>
-        </tr>
-      </tbody>
-    </table>
-    
-    <h4>Slots</h4>
-    <table class="api-table">
-      <thead>
-        <tr>
-          <th>Slot</th>
-          <th>Description</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><code>icon</code></td>
-          <td>SVG or icon element (24x24px recommended)</td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-  
-  <div class="api-card">
-    <h3>m3-navigation-rail-toggle</h3>
-    <p>Toggle button to expand/collapse the navigation rail.</p>
-    
-    <h4>Properties</h4>
-    <table class="api-table">
-      <thead>
-        <tr>
-          <th>Property</th>
-          <th>Type</th>
-          <th>Default</th>
-          <th>Description</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><code>expanded</code></td>
-          <td>boolean</td>
-          <td>false</td>
-          <td>Whether the rail is expanded</td>
-        </tr>
-      </tbody>
-    </table>
-    
-    <h4>Events</h4>
-    <table class="api-table">
-      <thead>
-        <tr>
-          <th>Event</th>
-          <th>Detail</th>
-          <th>Description</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><code>toggle-click</code></td>
-          <td><code>&#123; expanded: boolean &#125;</code></td>
-          <td>Fired when toggle is clicked</td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-</section>
-
-<section class="demo-section">
-  <h2>Framework Integration</h2>
-  
-  <div class="framework-card">
-    <h3>Angular</h3>
-    <app-code-block variant="block" language="typescript" [code]="angularExample"></app-code-block>
-  </div>
-  
-  <div class="framework-card">
-    <h3>React</h3>
-    <app-code-block variant="block" language="javascript" [code]="reactExample"></app-code-block>
-  </div>
-  
-  <div class="framework-card">
-    <h3>Vue</h3>
-    <app-code-block variant="block" language="html" [code]="vueExample"></app-code-block>
-  </div>
-</section>
-
-<section class="demo-section">
-  <h2>Live Example</h2>
-  <p>
-    💡 <strong>This website uses the Navigation Rail!</strong> The left sidebar you see on this page is built using the 
-    <code>m3-navigation-rail</code> component. Try clicking the toggle button to expand it and explore the different sections.
-  </p>
-</section>
+  <section class="demo-section">
+    <h2>Live Example</h2>
+    <p>
+      💡 <strong>This website uses the Navigation Rail!</strong> The left
+      sidebar you see on this page is built using the
+      <code>m3-navigation-rail</code> component. Try clicking the toggle button
+      to expand it and explore the different sections.
+    </p>
+  </section>
 </div>
-

--- a/apps/angular-app/src/pages/progress/progress.component.html
+++ b/apps/angular-app/src/pages/progress/progress.component.html
@@ -1,28 +1,43 @@
 <div class="page-container docs-page">
-  <header class="page-header">
-    <h1>Progress Indicator</h1>
-    <p class="subtitle">Progress indicators express an unspecified wait time or display the length of a process.</p>
-  </header>
-
   <section class="demo-section">
     <h2>Determinate</h2>
     <div class="interactive-demo">
-      <div class="demo-row" style="flex-direction:column; gap:24px; width:100%; max-width:400px; padding: 20px 0;">
+      <div
+        class="demo-row"
+        style="
+          flex-direction: column;
+          gap: 24px;
+          width: 100%;
+          max-width: 400px;
+          padding: 20px 0;
+        "
+      >
         <m3-progress value="0.3"></m3-progress>
         <m3-progress value="0.6"></m3-progress>
         <m3-progress value="1"></m3-progress>
       </div>
-      <app-code-block [code]="determinateExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="determinateExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 
   <section class="demo-section">
     <h2>Indeterminate</h2>
     <div class="interactive-demo">
-      <div class="demo-row" style="width:100%; max-width:400px; padding: 20px 0;">
+      <div
+        class="demo-row"
+        style="width: 100%; max-width: 400px; padding: 20px 0"
+      >
         <m3-progress indeterminate></m3-progress>
       </div>
-      <app-code-block [code]="indeterminateExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="indeterminateExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 </div>

--- a/apps/angular-app/src/pages/quick-start/quick-start.component.css
+++ b/apps/angular-app/src/pages/quick-start/quick-start.component.css
@@ -1,7 +1,8 @@
 .qs-sections {
   display: flex;
   flex-direction: column;
-  max-width: 760px;
+  gap: clamp(16px, 2.4vw, 24px);
+  max-width: 860px;
 }
 
 /* ─── Install grid ───────────────────────────────────────── */
@@ -23,7 +24,7 @@
 /* ─── Demo showcase ──────────────────────────────────────── */
 .demo-showcase {
   border: 1px solid var(--md-sys-color-outline-variant);
-  border-radius: 12px;
+  border-radius: 18px;
   padding: 24px;
   background: var(--md-sys-color-surface-container-low);
   display: flex;
@@ -41,15 +42,20 @@
 }
 
 .demo-image {
-  border-radius: 10px;
-  box-shadow: 0 2px 12px rgba(0,0,0,0.08);
+  border-radius: 14px;
+  box-shadow: 0 12px 32px
+    color-mix(in srgb, var(--md-sys-color-on-surface) 10%, transparent);
   border: 1px solid var(--md-sys-color-outline-variant);
   object-fit: contain;
   max-height: 360px;
 }
 
-.demo-image--desktop { width: 65%; }
-.demo-image--mobile  { width: 22%; }
+.demo-image--desktop {
+  width: 65%;
+}
+.demo-image--mobile {
+  width: 22%;
+}
 
 .demo-cta {
   text-decoration: none;

--- a/apps/angular-app/src/pages/quick-start/quick-start.component.html
+++ b/apps/angular-app/src/pages/quick-start/quick-start.component.html
@@ -1,15 +1,16 @@
 <div class="page-container docs-page">
-  <header class="page-header">
-    <h1>Quick Start</h1>
-    <p class="subtitle">Integrate Material 3 Web Components into any project in minutes.</p>
-  </header>
-
   <div class="qs-sections">
-
     <section class="page-section">
       <h2>CDN — no build step</h2>
-      <p>Import directly in your HTML via jsDelivr. Works in any modern browser with no tooling required.</p>
-      <app-code-block language="html" variant="block" [code]="cdnCode"></app-code-block>
+      <p>
+        Import directly in your HTML via jsDelivr. Works in any modern browser
+        with no tooling required.
+      </p>
+      <app-code-block
+        language="html"
+        variant="block"
+        [code]="cdnCode"
+      ></app-code-block>
     </section>
 
     <section class="page-section">
@@ -18,49 +19,95 @@
       <div class="code-grid">
         <div>
           <p class="code-label">npm</p>
-          <app-code-block language="bash" variant="block" [code]="installCode"></app-code-block>
+          <app-code-block
+            language="bash"
+            variant="block"
+            [code]="installCode"
+          ></app-code-block>
         </div>
         <div>
           <p class="code-label">pnpm</p>
-          <app-code-block language="bash" variant="block" [code]="pnpmCode"></app-code-block>
+          <app-code-block
+            language="bash"
+            variant="block"
+            [code]="pnpmCode"
+          ></app-code-block>
         </div>
       </div>
     </section>
 
     <section class="page-section">
       <h2>Angular</h2>
-      <p>Add <code>CUSTOM_ELEMENTS_SCHEMA</code> to your component or module to prevent template errors for unknown tags.</p>
-      <app-code-block language="typescript" variant="block" [code]="angularCode"></app-code-block>
+      <p>
+        Add <code>CUSTOM_ELEMENTS_SCHEMA</code> to your component or module to
+        prevent template errors for unknown tags.
+      </p>
+      <app-code-block
+        language="typescript"
+        variant="block"
+        [code]="angularCode"
+      ></app-code-block>
     </section>
 
     <section class="page-section">
       <h2>React</h2>
-      <p>React 19+ natively supports Custom Elements. Use the standard <code>onClick</code> handler for button activation.</p>
-      <app-code-block language="jsx" variant="block" [code]="reactCode"></app-code-block>
+      <p>
+        React 19+ natively supports Custom Elements. Use the standard
+        <code>onClick</code> handler for button activation.
+      </p>
+      <app-code-block
+        language="jsx"
+        variant="block"
+        [code]="reactCode"
+      ></app-code-block>
     </section>
 
     <section class="page-section">
       <h2>Vue</h2>
-      <p>Vue has native support for Custom Elements. Use the standard <code>&#64;click</code> directive for button activation.</p>
-      <app-code-block language="html" variant="block" [code]="vueCode"></app-code-block>
+      <p>
+        Vue has native support for Custom Elements. Use the standard
+        <code>&#64;click</code> directive for button activation.
+      </p>
+      <app-code-block
+        language="html"
+        variant="block"
+        [code]="vueCode"
+      ></app-code-block>
     </section>
 
     <section class="qs-section qs-section--demo">
       <h2>Live demo</h2>
-      <p>See all components working together in an interactive task management dashboard — no build step, pure CDN.</p>
+      <p>
+        See all components working together in an interactive task management
+        dashboard — no build step, pure CDN.
+      </p>
       <div class="demo-showcase">
         <div class="demo-images">
-          <img src="sim-desktop.png" alt="Desktop simulation" class="demo-image demo-image--desktop">
-          <img src="sim-mobile.png" alt="Mobile simulation" class="demo-image demo-image--mobile">
+          <img
+            src="sim-desktop.png"
+            alt="Desktop simulation"
+            class="demo-image demo-image--desktop"
+          />
+          <img
+            src="sim-mobile.png"
+            alt="Mobile simulation"
+            class="demo-image demo-image--mobile"
+          />
         </div>
-        <a href="cdn-example.html" target="_blank" rel="noopener" class="demo-cta">
+        <a
+          href="cdn-example.html"
+          target="_blank"
+          rel="noopener"
+          class="demo-cta"
+        >
           <m3-button variant="filled">
-            <span slot="icon" class="material-symbols-outlined">open_in_new</span>
+            <span slot="icon" class="material-symbols-outlined"
+              >open_in_new</span
+            >
             Open live demo
           </m3-button>
         </a>
       </div>
     </section>
-
   </div>
 </div>

--- a/apps/angular-app/src/pages/radio-buttons/radio-button.component.html
+++ b/apps/angular-app/src/pages/radio-buttons/radio-button.component.html
@@ -1,15 +1,12 @@
 <div class="page-container docs-page">
-  <header class="page-header">
-    <h1>Radio Buttons</h1>
-    <p class="subtitle">
-      Radio buttons allow users to select a single option from a group of options. They are best used when users need to see all available options.
-    </p>
-  </header>
-
   <!-- Basic Usage -->
   <section class="demo-section">
     <h2>Basic Usage</h2>
-    <p>Radio buttons allow users to select one option from a group. They follow Material Design 3 specifications with smooth animations and accessibility support.</p>
+    <p>
+      Radio buttons allow users to select one option from a group. They follow
+      Material Design 3 specifications with smooth animations and accessibility
+      support.
+    </p>
 
     <div class="variant-card">
       <div class="variant-header">
@@ -22,22 +19,37 @@
           <label>Unchecked</label>
         </div>
         <div class="radio-item">
-          <m3-radio-button name="demo1" value="option2" checked></m3-radio-button>
+          <m3-radio-button
+            name="demo1"
+            value="option2"
+            checked
+          ></m3-radio-button>
           <label>Checked</label>
         </div>
         <div class="radio-item">
-          <m3-radio-button name="demo1" value="option3" disabled></m3-radio-button>
+          <m3-radio-button
+            name="demo1"
+            value="option3"
+            disabled
+          ></m3-radio-button>
           <label>Disabled</label>
         </div>
       </div>
-      <app-code-block language="html" variant="sample" [code]="basicExample"></app-code-block>
+      <app-code-block
+        language="html"
+        variant="sample"
+        [code]="basicExample"
+      ></app-code-block>
     </div>
   </section>
 
   <!-- Radio Groups -->
   <section class="demo-section">
     <h2>Radio Groups</h2>
-    <p>Radio buttons with the same <code>name</code> attribute form a group where only one can be selected at a time.</p>
+    <p>
+      Radio buttons with the same <code>name</code> attribute form a group where
+      only one can be selected at a time.
+    </p>
 
     <div class="variant-card">
       <div class="variant-header">
@@ -46,45 +58,57 @@
       <p>Example of a radio group for theme selection:</p>
       <div class="radio-group">
         <div class="radio-item">
-          <m3-radio-button 
+          <m3-radio-button
             name="theme"
             value="light"
             [checked]="selectedTheme === 'light'"
             (change)="onRadioChange($event, 'theme')"
-            aria-label="Light theme">
+            aria-label="Light theme"
+          >
           </m3-radio-button>
           <label>Light</label>
         </div>
         <div class="radio-item">
-          <m3-radio-button 
+          <m3-radio-button
             name="theme"
             value="dark"
             [checked]="selectedTheme === 'dark'"
             (change)="onRadioChange($event, 'theme')"
-            aria-label="Dark theme">
+            aria-label="Dark theme"
+          >
           </m3-radio-button>
           <label>Dark</label>
         </div>
         <div class="radio-item">
-          <m3-radio-button 
+          <m3-radio-button
             name="theme"
             value="auto"
             [checked]="selectedTheme === 'auto'"
             (change)="onRadioChange($event, 'theme')"
-            aria-label="Auto theme">
+            aria-label="Auto theme"
+          >
           </m3-radio-button>
           <label>Auto</label>
         </div>
       </div>
-      <p class="selection-info">Selected: <strong>{{ selectedTheme }}</strong></p>
-      <app-code-block language="html" variant="sample" [code]="groupExample"></app-code-block>
+      <p class="selection-info">
+        Selected: <strong>{{ selectedTheme }}</strong>
+      </p>
+      <app-code-block
+        language="html"
+        variant="sample"
+        [code]="groupExample"
+      ></app-code-block>
     </div>
   </section>
 
   <!-- Interactive Examples -->
   <section class="demo-section">
     <h2>Interactive Examples</h2>
-    <p>Radio buttons emit events when their state changes, allowing you to react to user selections.</p>
+    <p>
+      Radio buttons emit events when their state changes, allowing you to react
+      to user selections.
+    </p>
 
     <div class="variant-card">
       <div class="variant-header">
@@ -92,91 +116,133 @@
       </div>
       <p>Example of radio buttons used in a settings interface:</p>
       <div class="settings-panel">
-        <div class="setting-item" (click)="radioSmall.click()" (keydown.enter)="radioSmall.click()">
+        <div
+          class="setting-item"
+          (click)="radioSmall.click()"
+          (keydown.enter)="radioSmall.click()"
+        >
           <div class="setting-info">
             <h4>Small</h4>
             <p>Compact size for dense layouts</p>
           </div>
-          <m3-radio-button 
+          <m3-radio-button
             #radioSmall
             name="size"
             value="small"
             size="small"
             [checked]="selectedSize === 'small'"
             (change)="onRadioChange($event, 'size')"
-            aria-label="Small size">
+            aria-label="Small size"
+          >
           </m3-radio-button>
         </div>
-        <div class="setting-item" (click)="radioMedium.click()" (keydown.enter)="radioMedium.click()">
+        <div
+          class="setting-item"
+          (click)="radioMedium.click()"
+          (keydown.enter)="radioMedium.click()"
+        >
           <div class="setting-info">
             <h4>Medium</h4>
             <p>Default size for most use cases</p>
           </div>
-          <m3-radio-button 
+          <m3-radio-button
             #radioMedium
             name="size"
             value="medium"
             size="medium"
             [checked]="selectedSize === 'medium'"
             (change)="onRadioChange($event, 'size')"
-            aria-label="Medium size">
+            aria-label="Medium size"
+          >
           </m3-radio-button>
         </div>
-        <div class="setting-item" (click)="radioLarge.click()" (keydown.enter)="radioLarge.click()">
+        <div
+          class="setting-item"
+          (click)="radioLarge.click()"
+          (keydown.enter)="radioLarge.click()"
+        >
           <div class="setting-info">
             <h4>Large</h4>
             <p>Larger size for increased prominence</p>
           </div>
-          <m3-radio-button 
+          <m3-radio-button
             #radioLarge
             name="size"
             value="large"
             size="large"
             [checked]="selectedSize === 'large'"
             (change)="onRadioChange($event, 'size')"
-            aria-label="Large size">
+            aria-label="Large size"
+          >
           </m3-radio-button>
         </div>
       </div>
-      <p class="selection-info">Selected size: <strong>{{ selectedSize }}</strong></p>
+      <p class="selection-info">
+        Selected size: <strong>{{ selectedSize }}</strong>
+      </p>
     </div>
   </section>
 
   <!-- States -->
   <section class="demo-section">
     <h2>States</h2>
-    <p>Radio buttons can be in different states: enabled, disabled, checked, and unchecked.</p>
+    <p>
+      Radio buttons can be in different states: enabled, disabled, checked, and
+      unchecked.
+    </p>
 
     <div class="variant-card">
       <div class="variant-header">
         <h3>Disabled State</h3>
       </div>
-      <p>Disabled radio buttons cannot be interacted with and have reduced opacity.</p>
+      <p>
+        Disabled radio buttons cannot be interacted with and have reduced
+        opacity.
+      </p>
       <div class="demo-radios">
         <div class="radio-item">
-          <m3-radio-button name="disabled1" value="1" disabled></m3-radio-button>
+          <m3-radio-button
+            name="disabled1"
+            value="1"
+            disabled
+          ></m3-radio-button>
           <label>Disabled Unchecked</label>
         </div>
         <div class="radio-item">
-          <m3-radio-button name="disabled1" value="2" checked disabled></m3-radio-button>
+          <m3-radio-button
+            name="disabled1"
+            value="2"
+            checked
+            disabled
+          ></m3-radio-button>
           <label>Disabled Checked</label>
         </div>
       </div>
-      <app-code-block language="html" variant="sample" [code]="disabledExample"></app-code-block>
+      <app-code-block
+        language="html"
+        variant="sample"
+        [code]="disabledExample"
+      ></app-code-block>
     </div>
   </section>
 
   <!-- Accessibility -->
   <section class="demo-section">
     <h2>Accessibility</h2>
-    <p>The radio button component follows Material Design 3 accessibility guidelines:</p>
+    <p>
+      The radio button component follows Material Design 3 accessibility
+      guidelines:
+    </p>
 
     <div class="variant-card">
       <div class="variant-header">
         <h3>ARIA Support</h3>
       </div>
       <ul class="feature-list">
-        <li>✓ Uses proper ARIA attributes (role="radio", aria-checked, aria-disabled)</li>
+        <li>
+          ✓ Uses proper ARIA attributes (role="radio", aria-checked,
+          aria-disabled)
+        </li>
         <li>✓ Supports keyboard navigation (Space and Enter keys)</li>
         <li>✓ Provides focus indicators</li>
         <li>✓ Supports screen readers with aria-label and aria-labelledby</li>
@@ -185,21 +251,33 @@
       <div class="demo-radios">
         <div class="radio-item">
           <label id="option-label">Option A</label>
-          <m3-radio-button name="aria" value="a" aria-labelledby="option-label"></m3-radio-button>
+          <m3-radio-button
+            name="aria"
+            value="a"
+            aria-labelledby="option-label"
+          ></m3-radio-button>
         </div>
         <div class="radio-item">
-          <m3-radio-button name="aria" value="b" aria-label="Option B"></m3-radio-button>
+          <m3-radio-button
+            name="aria"
+            value="b"
+            aria-label="Option B"
+          ></m3-radio-button>
           <label>Option B</label>
         </div>
       </div>
-      <app-code-block language="html" variant="sample" [code]="ariaExample"></app-code-block>
+      <app-code-block
+        language="html"
+        variant="sample"
+        [code]="ariaExample"
+      ></app-code-block>
     </div>
   </section>
 
   <!-- Properties & Events -->
   <section class="demo-section">
     <h2>Properties & Events</h2>
-    
+
     <div class="variant-card">
       <div class="variant-header">
         <h3>Properties</h3>
@@ -263,7 +341,10 @@
         <tbody>
           <tr>
             <td><code>change</code></td>
-            <td>Read <code>checked</code> and <code>value</code> from the radio element</td>
+            <td>
+              Read <code>checked</code> and <code>value</code> from the radio
+              element
+            </td>
             <td>Fired when the radio button state changes</td>
           </tr>
         </tbody>

--- a/apps/angular-app/src/pages/search-bar/search-bar.component.html
+++ b/apps/angular-app/src/pages/search-bar/search-bar.component.html
@@ -1,179 +1,227 @@
 <div class="page-container docs-page">
-    <header class="page-header">
-        <h1>Search Bar</h1>
-        <p class="subtitle">Material Design 3 search bar component with leading and trailing content projection slots.</p>
-    </header>
+  <section class="demo-section">
+    <h2>Basic Usage</h2>
 
+    <div class="variant-card">
+      <div class="variant-header">
+        <h3>Basic Search Bar</h3>
+      </div>
+      <div class="demo-container">
+        <m3-search-bar
+          placeholder="Search in your files"
+          [value]="searchValue"
+          (input)="onSearchInput($event)"
+          (keydown.enter)="onSearchSubmit($event)"
+          aria-label="Search"
+        >
+        </m3-search-bar>
+      </div>
+      <app-code-block
+        language="html"
+        variant="sample"
+        [code]="basicExample"
+      ></app-code-block>
+    </div>
+
+    <div class="variant-card">
+      <div class="variant-header">
+        <h3>With Leading Icon</h3>
+      </div>
+      <div class="demo-container">
+        <m3-search-bar
+          placeholder="Search products..."
+          [value]="searchValue"
+          (input)="onSearchInput($event)"
+          (keydown.enter)="onSearchSubmit($event)"
+          aria-label="Search products"
+        >
+          <span slot="leading" class="material-symbols-outlined">search</span>
+        </m3-search-bar>
+      </div>
+      <app-code-block
+        language="html"
+        variant="sample"
+        [code]="leadingIconExample"
+      ></app-code-block>
+    </div>
+
+    <div class="variant-card">
+      <div class="variant-header">
+        <h3>With Leading and Trailing Content</h3>
+      </div>
+      <div class="demo-container">
+        <m3-search-bar
+          #searchBarWithClear
+          placeholder="Search with clear button..."
+          [value]="searchValue"
+          (input)="onSearchInput($event)"
+          (keydown.enter)="onSearchSubmit($event)"
+          aria-label="Search with clear"
+        >
+          <span slot="leading" class="material-symbols-outlined">search</span>
+          @if (searchValue) {
+            <m3-button
+              aria-label="Clear search"
+              icon-only
+              slot="trailing"
+              variant="text"
+              (click)="clearSearch(searchBarWithClear)"
+            >
+              <span slot="icon" class="material-symbols-outlined">close</span>
+            </m3-button>
+          }
+          <m3-button
+            aria-label="Search options"
+            icon-only
+            slot="trailing"
+            variant="text"
+          >
+            <span slot="icon" class="material-symbols-outlined">more_vert</span>
+          </m3-button>
+        </m3-search-bar>
+      </div>
+      <app-code-block
+        language="html"
+        variant="sample"
+        [code]="leadingTrailingExample"
+      ></app-code-block>
+    </div>
+
+    <div class="variant-card">
+      <div class="variant-header">
+        <h3>With Menu Button (Leading)</h3>
+      </div>
+      <div class="demo-container">
+        <m3-search-bar
+          placeholder="Search with menu..."
+          [value]="searchValue"
+          (input)="onSearchInput($event)"
+          (keydown.enter)="onSearchSubmit($event)"
+          aria-label="Search with menu"
+        >
+          <m3-button
+            aria-label="Search menu"
+            icon-only
+            slot="leading"
+            variant="text"
+            class="menu-button"
+            size="small"
+          >
+            <span slot="icon" class="material-symbols-outlined">menu</span>
+          </m3-button>
+        </m3-search-bar>
+      </div>
+      <app-code-block
+        language="html"
+        variant="sample"
+        [code]="menuButtonExample"
+      ></app-code-block>
+    </div>
+
+    <div class="variant-card">
+      <div class="variant-header">
+        <h3>Disabled State</h3>
+      </div>
+      <div class="demo-container">
+        <m3-search-bar
+          placeholder="Disabled search..."
+          [disabled]="true"
+          aria-label="Disabled search"
+        >
+          <span slot="leading" class="material-symbols-outlined">search</span>
+        </m3-search-bar>
+      </div>
+      <app-code-block
+        language="html"
+        variant="sample"
+        [code]="disabledExample"
+      ></app-code-block>
+    </div>
+  </section>
+
+  @if (searchResults.length > 0) {
     <section class="demo-section">
-        <h2>Basic Usage</h2>
-
-        <div class="variant-card">
-            <div class="variant-header">
-                <h3>Basic Search Bar</h3>
+      <h2>Search Results</h2>
+      <m3-card>
+        <div class="results-container">
+          @for (result of searchResults; track result) {
+            <div class="result-item">
+              {{ result }}
             </div>
-            <div class="demo-container">
-                <m3-search-bar
-                    placeholder="Search in your files"
-                    [value]="searchValue"
-                    (input)="onSearchInput($event)"
-                    (keydown.enter)="onSearchSubmit($event)"
-                    aria-label="Search">
-                </m3-search-bar>
-            </div>
-            <app-code-block language="html" variant="sample" [code]="basicExample"></app-code-block>
+          }
         </div>
-
-        <div class="variant-card">
-            <div class="variant-header">
-                <h3>With Leading Icon</h3>
-            </div>
-            <div class="demo-container">
-                <m3-search-bar
-                    placeholder="Search products..."
-                    [value]="searchValue"
-                    (input)="onSearchInput($event)"
-                    (keydown.enter)="onSearchSubmit($event)"
-                    aria-label="Search products">
-                    <span slot="leading" class="material-symbols-outlined">search</span>
-                </m3-search-bar>
-            </div>
-            <app-code-block language="html" variant="sample" [code]="leadingIconExample"></app-code-block>
-        </div>
-
-        <div class="variant-card">
-            <div class="variant-header">
-                <h3>With Leading and Trailing Content</h3>
-            </div>
-            <div class="demo-container">
-                <m3-search-bar
-                    #searchBarWithClear
-                    placeholder="Search with clear button..."
-                    [value]="searchValue"
-                    (input)="onSearchInput($event)"
-                    (keydown.enter)="onSearchSubmit($event)"
-                    aria-label="Search with clear">
-                    <span slot="leading" class="material-symbols-outlined">search</span>
-                    @if (searchValue) {
-                        <m3-button aria-label="Clear search" icon-only slot="trailing" variant="text" (click)="clearSearch(searchBarWithClear)">
-                            <span slot="icon" class="material-symbols-outlined">close</span>
-                        </m3-button>
-                    }
-                    <m3-button aria-label="Search options" icon-only slot="trailing" variant="text">
-                        <span slot="icon" class="material-symbols-outlined">more_vert</span>
-                    </m3-button>
-                </m3-search-bar>
-            </div>
-            <app-code-block language="html" variant="sample" [code]="leadingTrailingExample"></app-code-block>
-        </div>
-
-        <div class="variant-card">
-            <div class="variant-header">
-                <h3>With Menu Button (Leading)</h3>
-            </div>
-            <div class="demo-container">
-                <m3-search-bar
-                    placeholder="Search with menu..."
-                    [value]="searchValue"
-                    (input)="onSearchInput($event)"
-                    (keydown.enter)="onSearchSubmit($event)"
-                    aria-label="Search with menu">
-                    <m3-button aria-label="Search menu" icon-only slot="leading" variant="text" class="menu-button" size="small">
-                        <span slot="icon" class="material-symbols-outlined">menu</span>
-                    </m3-button>
-                </m3-search-bar>
-            </div>
-            <app-code-block language="html" variant="sample" [code]="menuButtonExample"></app-code-block>
-        </div>
-
-        <div class="variant-card">
-            <div class="variant-header">
-                <h3>Disabled State</h3>
-            </div>
-            <div class="demo-container">
-                <m3-search-bar
-                    placeholder="Disabled search..."
-                    [disabled]="true"
-                    aria-label="Disabled search">
-                    <span slot="leading" class="material-symbols-outlined">search</span>
-                </m3-search-bar>
-            </div>
-            <app-code-block language="html" variant="sample" [code]="disabledExample"></app-code-block>
-        </div>
+      </m3-card>
     </section>
+  }
 
-    @if (searchResults.length > 0) {
-        <section class="demo-section">
-            <h2>Search Results</h2>
-            <m3-card>
-                <div class="results-container">
-                    @for (result of searchResults; track result) {
-                        <div class="result-item">
-                            {{ result }}
-                        </div>
-                    }
-                </div>
-            </m3-card>
-        </section>
-    }
+  <section class="demo-section">
+    <h2>API Reference</h2>
 
-    <section class="demo-section">
-        <h2>API Reference</h2>
-
-        <div class="variant-card">
-            <div class="variant-header">
-                <h3>Properties</h3>
-            </div>
-            <div class="properties-list">
-                <div class="property-item">
-                    <strong>placeholder</strong>: <code>string</code> - Placeholder text for the input
-                </div>
-                <div class="property-item">
-                    <strong>value</strong>: <code>string</code> - Current value of the input
-                </div>
-                <div class="property-item">
-                    <strong>disabled</strong>: <code>boolean</code> - Disables the search bar
-                </div>
-                <div class="property-item">
-                    <strong>name</strong>: <code>string | null</code> - Name attribute for form submission
-                </div>
-                <div class="property-item">
-                    <strong>form</strong>: <code>string | null</code> - Form attribute to associate with a form
-                </div>
-                <div class="property-item">
-                    <strong>aria-label</strong>: <code>string | null</code> - ARIA label for accessibility
-                </div>
-            </div>
+    <div class="variant-card">
+      <div class="variant-header">
+        <h3>Properties</h3>
+      </div>
+      <div class="properties-list">
+        <div class="property-item">
+          <strong>placeholder</strong>: <code>string</code> - Placeholder text
+          for the input
         </div>
-
-        <div class="variant-card">
-            <div class="variant-header">
-                <h3>Slots</h3>
-            </div>
-            <div class="properties-list">
-                <div class="property-item">
-                    <strong>leading</strong>: Content to display before the input (e.g., search icon, menu button)
-                </div>
-                <div class="property-item">
-                    <strong>trailing</strong>: Content to display after the input (e.g., clear button, avatar)
-                </div>
-            </div>
+        <div class="property-item">
+          <strong>value</strong>: <code>string</code> - Current value of the
+          input
         </div>
-
-        <div class="variant-card">
-            <div class="variant-header">
-                <h3>Events</h3>
-            </div>
-            <div class="properties-list">
-                <div class="property-item">
-                    <strong>input</strong>: Native event fired when the input value changes
-                </div>
-                <div class="property-item">
-                    <strong>change</strong>: Native event fired when the value is committed or cleared
-                </div>
-                <div class="property-item">
-                    <strong>submit</strong>: Use the owner form's native submit event
-                </div>
-            </div>
+        <div class="property-item">
+          <strong>disabled</strong>: <code>boolean</code> - Disables the search
+          bar
         </div>
-    </section>
+        <div class="property-item">
+          <strong>name</strong>: <code>string | null</code> - Name attribute for
+          form submission
+        </div>
+        <div class="property-item">
+          <strong>form</strong>: <code>string | null</code> - Form attribute to
+          associate with a form
+        </div>
+        <div class="property-item">
+          <strong>aria-label</strong>: <code>string | null</code> - ARIA label
+          for accessibility
+        </div>
+      </div>
+    </div>
+
+    <div class="variant-card">
+      <div class="variant-header">
+        <h3>Slots</h3>
+      </div>
+      <div class="properties-list">
+        <div class="property-item">
+          <strong>leading</strong>: Content to display before the input (e.g.,
+          search icon, menu button)
+        </div>
+        <div class="property-item">
+          <strong>trailing</strong>: Content to display after the input (e.g.,
+          clear button, avatar)
+        </div>
+      </div>
+    </div>
+
+    <div class="variant-card">
+      <div class="variant-header">
+        <h3>Events</h3>
+      </div>
+      <div class="properties-list">
+        <div class="property-item">
+          <strong>input</strong>: Native event fired when the input value
+          changes
+        </div>
+        <div class="property-item">
+          <strong>change</strong>: Native event fired when the value is
+          committed or cleared
+        </div>
+        <div class="property-item">
+          <strong>submit</strong>: Use the owner form's native submit event
+        </div>
+      </div>
+    </div>
+  </section>
 </div>

--- a/apps/angular-app/src/pages/slider/slider.component.html
+++ b/apps/angular-app/src/pages/slider/slider.component.html
@@ -1,19 +1,22 @@
 <div class="page-container docs-page">
-  <header class="page-header">
-    <h1>Slider</h1>
-    <p class="subtitle">
-      Material 3 Expressive Sliders allow users to make selections from a range of values.
-    </p>
-  </header>
-
   <section class="demo-section">
     <h2>Usage</h2>
-    <p>Sliders reflect a range of values along a bar, from which users may select a single value.</p>
+    <p>
+      Sliders reflect a range of values along a bar, from which users may select
+      a single value.
+    </p>
     <div class="interactive-demo">
-      <div class="demo-row" style="width: 100%; max-width: 400px; padding: 24px 0;">
-        <m3-slider min="0" max="100" value="50" style="width: 100%;"></m3-slider>
+      <div
+        class="demo-row"
+        style="width: 100%; max-width: 400px; padding: 24px 0"
+      >
+        <m3-slider min="0" max="100" value="50" style="width: 100%"></m3-slider>
       </div>
-      <app-code-block [code]="basicExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="basicExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 
@@ -21,27 +24,73 @@
     <h2>Disabled State</h2>
     <p>Sliders can be disabled to prevent user interaction.</p>
     <div class="interactive-demo">
-      <div class="demo-row" style="width: 100%; max-width: 400px; padding: 24px 0; flex-direction: column; gap: 32px;">
-        <m3-slider disabled value="30" style="width: 100%;"></m3-slider>
-        <m3-slider disabled value="75" style="width: 100%;"></m3-slider>
+      <div
+        class="demo-row"
+        style="
+          width: 100%;
+          max-width: 400px;
+          padding: 24px 0;
+          flex-direction: column;
+          gap: 32px;
+        "
+      >
+        <m3-slider disabled value="30" style="width: 100%"></m3-slider>
+        <m3-slider disabled value="75" style="width: 100%"></m3-slider>
       </div>
-      <app-code-block [code]="disabledExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="disabledExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 
   <section class="demo-section">
     <h2>Interactive Example</h2>
-    <p>Listen to the native <code>input</code> event to respond while the value changes.</p>
+    <p>
+      Listen to the native <code>input</code> event to respond while the value
+      changes.
+    </p>
     <div class="interactive-demo">
-      <div class="demo-row" style="width: 100%; max-width: 400px; padding: 24px 0; flex-direction: column; gap: 16px;">
-        <div style="width: 100%; display: flex; align-items: center; gap: 16px;">
-            <span class="material-symbols-outlined" style="color: var(--md-sys-color-on-surface-variant)">volume_down</span>
-            <m3-slider aria-label="Volume" min="0" max="100" [value]="volume" (input)="onSliderChange($event, 'volume')" style="flex: 1;"></m3-slider>
-            <span class="material-symbols-outlined" style="color: var(--md-sys-color-on-surface-variant)">volume_up</span>
+      <div
+        class="demo-row"
+        style="
+          width: 100%;
+          max-width: 400px;
+          padding: 24px 0;
+          flex-direction: column;
+          gap: 16px;
+        "
+      >
+        <div style="width: 100%; display: flex; align-items: center; gap: 16px">
+          <span
+            class="material-symbols-outlined"
+            style="color: var(--md-sys-color-on-surface-variant)"
+            >volume_down</span
+          >
+          <m3-slider
+            aria-label="Volume"
+            min="0"
+            max="100"
+            [value]="volume"
+            (input)="onSliderChange($event, 'volume')"
+            style="flex: 1"
+          ></m3-slider>
+          <span
+            class="material-symbols-outlined"
+            style="color: var(--md-sys-color-on-surface-variant)"
+            >volume_up</span
+          >
         </div>
-        <div style="color: var(--md-sys-color-on-surface); font-weight: 500;">Volume Value: {{ volume }}</div>
+        <div style="color: var(--md-sys-color-on-surface); font-weight: 500">
+          Volume Value: {{ volume }}
+        </div>
       </div>
-      <app-code-block [code]="interactiveExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="interactiveExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 </div>

--- a/apps/angular-app/src/pages/snackbar/snackbar.component.html
+++ b/apps/angular-app/src/pages/snackbar/snackbar.component.html
@@ -1,21 +1,26 @@
 <div class="page-container docs-page">
-  <header class="page-header">
-    <h1>Snackbar</h1>
-    <p class="subtitle">Snackbars provide brief messages about app processes with expressive animations.</p>
-  </header>
-
   <section class="demo-section">
     <h2>Basic</h2>
     <div class="interactive-demo">
       <div class="demo-row">
-        <m3-button variant="filled" (click)="showBasic.set(true)">Show Snackbar</m3-button>
+        <m3-button variant="filled" (click)="showBasic.set(true)"
+          >Show Snackbar</m3-button
+        >
       </div>
       <div class="demo-row snackbar-demo">
-        <m3-snackbar [attr.open]="showBasic() ? '' : null" duration="3000" (snackbar-dismiss)="showBasic.set(false)">
+        <m3-snackbar
+          [attr.open]="showBasic() ? '' : null"
+          duration="3000"
+          (snackbar-dismiss)="showBasic.set(false)"
+        >
           Settings saved successfully
         </m3-snackbar>
       </div>
-      <app-code-block [code]="basicExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="basicExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 
@@ -23,15 +28,25 @@
     <h2>With Action</h2>
     <div class="interactive-demo">
       <div class="demo-row">
-        <m3-button variant="filled" (click)="showAction.set(true)">Show Snackbar</m3-button>
+        <m3-button variant="filled" (click)="showAction.set(true)"
+          >Show Snackbar</m3-button
+        >
       </div>
       <div class="demo-row snackbar-demo">
-        <m3-snackbar [attr.open]="showAction() ? '' : null" duration="5000" (snackbar-dismiss)="showAction.set(false)">
+        <m3-snackbar
+          [attr.open]="showAction() ? '' : null"
+          duration="5000"
+          (snackbar-dismiss)="showAction.set(false)"
+        >
           Message deleted
           <m3-button slot="action" variant="text">Undo</m3-button>
         </m3-snackbar>
       </div>
-      <app-code-block [code]="actionExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="actionExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 
@@ -39,15 +54,27 @@
     <h2>Two-Line</h2>
     <div class="interactive-demo">
       <div class="demo-row">
-        <m3-button variant="filled" (click)="showTwoLine.set(true)">Show Snackbar</m3-button>
+        <m3-button variant="filled" (click)="showTwoLine.set(true)"
+          >Show Snackbar</m3-button
+        >
       </div>
       <div class="demo-row snackbar-demo">
-        <m3-snackbar [attr.open]="showTwoLine() ? '' : null" lines="2" duration="6000" (snackbar-dismiss)="showTwoLine.set(false)">
-          This item was moved to trash. It will be deleted permanently in 30 days.
+        <m3-snackbar
+          [attr.open]="showTwoLine() ? '' : null"
+          lines="2"
+          duration="6000"
+          (snackbar-dismiss)="showTwoLine.set(false)"
+        >
+          This item was moved to trash. It will be deleted permanently in 30
+          days.
           <m3-button slot="action" variant="text">Undo</m3-button>
         </m3-snackbar>
       </div>
-      <app-code-block [code]="twoLineExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="twoLineExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 </div>

--- a/apps/angular-app/src/pages/split-button/split-button.component.html
+++ b/apps/angular-app/src/pages/split-button/split-button.component.html
@@ -1,33 +1,50 @@
 <div class="page-container docs-page">
-  <header class="page-header">
-    <h1>Split Button</h1>
-    <p class="subtitle">A primary action paired with a keyboard-complete menu trigger.</p>
-  </header>
-
   <section class="demo-section">
     <h2>Interactive Demo</h2>
     <div class="variant-card">
-      <m3-split-button [open]="menuOpen" menu-label="More send options"
+      <m3-split-button
+        [open]="menuOpen"
+        menu-label="More send options"
         (split-button-click)="handlePrimaryAction()"
-        (split-button-open-change)="handleMenuChange($event)">
+        (split-button-open-change)="handleMenuChange($event)"
+      >
         Send
-        <m3-menu slot="menu" placement="bottom-end" (menu-item-select)="handleMenuItemSelect($event)">
+        <m3-menu
+          slot="menu"
+          placement="bottom-end"
+          (menu-item-select)="handleMenuItemSelect($event)"
+        >
           <m3-menu-item value="schedule-send">Schedule send</m3-menu-item>
           <m3-menu-item value="save-draft">Save draft</m3-menu-item>
           <m3-menu-item value="send-test">Send test</m3-menu-item>
         </m3-menu>
       </m3-split-button>
-      <p style="margin: 12px 0 0;">Last interaction: <code>{{ lastInteraction }}</code></p>
-      <app-code-block language="html" variant="sample" [code]="basicExample"></app-code-block>
+      <p style="margin: 12px 0 0">
+        Last interaction: <code>{{ lastInteraction }}</code>
+      </p>
+      <app-code-block
+        language="html"
+        variant="sample"
+        [code]="basicExample"
+      ></app-code-block>
     </div>
   </section>
 
   <section class="demo-section accessibility">
     <h2>♿ Accessibility</h2>
     <ul class="feature-list">
-      <li><strong>Keyboard:</strong> Arrow keys, Home, and End open and enter the menu.</li>
-      <li><strong>Focus:</strong> Escape and outside click return focus to the menu trigger.</li>
-      <li><strong>ARIA:</strong> The trigger exposes a real <code>aria-controls</code> relationship.</li>
+      <li>
+        <strong>Keyboard:</strong> Arrow keys, Home, and End open and enter the
+        menu.
+      </li>
+      <li>
+        <strong>Focus:</strong> Escape and outside click return focus to the
+        menu trigger.
+      </li>
+      <li>
+        <strong>ARIA:</strong> The trigger exposes a real
+        <code>aria-controls</code> relationship.
+      </li>
     </ul>
   </section>
 </div>

--- a/apps/angular-app/src/pages/switches/switch.component.html
+++ b/apps/angular-app/src/pages/switches/switch.component.html
@@ -1,15 +1,12 @@
 <div class="page-container docs-page">
-  <header class="page-header">
-    <h1>Switches</h1>
-    <p class="subtitle">
-      Switches toggle the state of a single setting on or off. They are the preferred way to adjust settings on mobile.
-    </p>
-  </header>
-
   <!-- Basic Usage -->
   <section class="demo-section">
     <h2>Basic Usage</h2>
-    <p>Switches allow users to toggle between on and off states. They follow Material Design 3 specifications with smooth animations and accessibility support.</p>
+    <p>
+      Switches allow users to toggle between on and off states. They follow
+      Material Design 3 specifications with smooth animations and accessibility
+      support.
+    </p>
 
     <div class="variant-card">
       <div class="variant-header">
@@ -26,20 +23,29 @@
           <m3-switch checked></m3-switch>
         </div>
       </div>
-      <app-code-block language="html" variant="sample" [code]="basicExample"></app-code-block>
+      <app-code-block
+        language="html"
+        variant="sample"
+        [code]="basicExample"
+      ></app-code-block>
     </div>
   </section>
 
   <!-- States -->
   <section class="demo-section">
     <h2>States</h2>
-    <p>Switches can be in different states: enabled, disabled, checked, and unchecked.</p>
+    <p>
+      Switches can be in different states: enabled, disabled, checked, and
+      unchecked.
+    </p>
 
     <div class="variant-card">
       <div class="variant-header">
         <h3>Disabled State</h3>
       </div>
-      <p>Disabled switches cannot be interacted with and have reduced opacity.</p>
+      <p>
+        Disabled switches cannot be interacted with and have reduced opacity.
+      </p>
       <div class="demo-switches">
         <div class="switch-item">
           <label>Disabled Off</label>
@@ -50,14 +56,21 @@
           <m3-switch checked disabled></m3-switch>
         </div>
       </div>
-      <app-code-block language="html" variant="sample" [code]="disabledExample"></app-code-block>
+      <app-code-block
+        language="html"
+        variant="sample"
+        [code]="disabledExample"
+      ></app-code-block>
     </div>
   </section>
 
   <!-- Interactive Examples -->
   <section class="demo-section">
     <h2>Interactive Examples</h2>
-    <p>Switches emit events when their state changes, allowing you to react to user interactions.</p>
+    <p>
+      Switches emit events when their state changes, allowing you to react to
+      user interactions.
+    </p>
 
     <div class="variant-card">
       <div class="variant-header">
@@ -70,10 +83,11 @@
             <h4>Enable Notifications</h4>
             <p>Receive push notifications for important updates</p>
           </div>
-          <m3-switch 
+          <m3-switch
             [checked]="notificationsEnabled"
             (change)="onSwitchChange($event, 'notifications')"
-            aria-label="Enable notifications">
+            aria-label="Enable notifications"
+          >
           </m3-switch>
         </div>
         <div class="setting-item">
@@ -81,10 +95,11 @@
             <h4>Dark Mode</h4>
             <p>Switch to dark theme for better viewing in low light</p>
           </div>
-          <m3-switch 
+          <m3-switch
             [checked]="darkModeEnabled"
             (change)="onSwitchChange($event, 'darkMode')"
-            aria-label="Enable dark mode">
+            aria-label="Enable dark mode"
+          >
           </m3-switch>
         </div>
         <div class="setting-item">
@@ -92,10 +107,11 @@
             <h4>Auto-save</h4>
             <p>Automatically save your work as you type</p>
           </div>
-          <m3-switch 
+          <m3-switch
             [checked]="autoSaveEnabled"
             (change)="onSwitchChange($event, 'autoSave')"
-            aria-label="Enable auto-save">
+            aria-label="Enable auto-save"
+          >
           </m3-switch>
         </div>
         <div class="setting-item">
@@ -103,28 +119,38 @@
             <h4>Location Services</h4>
             <p>Allow apps to access your location</p>
           </div>
-          <m3-switch 
+          <m3-switch
             [checked]="locationEnabled"
             (change)="onSwitchChange($event, 'location')"
-            aria-label="Enable location services">
+            aria-label="Enable location services"
+          >
           </m3-switch>
         </div>
       </div>
-      <app-code-block language="html" variant="sample" [code]="interactiveExample"></app-code-block>
+      <app-code-block
+        language="html"
+        variant="sample"
+        [code]="interactiveExample"
+      ></app-code-block>
     </div>
   </section>
 
   <!-- Accessibility -->
   <section class="demo-section">
     <h2>Accessibility</h2>
-    <p>The switch component follows Material Design 3 accessibility guidelines:</p>
+    <p>
+      The switch component follows Material Design 3 accessibility guidelines:
+    </p>
 
     <div class="variant-card">
       <div class="variant-header">
         <h3>ARIA Support</h3>
       </div>
       <ul class="feature-list">
-        <li>✓ Uses proper ARIA attributes (role="switch", aria-checked, aria-disabled)</li>
+        <li>
+          ✓ Uses proper ARIA attributes (role="switch", aria-checked,
+          aria-disabled)
+        </li>
         <li>✓ Supports keyboard navigation (Space and Enter keys)</li>
         <li>✓ Provides focus indicators</li>
         <li>✓ Supports screen readers with aria-label and aria-labelledby</li>
@@ -138,14 +164,18 @@
           <m3-switch aria-label="Enable Bluetooth"></m3-switch>
         </div>
       </div>
-      <app-code-block language="html" variant="sample" [code]="ariaExample"></app-code-block>
+      <app-code-block
+        language="html"
+        variant="sample"
+        [code]="ariaExample"
+      ></app-code-block>
     </div>
   </section>
 
   <!-- Properties & Events -->
   <section class="demo-section">
     <h2>Properties & Events</h2>
-    
+
     <div class="variant-card">
       <div class="variant-header">
         <h3>Properties</h3>

--- a/apps/angular-app/src/pages/tabs/tabs.component.html
+++ b/apps/angular-app/src/pages/tabs/tabs.component.html
@@ -1,12 +1,4 @@
 <div class="page-container docs-page">
-  <header class="page-header">
-    <h1>Tabs</h1>
-    <p class="subtitle">
-      Tabs organize content across different screens, data sets, and other
-      interactions.
-    </p>
-  </header>
-
   <section class="demo-section">
     <h2>Usage</h2>
     <div class="interactive-demo">

--- a/apps/angular-app/src/pages/text-field/text-field.component.html
+++ b/apps/angular-app/src/pages/text-field/text-field.component.html
@@ -1,11 +1,4 @@
 <div class="page-container docs-page">
-  <header class="page-header">
-    <h1>Text Field</h1>
-    <p class="subtitle">
-      Material 3 Expressive Text Fields let users enter and edit text.
-    </p>
-  </header>
-
   <section class="demo-section">
     <h2>Usage</h2>
     <p>

--- a/apps/angular-app/src/pages/tooltip/tooltip.component.html
+++ b/apps/angular-app/src/pages/tooltip/tooltip.component.html
@@ -1,30 +1,42 @@
 <div class="page-container docs-page">
-  <header class="page-header">
-    <h1>Tooltip</h1>
-    <p class="subtitle">Tooltips display informative text when users hover over, focus on, or tap an element.</p>
-  </header>
-
   <section class="demo-section">
     <h2>Plain Tooltip</h2>
     <div class="interactive-demo">
       <div class="demo-row">
-        <m3-tooltip text="Save document" placement="top"><m3-button>Hover me</m3-button></m3-tooltip>
-        <m3-tooltip text="Delete item" placement="bottom"><m3-button variant="outlined">Bottom</m3-button></m3-tooltip>
+        <m3-tooltip text="Save document" placement="top"
+          ><m3-button>Hover me</m3-button></m3-tooltip
+        >
+        <m3-tooltip text="Delete item" placement="bottom"
+          ><m3-button variant="outlined">Bottom</m3-button></m3-tooltip
+        >
       </div>
-      <app-code-block [code]="basicExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="basicExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 
   <section class="demo-section">
     <h2>Interactive Rich Tooltip</h2>
-    <p>Move from the trigger into the surface, or use the link with the keyboard. Press Escape to dismiss.</p>
+    <p>
+      Move from the trigger into the surface, or use the link with the keyboard.
+      Press Escape to dismiss.
+    </p>
     <div class="interactive-demo">
       <m3-tooltip variant="rich" placement="right">
         <m3-button variant="outlined">More details</m3-button>
         <strong slot="title">Storage limit</strong>
-        <span slot="content">You have 2 GB remaining. <a href="/storage">Manage storage</a></span>
+        <span slot="content"
+          >You have 2 GB remaining. <a href="/storage">Manage storage</a></span
+        >
       </m3-tooltip>
-      <app-code-block [code]="richExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="richExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 </div>

--- a/apps/angular-app/src/pages/top-app-bar/top-app-bar.component.html
+++ b/apps/angular-app/src/pages/top-app-bar/top-app-bar.component.html
@@ -1,25 +1,36 @@
 <div class="page-container docs-page">
-  <header class="page-header">
-    <h1>Top App Bar</h1>
-    <p class="subtitle">Top app bars display navigation, title, and actions at the top of the screen.</p>
-  </header>
-
   <section class="demo-section">
     <h2>Small (Default)</h2>
     <div class="interactive-demo">
       <div class="demo-row">
         <div class="app-bar-demo">
           <m3-top-app-bar>
-            <m3-icon-button slot="navigation-icon" aria-label="Menu"><span class="material-symbols-outlined">menu</span></m3-icon-button>
+            <m3-icon-button slot="navigation-icon" aria-label="Menu"
+              ><span class="material-symbols-outlined"
+                >menu</span
+              ></m3-icon-button
+            >
             My App
             <span slot="actions">
-              <m3-icon-button aria-label="Search"><span class="material-symbols-outlined">search</span></m3-icon-button>
-              <m3-icon-button aria-label="More"><span class="material-symbols-outlined">more_vert</span></m3-icon-button>
+              <m3-icon-button aria-label="Search"
+                ><span class="material-symbols-outlined"
+                  >search</span
+                ></m3-icon-button
+              >
+              <m3-icon-button aria-label="More"
+                ><span class="material-symbols-outlined"
+                  >more_vert</span
+                ></m3-icon-button
+              >
             </span>
           </m3-top-app-bar>
         </div>
       </div>
-      <app-code-block [code]="smallExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="smallExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 
@@ -29,12 +40,20 @@
       <div class="demo-row">
         <div class="app-bar-demo">
           <m3-top-app-bar variant="center-aligned">
-            <m3-icon-button slot="navigation-icon" aria-label="Back"><span class="material-symbols-outlined">arrow_back</span></m3-icon-button>
+            <m3-icon-button slot="navigation-icon" aria-label="Back"
+              ><span class="material-symbols-outlined"
+                >arrow_back</span
+              ></m3-icon-button
+            >
             Page Title
           </m3-top-app-bar>
         </div>
       </div>
-      <app-code-block [code]="centerExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="centerExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 
@@ -44,12 +63,20 @@
       <div class="demo-row">
         <div class="app-bar-demo">
           <m3-top-app-bar variant="medium">
-            <m3-icon-button slot="navigation-icon" aria-label="Menu"><span class="material-symbols-outlined">menu</span></m3-icon-button>
+            <m3-icon-button slot="navigation-icon" aria-label="Menu"
+              ><span class="material-symbols-outlined"
+                >menu</span
+              ></m3-icon-button
+            >
             Headline
           </m3-top-app-bar>
         </div>
       </div>
-      <app-code-block [code]="mediumExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="mediumExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 
@@ -59,12 +86,20 @@
       <div class="demo-row">
         <div class="app-bar-demo">
           <m3-top-app-bar variant="large">
-            <m3-icon-button slot="navigation-icon" aria-label="Menu"><span class="material-symbols-outlined">menu</span></m3-icon-button>
+            <m3-icon-button slot="navigation-icon" aria-label="Menu"
+              ><span class="material-symbols-outlined"
+                >menu</span
+              ></m3-icon-button
+            >
             Large Headline
           </m3-top-app-bar>
         </div>
       </div>
-      <app-code-block [code]="largeExample" language="html" variant="sample"></app-code-block>
+      <app-code-block
+        [code]="largeExample"
+        language="html"
+        variant="sample"
+      ></app-code-block>
     </div>
   </section>
 </div>

--- a/apps/angular-app/src/styles.css
+++ b/apps/angular-app/src/styles.css
@@ -1,16 +1,20 @@
-@import "highlight.js/styles/github-dark.css";
-@import "../../../tokens/generated/light.css";
-@import "../../../tokens/generated/dark.css";
-@import "../../../tokens/generated/high-contrast.css";
+@import 'highlight.js/styles/github-dark.css';
+@import '../../../tokens/generated/light.css';
+@import '../../../tokens/generated/dark.css';
+@import '../../../tokens/generated/high-contrast.css';
+@import './pages/home/home-preview.css';
 
 /* ─── Reset ─────────────────────────────────────────────── */
-*, *::before, *::after {
+*,
+*::before,
+*::after {
   margin: 0;
   padding: 0;
   box-sizing: border-box;
 }
 
-html, body {
+html,
+body {
   height: 100%;
   width: 100%;
 }
@@ -20,7 +24,9 @@ html, body {
    duration override from the generated token stylesheets. */
 @media (prefers-reduced-motion: reduce) {
   /* motion-literal-exempt: static reduced-motion final states. */
-  *, *::before, *::after {
+  *,
+  *::before,
+  *::after {
     animation-duration: 1ms !important;
     animation-delay: 0ms !important;
     animation-iteration-count: 1 !important;
@@ -30,9 +36,9 @@ html, body {
   }
 }
 
-:root[data-motion="reduced"] *,
-:root[data-motion="reduced"] *::before,
-:root[data-motion="reduced"] *::after {
+:root[data-motion='reduced'] *,
+:root[data-motion='reduced'] *::before,
+:root[data-motion='reduced'] *::after {
   /* motion-literal-exempt: demo verification mode resolves to static states. */
   animation-duration: 1ms !important;
   animation-delay: 0ms !important;
@@ -78,15 +84,18 @@ html, body {
   --md-sys-color-outline-variant: #e5e7eb;
 
   /* Elevation */
-  --md-sys-elevation-level2: 0 1px 3px rgba(0,0,0,.08), 0 1px 2px rgba(0,0,0,.06);
+  --md-sys-elevation-level2:
+    0 1px 3px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.06);
 
   /* Typography */
-  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  --font-mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', ui-monospace, monospace;
+  --font-sans:
+    'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-mono:
+    'JetBrains Mono', 'Fira Code', 'Cascadia Code', ui-monospace, monospace;
 }
 
 /* ─── Design tokens – dark ──────────────────────────────── */
-:root[theme="dark"] {
+:root[theme='dark'] {
   --md-sys-color-primary: #818cf8;
   --md-sys-color-primary-hover: #939cf9;
   --md-sys-color-on-primary: #1e1b4b;
@@ -115,11 +124,12 @@ html, body {
   --md-sys-color-outline: #374151;
   --md-sys-color-outline-variant: #1f2937;
 
-  --md-sys-elevation-level2: 0 1px 3px rgba(0,0,0,.4), 0 1px 2px rgba(0,0,0,.3);
+  --md-sys-elevation-level2:
+    0 1px 3px rgba(0, 0, 0, 0.4), 0 1px 2px rgba(0, 0, 0, 0.3);
 }
 
 /* ─── Theme: Emerald (light) ────────────────────────────── */
-:root[theme="emerald"] {
+:root[theme='emerald'] {
   --md-sys-color-primary: #059669;
   --md-sys-color-primary-hover: #047857;
   --md-sys-color-on-primary: #ffffff;
@@ -145,7 +155,7 @@ html, body {
 }
 
 /* ─── Theme: Emerald (dark) ─────────────────────────────── */
-:root[theme="emerald-dark"] {
+:root[theme='emerald-dark'] {
   --md-sys-color-primary: #34d399;
   --md-sys-color-primary-hover: #6ee7b7;
   --md-sys-color-on-primary: #064e3b;
@@ -171,7 +181,7 @@ html, body {
 }
 
 /* ─── Theme: Rose (light) ───────────────────────────────── */
-:root[theme="rose"] {
+:root[theme='rose'] {
   --md-sys-color-primary: #e11d48;
   --md-sys-color-primary-hover: #be123c;
   --md-sys-color-on-primary: #ffffff;
@@ -197,7 +207,7 @@ html, body {
 }
 
 /* ─── Theme: Rose (dark) ────────────────────────────────── */
-:root[theme="rose-dark"] {
+:root[theme='rose-dark'] {
   --md-sys-color-primary: #fb7185;
   --md-sys-color-primary-hover: #fda4af;
   --md-sys-color-on-primary: #881337;
@@ -223,7 +233,7 @@ html, body {
 }
 
 /* ─── Theme: Amber (light) ──────────────────────────────── */
-:root[theme="amber"] {
+:root[theme='amber'] {
   --md-sys-color-primary: #d97706;
   --md-sys-color-primary-hover: #b45309;
   --md-sys-color-on-primary: #ffffff;
@@ -249,7 +259,7 @@ html, body {
 }
 
 /* ─── Theme: Amber (dark) ───────────────────────────────── */
-:root[theme="amber-dark"] {
+:root[theme='amber-dark'] {
   --md-sys-color-primary: #fbbf24;
   --md-sys-color-primary-hover: #fcd34d;
   --md-sys-color-on-primary: #78350f;
@@ -275,17 +285,23 @@ html, body {
 }
 
 /* ─── Theme transition ───────────────────────────────────── */
-*, *::before, *::after {
+*,
+*::before,
+*::after {
   transition:
-    background-color var(--md-sys-motion-duration-medium1) var(--md-sys-motion-easing-standard),
-    border-color var(--md-sys-motion-duration-medium1) var(--md-sys-motion-easing-standard),
-    color var(--md-sys-motion-duration-medium1) var(--md-sys-motion-easing-standard),
-    box-shadow var(--md-sys-motion-duration-medium1) var(--md-sys-motion-easing-standard);
+    background-color var(--md-sys-motion-duration-medium1)
+      var(--md-sys-motion-easing-standard),
+    border-color var(--md-sys-motion-duration-medium1)
+      var(--md-sys-motion-easing-standard),
+    color var(--md-sys-motion-duration-medium1)
+      var(--md-sys-motion-easing-standard),
+    box-shadow var(--md-sys-motion-duration-medium1)
+      var(--md-sys-motion-easing-standard);
 }
 
 /* Exclude elements where transition would look wrong */
 *:where(
-  [class*="material-symbols"],
+  [class*='material-symbols'],
   m3-button,
   m3-switch,
   m3-slider,
@@ -306,7 +322,12 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
-h1, h2, h3, h4, h5, h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   font-family: var(--font-sans);
   font-weight: 600;
   color: var(--md-sys-color-on-surface);
@@ -314,9 +335,19 @@ h1, h2, h3, h4, h5, h6 {
   letter-spacing: -0.01em;
 }
 
-h1 { font-size: clamp(1.75rem, 3.5vw, 2.5rem); margin-bottom: 0.75rem; }
-h2 { font-size: clamp(1.25rem, 2.5vw, 1.75rem); margin-top: 1.5rem; margin-bottom: 0.75rem; }
-h3 { font-size: 1.125rem; margin-bottom: 0.5rem; }
+h1 {
+  font-size: clamp(1.75rem, 3.5vw, 2.5rem);
+  margin-bottom: 0.75rem;
+}
+h2 {
+  font-size: clamp(1.25rem, 2.5vw, 1.75rem);
+  margin-top: 1.5rem;
+  margin-bottom: 0.75rem;
+}
+h3 {
+  font-size: 1.125rem;
+  margin-bottom: 0.5rem;
+}
 
 p {
   margin-bottom: 1rem;
@@ -324,12 +355,15 @@ p {
   color: var(--md-sys-color-on-surface-variant);
 }
 
-ul, ol {
+ul,
+ol {
   margin: 0.75rem 0;
   padding-inline-start: 1.5rem;
 }
 
-li { line-height: 1.7; }
+li {
+  line-height: 1.7;
+}
 
 code {
   font-family: var(--font-mono);
@@ -343,7 +377,11 @@ code {
 
 /* ─── Material Symbols ───────────────────────────────────── */
 .material-symbols-outlined {
-  font-variation-settings: 'FILL' 0, 'wght' 300, 'GRAD' 0, 'opsz' 20;
+  font-variation-settings:
+    'FILL' 0,
+    'wght' 300,
+    'GRAD' 0,
+    'opsz' 20;
   vertical-align: middle;
   display: inline-flex;
   align-items: center;
@@ -351,7 +389,8 @@ code {
   font-size: 20px;
   /* Hide icon text until font is loaded to prevent FOUT */
   opacity: 0;
-  transition: opacity var(--md-sys-motion-duration-short3) var(--md-sys-motion-easing-standard);
+  transition: opacity var(--md-sys-motion-duration-short3)
+    var(--md-sys-motion-easing-standard);
   -webkit-user-select: none;
   user-select: none;
 }
@@ -359,7 +398,7 @@ code {
 /* Disable tap highlight and text selection on interactive elements */
 button,
 a,
-[role="button"],
+[role='button'],
 m3-button,
 m3-navigation-rail-item,
 m3-navigation-rail-toggle,
@@ -382,69 +421,86 @@ m3-radio-button {
 
 /* Fallback: reveal after the extra-long motion role so icons never stay invisible. */
 @keyframes icons-reveal {
-  to { opacity: 1; }
+  to {
+    opacity: 1;
+  }
 }
 
 .material-symbols-outlined {
-  animation: icons-reveal var(--md-sys-motion-duration-short1) var(--md-sys-motion-duration-extra-long4) forwards;
+  animation: icons-reveal var(--md-sys-motion-duration-short1)
+    var(--md-sys-motion-duration-extra-long4) forwards;
 }
 
-/* ─── Docs page layout ───────────────────────────────────── */
-.docs-page .page-header {
-  margin-bottom: clamp(12px, 2vw, 20px);
-  padding-bottom: clamp(12px, 2vw, 20px);
-  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+/* ─── Shared documentation layout ───────────────────────── */
+.page-container,
+.docs-page {
+  min-width: 0;
 }
 
-.docs-page .page-header h1 {
-  margin: 0;
-  font-size: clamp(1.375rem, 4vw, 2.25rem);
-  font-weight: 700;
-  letter-spacing: -0.02em;
-  line-height: 1.15;
+.docs-page {
+  display: grid;
+  gap: clamp(18px, 2.4vw, 28px);
 }
 
-.docs-page .subtitle,
-.docs-page .page-header > p {
-  margin: 0.5rem 0 0;
-  max-width: 75ch;
-  font-size: clamp(0.875rem, 1.5vw, 0.9375rem);
-  line-height: 1.7;
-  color: var(--md-sys-color-on-surface-variant);
-}
-
-/* Demo sections */
+/* Primary content surfaces: all component pages use this contract. */
 .docs-page :is(.demo-section, .section, .doc-section) {
-  margin-top: clamp(16px, 2.5vw, 24px);
-  padding: clamp(16px, 2vw, 22px);
-  background: var(--md-sys-color-surface-container-low);
+  min-width: 0;
+  margin: 0;
+  padding: clamp(20px, 3vw, 32px);
+  overflow: clip;
+  background: var(--md-sys-color-surface);
   border: 1px solid var(--md-sys-color-outline-variant);
-  border-radius: 12px;
+  border-radius: clamp(20px, 2.5vw, 28px);
+  box-shadow:
+    0 1px 2px color-mix(in srgb, var(--md-sys-color-on-surface) 4%, transparent),
+    0 12px 32px
+      color-mix(in srgb, var(--md-sys-color-on-surface) 4%, transparent);
 }
 
-.docs-page :is(.demo-section, .section, .doc-section):first-of-type {
-  margin-top: 0;
+.docs-page :is(.demo-section, .section, .doc-section) > h2 {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 0;
+  font-size: clamp(1.15rem, 2vw, 1.45rem);
+  font-weight: 680;
+  letter-spacing: -0.025em;
 }
 
-.docs-page :is(.demo-section, .section, .doc-section) h2 {
-  margin: 0 0 0.5rem;
-  font-size: clamp(1.05rem, 1.8vw, 1.25rem);
-  font-weight: 600;
+.docs-page :is(.demo-section, .section, .doc-section) > h2::before {
+  content: '';
+  inline-size: 5px;
+  block-size: 1.15em;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: var(--md-sys-color-primary);
 }
 
 .docs-page :is(.demo-section, .section, .doc-section) > p:first-of-type,
 .docs-page .section-description {
-  margin-bottom: 1rem;
   max-width: 72ch;
+  margin: 10px 0 20px;
+  color: var(--md-sys-color-on-surface-variant);
+  font-size: 0.925rem;
 }
 
-/* Variant / pattern cards */
+/* Secondary surfaces hold live controls, variants, and patterns. */
 .docs-page :is(.variant-card, .pattern-card, .interactive-demo) {
-  margin-top: 0.875rem;
-  padding: clamp(14px, 1.5vw, 18px);
+  min-width: 0;
+  margin-top: 18px;
+  padding: clamp(16px, 2.2vw, 24px);
+  background: var(--md-sys-color-surface-container-low);
+  border: 1px solid
+    color-mix(in srgb, var(--md-sys-color-outline-variant) 80%, transparent);
+  border-radius: clamp(16px, 2vw, 20px);
+}
+
+.docs-page :is(.variant-card, .pattern-card, .interactive-demo):first-child {
+  margin-top: 0;
+}
+
+.docs-page :is(.variant-card, .pattern-card) > .interactive-demo {
   background: var(--md-sys-color-surface);
-  border: 1px solid var(--md-sys-color-outline-variant);
-  border-radius: 10px;
 }
 
 .docs-page .variant-header {
@@ -453,14 +509,15 @@ m3-radio-button {
   justify-content: space-between;
   gap: 12px;
   flex-wrap: wrap;
-  margin-bottom: 0.5rem;
+  margin-bottom: 12px;
 }
 
 .docs-page .variant-header h3,
 .docs-page .pattern-card h4 {
   margin: 0;
-  font-size: 0.9375rem;
-  font-weight: 600;
+  font-size: 0.95rem;
+  font-weight: 680;
+  letter-spacing: -0.01em;
 }
 
 .docs-page :is(.demo-row, .demo-buttons, .button-group) {
@@ -468,69 +525,86 @@ m3-radio-button {
   align-items: center;
   flex-wrap: wrap;
   gap: 12px;
-  margin-top: 0.875rem;
+  margin-top: 16px;
+}
+
+.docs-page :is(.demo-row, .demo-buttons) {
+  min-height: 52px;
 }
 
 .docs-page .feature-list {
-  margin: 0.75rem 0 0;
+  margin: 14px 0 0;
 }
 
 .docs-page .feature-list li + li {
-  margin-top: 0.375rem;
+  margin-top: 6px;
+}
+
+.docs-page .accessibility {
+  background: linear-gradient(
+    135deg,
+    color-mix(
+      in srgb,
+      var(--md-sys-color-primary-container) 34%,
+      var(--md-sys-color-surface)
+    ),
+    var(--md-sys-color-surface)
+  );
 }
 
 .docs-page .accessibility .feature-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 10px;
   list-style: none;
   padding: 0;
 }
 
-.docs-page .accessibility .feature-list li {
-  margin: 0;
-  padding: 0.75rem 1rem;
-  background: var(--md-sys-color-surface);
-  border: 1px solid var(--md-sys-color-outline-variant);
-  border-radius: 8px;
-}
-
+.docs-page .accessibility .feature-list li,
 .docs-page .accessibility .feature-list li + li {
-  margin-top: 0.5rem;
+  margin: 0;
+  padding: 14px 16px;
+  background: color-mix(in srgb, var(--md-sys-color-surface) 84%, transparent);
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: 14px;
 }
 
 .docs-page .accessibility .feature-list strong {
   color: var(--md-sys-color-primary);
 }
 
-.docs-page .code-sample {
-  margin-top: 0.875rem;
-  border-radius: 10px;
+.docs-page :is(.code-sample, app-code-block) {
+  display: block;
+  min-width: 0;
+  margin-top: 16px;
 }
 
-/* ─── Shared page section pattern ───────────────────────── */
-/* Used by quick-start, contact, and similar content pages   */
+/* Guides and community pages use the same card primitive. */
 .page-section {
-  padding: 24px 0;
-  border-bottom: 1px solid var(--md-sys-color-outline-variant);
-  max-width: 760px;
-}
-
-.page-section:last-child {
-  border-bottom: none;
+  width: 100%;
+  max-width: 860px;
+  padding: clamp(20px, 3vw, 30px);
+  background: var(--md-sys-color-surface);
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: 22px;
+  box-shadow: 0 10px 28px
+    color-mix(in srgb, var(--md-sys-color-on-surface) 4%, transparent);
 }
 
 .page-section h2,
 .comp-section h2 {
-  font-size: 0.75rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.07em;
-  color: var(--md-sys-color-on-surface-variant);
   margin: 0 0 12px;
+  color: var(--md-sys-color-primary);
+  font-size: 0.75rem;
+  font-weight: 750;
+  letter-spacing: 0.075em;
+  text-transform: uppercase;
 }
 
 .page-section > p {
-  font-size: 0.9375rem;
+  margin: 0 0 18px;
   color: var(--md-sys-color-on-surface-variant);
-  margin: 0 0 16px;
+  font-size: 0.9375rem;
   line-height: 1.7;
 }
 
@@ -539,8 +613,23 @@ m3-radio-button {
 }
 
 @media (max-width: 600px) {
+  .docs-page {
+    gap: 16px;
+  }
+
+  .docs-page :is(.demo-section, .section, .doc-section) {
+    padding: 18px 16px;
+    border-radius: 20px;
+  }
+
+  .docs-page :is(.variant-card, .pattern-card, .interactive-demo) {
+    padding: 16px 14px;
+    border-radius: 16px;
+  }
+
   .page-section {
-    padding: 18px 0;
+    padding: 20px 17px;
+    border-radius: 18px;
   }
 }
 .button-group {


### PR DESCRIPTION
## Summary
- centralize route page introductions in a reusable PageHeaderComponent
- apply one professional layout system to demos, variants, guides, contact, and the component index
- redesign Home with a responsive Material 3 hero and live component preview
- remove duplicated page headers and the duplicated progress route
- add Playwright coverage for every documentation route and mobile overflow

## Validation
- Angular lint
- Angular typecheck
- 11 unit tests
- 36 Playwright tests across Chromium, Firefox, and WebKit
- production build with 30 prerendered routes